### PR TITLE
Mention that focus event work only with content cells (#176)

### DIFF
--- a/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onFocusedCellChanged.md
+++ b/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onFocusedCellChanged.md
@@ -6,7 +6,7 @@ EventForAction: dxDataGrid.focusedCellChanged
 ---
 ---
 ##### shortDescription
-A function that is executed after the focused cell changes.
+A function that is executed after the focused cell changes. Applies only to cells in data or group rows.
 
 ##### param(e): Object
 Information about the event that caused the function's execution.
@@ -36,6 +36,7 @@ The row's properties.
 The index of the cell's row.
 
 ---
+
 #####See Also#####
 - [focusedRowIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowIndex.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/#focusedRowIndex') | [focusedRowKey](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowKey.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/#focusedRowKey')
 - [focusedColumnIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedColumnIndex.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/#focusedColumnIndex')

--- a/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onFocusedCellChanging.md
+++ b/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onFocusedCellChanging.md
@@ -6,7 +6,7 @@ EventForAction: dxDataGrid.focusedCellChanging
 ---
 ---
 ##### shortDescription
-A function that is executed before the focused cell changes.
+A function that is executed before the focused cell changes. Applies only to cells in data or group rows.
 
 ##### param(e): Object
 Information about the event that caused the function's execution.

--- a/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onFocusedRowChanged.md
+++ b/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onFocusedRowChanged.md
@@ -6,7 +6,7 @@ EventForAction: dxDataGrid.focusedRowChanged
 ---
 ---
 ##### shortDescription
-A function that is executed after the focused row changes. Applies only when [focusedRowEnabled](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowEnabled.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/#focusedRowEnabled') is **true**.
+A function that is executed after the focused row changes. Applies only to data or group rows. [focusedRowEnabled](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowEnabled.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/#focusedRowEnabled') should be **true**.
 
 ##### param(e): Object
 Information about the event that caused the function's execution.

--- a/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onFocusedRowChanging.md
+++ b/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onFocusedRowChanging.md
@@ -6,7 +6,7 @@ EventForAction: dxDataGrid.focusedRowChanging
 ---
 ---
 ##### shortDescription
-A function that is executed before the focused row changes. Applies only when [focusedRowEnabled](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowEnabled.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/#focusedRowEnabled') is **true**.
+A function that is executed before the focused row changes. Applies only to data or group rows. [focusedRowEnabled](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowEnabled.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/#focusedRowEnabled') should be **true**.
 
 ##### param(e): Object
 Information about the event that caused the function's execution.

--- a/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onFocusedCellChanged.md
+++ b/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onFocusedCellChanged.md
@@ -6,7 +6,7 @@ EventForAction: dxTreeList.focusedCellChanged
 ---
 ---
 ##### shortDescription
-A function that is executed after the focused cell changes.
+A function that is executed after the focused cell changes. Applies only to cells in data rows.
 
 ##### param(e): Object
 Information about the event that caused the function's execution.
@@ -36,6 +36,7 @@ The row's properties.
 The index of the cell's row.
 
 ---
+
 #####See Also#####
 - [focusedRowIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowIndex.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedRowIndex') | [focusedRowKey](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowKey.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedRowKey')
 - [focusedColumnIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedColumnIndex.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedColumnIndex')

--- a/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onFocusedCellChanging.md
+++ b/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onFocusedCellChanging.md
@@ -6,7 +6,7 @@ EventForAction: dxTreeList.focusedCellChanging
 ---
 ---
 ##### shortDescription
-A function that is executed before the focused cell changes.
+A function that is executed before the focused cell changes. Applies only to cells in data rows.
 
 ##### param(e): Object
 Information about the event that caused the function's execution.

--- a/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onFocusedRowChanged.md
+++ b/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onFocusedRowChanged.md
@@ -6,7 +6,7 @@ EventForAction: dxTreeList.focusedRowChanged
 ---
 ---
 ##### shortDescription
-A function that executed when the focused row changes. Applies only when [focusedRowEnabled](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowEnabled.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedRowEnabled') is **true**.
+A function that executed when the focused row changes. Applies only to data rows. [focusedRowEnabled](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowEnabled.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedRowEnabled') should be **true**.
 
 ##### param(e): Object
 Information about the event that caused the function's execution.
@@ -30,6 +30,7 @@ The row's properties.
 The row's index.
 
 ---
+
 #####See Also#####
 - [focusedRowIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowIndex.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedRowIndex') | [focusedRowKey](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowKey.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedRowKey')
 - [focusedColumnIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedColumnIndex.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedColumnIndex')

--- a/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onFocusedRowChanging.md
+++ b/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onFocusedRowChanging.md
@@ -6,7 +6,7 @@ EventForAction: dxTreeList.focusedRowChanging
 ---
 ---
 ##### shortDescription
-A function that is executed before the focused row changes. Applies only when [focusedRowEnabled](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowEnabled.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedRowEnabled') is **true**.
+A function that is executed before the focused row changes. Applies only to data rows. [focusedRowEnabled](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowEnabled.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedRowEnabled') should be **true**.
 
 ##### param(e): Object
 Information about the event that caused the function's execution.
@@ -39,6 +39,7 @@ The index of the previously focused row.
 The visible rows' properties.
 
 ---
+
 #####See Also#####
 - [focusedRowIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowIndex.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedRowIndex') | [focusedRowKey](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowKey.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedRowKey')
 - [focusedColumnIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedColumnIndex.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedColumnIndex')


### PR DESCRIPTION
* Mention that focus event work only with content cells

* Move info from the note to the short description

* Remove the excessive articles

(cherry picked from commit fa1271fc46a8f71a0e69b72c0adb8b6a697fc678)