### PR TITLE
Add a demo button to the value options of all the Editors

### DIFF
--- a/api-reference/10 UI Widgets/Editor/1 Configuration/value.md
+++ b/api-reference/10 UI Widgets/Editor/1 Configuration/value.md
@@ -9,3 +9,7 @@ firedEvents: valueChanged
 Specifies the widget's value.
 
 ---
+
+#include common-demobutton with {
+    url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/{WidgetName}/Overview/"
+}

--- a/api-reference/10 UI Widgets/dxAutocomplete/1 Configuration/value.md
+++ b/api-reference/10 UI Widgets/dxAutocomplete/1 Configuration/value.md
@@ -9,3 +9,7 @@ Specifies the current value displayed by the widget.
 
 ---
 If autocomplete items represent objects, the **value** option returns the value of the specified field of the currently selected item object. The field whose value is returned by the **value** option is specified by using the [valueExpr](/api-reference/10%20UI%20Widgets/DataExpressionMixin/1%20Configuration/valueExpr.md '/Documentation/ApiReference/UI_Widgets/dxAutocomplete/Configuration/#valueExpr') option.
+
+#include common-demobutton with {
+    url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Autocomplete/Overview/"
+}

--- a/api-reference/10 UI Widgets/dxCalendar/1 Configuration/value.md
+++ b/api-reference/10 UI Widgets/dxCalendar/1 Configuration/value.md
@@ -25,3 +25,7 @@ You can specify the current widget value using any of the following formats.
  - "yyyy-MM-ddTHH:mm:ssx" (for example, "2017-03-27T16:54:10+03")
 
 If the widget value is changed by an end-user, the new value is saved in the same format as the initial value.
+
+#include common-demobutton with {
+    url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Calendar/Overview/"
+}

--- a/api-reference/10 UI Widgets/dxDateBox/1 Configuration/value.md
+++ b/api-reference/10 UI Widgets/dxDateBox/1 Configuration/value.md
@@ -26,5 +26,9 @@ You can specify the current widget value using any of the following formats.
 
 If the widget value is changed by an end-user, the new value is saved in the same format as the initial value.
 
+#include common-demobutton with {
+    url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/DateBox/Overview/"
+}
+
 #####See Also#####
 - [displayFormat](/api-reference/10%20UI%20Widgets/dxDateBox/1%20Configuration/displayFormat.md '/Documentation/ApiReference/UI_Widgets/dxDateBox/Configuration/#displayFormat')

--- a/api-reference/10 UI Widgets/dxTagBox/1 Configuration/value.md
+++ b/api-reference/10 UI Widgets/dxTagBox/1 Configuration/value.md
@@ -9,3 +9,7 @@ Specifies the selected items.
 
 ---
 Pass an array of items to this option to select them.
+
+#include common-demobutton with {
+    url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/TagBox/Overview/"
+}


### PR DESCRIPTION
List of the editors that have the value option(most of them inherit it directly from the Editor):
"dxAutocomplete"
"dxCalendar"
"dxCheckBox"
"dxColorBox"
"dxDateBox"
"dxDropDownBox"
"dxHtmlEditor"
"dxFileUploader"
"dxLookup"
"dxNumberBox"
"dxProgressBar"
"dxRadioGroup"
"dxRangeSlider"
"dxSelectBox"
"dxSlider"
"dxSwitch"
"dxTagBox"
"dxTextArea"
"dxTextBox"

Four  of them do not inherit but have their own file for the value option, so I added a hard-coded link to the demo:
1. Calendar
2. Tagbox
3. DateBox 
4. AutoComplete 


One widget - ProgressBar - is left without a link to the demo since the value option is not illustrated in the demo.