### PR TITLE
Add a note to onEditorPreparing that only several parameters can be changed

### DIFF
--- a/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onEditorPreparing.md
+++ b/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onEditorPreparing.md
@@ -66,6 +66,8 @@ The editor's value.
 The editor's width; equals **null** for all editors except for those whose **parentType** equals *"searchPanel"*.
 
 ---
+[note] In this function, you can change only **cancel**, **editorName**, **editorOptions**, and **updateValueTimeout**. All the rest parameters are read only.
+
 Use this function to:
 
 - Override the default editor's **onValueChanged** handler. For other default editor customizations, use [editorOptions](/api-reference/_hidden/GridBaseColumn/editorOptions.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/columns/#editorOptions').


### PR DESCRIPTION
https://trello.com/c/CPBGGp4S/1281-datagrid-extend-the-oneditorpreparing-method-value-argument-description