### PR TITLE
Describe a way to override keyboard shortcuts in Grids (#138)

### DIFF
--- a/api-reference/10 UI Widgets/GridBase/1 Configuration/onKeyDown.md
+++ b/api-reference/10 UI Widgets/GridBase/1 Configuration/onKeyDown.md
@@ -18,7 +18,7 @@ The widget's instance.
 #include common-ref-elementparam with { element: "widget" }
 
 ##### field(e.event): event
-#include common-ref-eventparam
+The event that caused the function to execute. It is a [dxEvent](/api-reference/50%20Common/Object%20Structures/dxEvent '/Documentation/ApiReference/Common/Object_Structures/dxEvent/') or a <a href="http://api.jquery.com/category/events/event-object/" target="_blank">jQuery.Event</a> when you use jQuery. This event is based on the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/keydown_event" target="_blank">keydown</a> native event.
 
 ##### field(e.handled): Boolean
 Indicates whether the widget has already handled this event.
@@ -31,5 +31,121 @@ The jQuery event that caused the function's execution. Deprecated in favor of th
 
 ##### field(e.model): Object
 Model data. Available only if you use Knockout.
+
+---
+
+---
+##### jQuery
+
+    <!-- tab: index.js -->
+    $(function() {
+        $("#{widgetName}").dx{WidgetName}({
+            // ...
+            onKeyDown(e) {
+                if (e.event.ctrlKey && e.event.key === "Q") {
+                    console.log("Ctrl + Q was pressed"); 
+                }
+            }
+        });
+    });
+
+##### Angular
+
+    <!-- tab: app.component.html -->
+    <dx-{widget-name} ...
+        (onKeyDown)="onKeyDown($event)">
+    </dx-{widget-name}>
+
+    <!-- tab: app.component.ts -->
+    import { Component } from '@angular/core';
+
+    @Component({
+        selector: 'app-root',
+        templateUrl: './app.component.html',
+        styleUrls: ['./app.component.css']
+    })
+    export class AppComponent {
+        onKeyDown(e) {
+            if (e.event.ctrlKey && e.event.key === "Q") {
+                console.log("Ctrl + Q was pressed"); 
+            }
+        }
+    }
+
+    <!-- tab: app.module.ts -->
+    import { BrowserModule } from '@angular/platform-browser';
+    import { NgModule } from '@angular/core';
+    import { AppComponent } from './app.component';
+
+    import { Dx{WidgetName}Module } from 'devextreme-angular';
+
+    @NgModule({
+        declarations: [
+            AppComponent
+        ],
+        imports: [
+            BrowserModule,
+            Dx{WidgetName}Module
+        ],
+        providers: [ ],
+        bootstrap: [AppComponent]
+    })
+    export class AppModule { }
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <Dx{WidgetName} ...
+            @key-down="onKeyDown">            
+        </Dx{WidgetName}>
+    </template>
+
+    <script>
+    import 'devextreme/dist/css/dx.common.css';
+    import 'devextreme/dist/css/dx.light.css';
+
+    import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
+
+    export default {
+        components: {
+            Dx{WidgetName}
+        },
+        methods: {
+            onKeyDown(e) {
+                if (e.event.ctrlKey && e.event.key === "Q") {
+                    console.log("Ctrl + Q was pressed"); 
+                }
+            }
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import 'devextreme/dist/css/dx.common.css';
+    import 'devextreme/dist/css/dx.light.css';
+
+    import {WidgetName} from 'devextreme-react/{widget-name}';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <{WidgetName} ...
+                    onKeyDown={this.onKeyDown}>
+                </{WidgetName}>
+            );
+        }
+
+        onKeyDown(e) {
+            if (e.event.ctrlKey && e.event.key === "Q") {
+                console.log("Ctrl + Q was pressed"); 
+            }
+        }
+    }
+    export default App;
 
 ---

--- a/concepts/05 Widgets/DataGrid/75 Keyboard Support.md
+++ b/concepts/05 Widgets/DataGrid/75 Keyboard Support.md
@@ -85,6 +85,8 @@ A user can interact with the widget using the following keys:
     </table>
 </div>
 
+You can override these shortcuts or create your own shortcuts using the [onKeyDown](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/onKeyDown.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/#onKeyDown') event handler.
+
 <div style="font-size:12px;margin-bottom:10px;">
     <sup>1</sup> - If the <a href="/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/keyboardNavigation/#enterKeyAction">enterKeyAction</a> is <i>"startEdit"</i>.<br/>
     <sup>2</sup> - If the <b>edititng</b>.<a href="/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/editing/#mode">mode</a> is <i>"cell"</i> or <i>"batch"</i> and the <a href="/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/keyboardNavigation/#enterKeyAction">enterKeyAction</a> is <i>"moveFocus"</i>.<br/>

--- a/concepts/05 Widgets/TreeList/70 Keyboard Support.md
+++ b/concepts/05 Widgets/TreeList/70 Keyboard Support.md
@@ -83,6 +83,8 @@ A user can interact with the widget using the following keys:
     </table>
 </div>
 
+You can override these shortcuts or create your own shortcuts using the [onKeyDown](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/onKeyDown.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#onKeyDown') event handler.
+
 <div style="font-size:12px">
     <sup>1</sup> - If the <a href="/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/keyboardNavigation/#enterKeyAction">enterKeyAction</a> is <i>"startEdit"</i>.<br/>
     <sup>2</sup> - If the <b>edititng</b>.<a href="/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/editing/#mode">mode</a> is <i>"cell"</i> or <i>"batch"</i> and the <a href="/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/keyboardNavigation/#enterKeyAction">enterKeyAction</a> is <i>"moveFocus"</i>.<br/>


### PR DESCRIPTION
* Describe a way to override keyboard shortcuts in Grids

* Add the onKeyDown snippet

* Add the target blank attribute

* Fix the snippet

* Fix the snippets synthax

* Apply suggestions from code review

Co-Authored-By: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

* Address Armina's comment

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>
(cherry picked from commit a5f51ec43fbda7d81945a4a4d01708032471a351)