### PR TITLE
Add Vue and React snippets to the dataviz widgets (#242)

### DIFF
--- a/api-reference/20 Data Visualization Widgets/BaseChart/1 Configuration/onPointClick.md
+++ b/api-reference/20 Data Visualization Widgets/BaseChart/1 Configuration/onPointClick.md
@@ -57,7 +57,7 @@ The [onSeriesClick](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1
     import { Dx{WidgetName}Module } from "devextreme-angular";
     // ...
     export class AppComponent {
-        {widgetName}_onPointClick (e) {
+        cancelSeriesClick (e) {
             e.event.cancel = true;
         }
     }
@@ -70,8 +70,55 @@ The [onSeriesClick](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1
     })
 
     <!--HTML--><dx-{widget-name} ...
-        (onPointClick)="{widgetName}_onPointClick($event)">
+        (onPointClick)="cancelSeriesClick($event)">
     </dx-{widget-name}>
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <Dx{WidgetName} ...
+            @point-click="cancelSeriesClick">
+        </Dx{WidgetName}>
+    </template>
+
+    <script>
+    import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
+
+    export default {
+        components: {
+            Dx{WidgetName}
+        },
+        methods: {
+            cancelSeriesClick (e) {
+                e.event.cancel = true;
+            }
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import {WidgetName} from 'devextreme-react/{widget-name}';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <{WidgetName} ...
+                    onPointClick={this.cancelSeriesClick}>
+                </{WidgetName}>
+            );
+        }
+
+        cancelSeriesClick (e) {
+            e.event.cancel = true;
+        }
+    }
+
+    export default App;
 
 ---
 

--- a/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/argumentAxis/aggregationInterval/aggregationInterval.md
+++ b/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/argumentAxis/aggregationInterval/aggregationInterval.md
@@ -51,6 +51,60 @@ If the axis displays numbers, assign a number to this option. For example, an **
         // ...
     })
 
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxChart ... >
+            <DxArgumentAxis
+                aggregation-interval="day">     <!-- Interval of one day -->
+                <DxAggregationInterval 
+                    :days="5" />                <!-- Interval of five days -->
+            </DxArgumentAxis>
+        </DxChart>
+    </template>
+
+    <script>
+    import DxChart, {
+        DxArgumentAxis,
+        DxAggregationInterval
+    } from 'devextreme-vue/chart';
+
+    export default {
+        components: {
+            DxChart,
+            DxArgumentAxis,
+            DxAggregationInterval
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import Chart, {
+        ArgumentAxis,
+        AggregationInterval
+    } from 'devextreme-react/chart';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <Chart ... >
+                    <ArgumentAxis
+                        aggregationInterval={"day"}>    {/* Interval of one day */}
+                        <AggregationInterval 
+                            days={5} />                 {/* Interval of five days */}
+                    </ArgumentAxis>
+                </Chart>
+            );
+        }
+    }
+
+    export default App;     
+
 ---
 
 On a [logarithmic axis](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1%20Configuration/argumentAxis/type.md '/Documentation/ApiReference/Data_Visualization_Widgets/dxChart/Configuration/argumentAxis/#type'), intervals are calculated based on powers. For example, if the [logarithmBase](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1%20Configuration/argumentAxis/logarithmBase.md '/Documentation/ApiReference/Data_Visualization_Widgets/dxChart/Configuration/argumentAxis/#logarithmBase') is 10 and the **aggregationInterval** is 1, the following intervals are produced: 10<sup>0</sup> to 10<sup>1</sup>, 10<sup>1</sup> to 10<sup>2</sup>, 10<sup>2</sup> to 10<sup>3</sup>, etc. If the **aggregationInterval** becomes 2, intervals become longer: 10<sup>0</sup> to 10<sup>2</sup>, 10<sup>2</sup> to 10<sup>4</sup>, 10<sup>4</sup> to 10<sup>6</sup>, etc.

--- a/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/argumentAxis/categories.md
+++ b/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/argumentAxis/categories.md
@@ -28,8 +28,15 @@ To sort the arguments, for example, alphabetically, you need to assign an array 
         $("#chartContainer").dxChart({
             // ...
             argumentAxis: {
-                categories: ['Africa', 'Antarctica', 'Asia', 'Australia',
-                    'Europe', 'North America', 'South America']
+                categories: [
+                    'Africa', 
+                    'Antarctica', 
+                    'Asia', 
+                    'Australia',
+                    'Europe',
+                    'North America',
+                    'South America'
+                ]
             }
         });
     });
@@ -38,8 +45,7 @@ To sort the arguments, for example, alphabetically, you need to assign an array 
 
     <!--HTML--><dx-chart ... >
         <dxo-argument-axis
-            [categories]="['Africa', 'Antarctica', 'Asia', 'Australia',
-                'Europe', 'North America', 'South America']">
+            [categories]="continents">
         </dxo-argument-axis>
     </dx-chart>
 
@@ -48,6 +54,15 @@ To sort the arguments, for example, alphabetically, you need to assign an array 
     // ...
     export class AppComponent {
         // ...
+        continents = [
+            'Africa', 
+            'Antarctica', 
+            'Asia', 
+            'Australia',
+            'Europe',
+            'North America',
+            'South America'
+        ];
     }
     @NgModule({
         imports: [
@@ -56,6 +71,76 @@ To sort the arguments, for example, alphabetically, you need to assign an array 
         ],
         // ...
     })
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxChart ... >
+            <DxArgumentAxis 
+                :categories="continents" 
+            />
+        </DxChart>
+    </template>
+
+    <script>
+    import DxChart, {
+        DxArgumentAxis
+    } from 'devextreme-vue/chart'; 
+
+    export default {
+        components: {
+            DxChart,
+            DxArgumentAxis
+        },
+        data() {
+            return {
+                continents: [
+                    'Africa', 
+                    'Antarctica', 
+                    'Asia', 
+                    'Australia',
+                    'Europe',
+                    'North America',
+                    'South America'
+                ]
+            };
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import Chart, {
+        ArgumentAxis
+    } from 'devextreme-react/chart';
+    
+    const continents = [
+        'Africa', 
+        'Antarctica', 
+        'Asia', 
+        'Australia',
+        'Europe',
+        'North America',
+        'South America'
+    ];
+
+    class App extends React.Component {
+        render() {
+            return (
+                <Chart ... >
+                    <ArgumentAxis
+                        categories={continents}
+                    />
+                </Chart>
+            );
+        }
+    }
+
+    export default App;     
 
 ---
 

--- a/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/argumentAxis/minorTickInterval/minorTickInterval.md
+++ b/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/argumentAxis/minorTickInterval/minorTickInterval.md
@@ -46,6 +46,56 @@ If the axis displays numbers, assign a number to this option. If the axis displa
         // ...
     })
 
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxChart ... >
+            <DxArgumentAxis>
+                <DxMinorTickInterval :days="5" />
+            </DxArgumentAxis>
+        </DxChart>
+    </template>
+
+    <script>
+    import DxChart, {
+        DxArgumentAxis,
+        DxMinorTickInterval
+    } from 'devextreme-vue/chart';
+
+    export default {
+        components: {
+            DxChart,
+            DxArgumentAxis,
+            DxMinorTickInterval
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import Chart, {
+        ArgumentAxis,
+        MinorTickInterval
+    } from 'devextreme-react/chart';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <Chart ... >
+                    <ArgumentAxis>
+                        <MinorTickInterval days={5} />
+                    </ArgumentAxis>
+                </Chart>
+            );
+        }
+    }
+
+    export default App;     
+
 ---
 
 When using the widget as an <a href="https://docs.devexpress.com/DevExtremeAspNetMvc/400943/devextreme-aspnet-mvc-controls" target="_blank">ASP.NET MVC 5 Control</a> or a <a href="https://docs.devexpress.com/AspNetCore/400263/aspnet-core-controls#devextreme-based-aspnet-core-controls" target="_blank">DevExtreme-Based ASP.NET Core Control</a>, specify this option using the `VizTimeInterval` enum. This enum accepts the same values, but they start with an upper-case letter, for example, *'day'* becomes `Day`.

--- a/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/argumentAxis/tickInterval/tickInterval.md
+++ b/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/argumentAxis/tickInterval/tickInterval.md
@@ -46,6 +46,56 @@ If the axis displays numbers, assign a number to this option. If the axis displa
         // ...
     })
 
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxChart ... >
+            <DxArgumentAxis>
+                <DxTickInterval :days="5" />
+            </DxArgumentAxis>
+        </DxChart>
+    </template>
+
+    <script>
+    import DxChart, {
+        DxArgumentAxis,
+        DxTickInterval
+    } from 'devextreme-vue/chart';
+
+    export default {
+        components: {
+            DxChart,
+            DxArgumentAxis,
+            DxTickInterval
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import Chart, {
+        ArgumentAxis,
+        TickInterval
+    } from 'devextreme-react/chart';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <Chart ... >
+                    <ArgumentAxis>
+                        <TickInterval days={5} />
+                    </ArgumentAxis>
+                </Chart>
+            );
+        }
+    }
+
+    export default App;     
+
 ---
 
 When you use an axis of the *"logarithmic"* [type](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1%20Configuration/argumentAxis/type.md '/Documentation/ApiReference/Data_Visualization_Widgets/dxChart/Configuration/argumentAxis/#type'), ticks are generated on a base of powers. For example, assuming that the [logarithm base](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1%20Configuration/argumentAxis/logarithmBase.md '/Documentation/ApiReference/Data_Visualization_Widgets/dxChart/Configuration/argumentAxis/#logarithmBase') is 10 and the tick interval is 1, ticks are generated at 10<sup>-2</sup>, 10<sup>-1</sup>, 10<sup>0</sup>, 10<sup>1</sup>, 10<sup>2</sup>, 10<sup>3</sup>, etc. If the tick interval becomes 2, ticks are generated at 10<sup>-1</sup>, 10<sup>1</sup>, 10<sup>3</sup>, etc.

--- a/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/onLegendClick.md
+++ b/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/onLegendClick.md
@@ -57,7 +57,7 @@ The [onSeriesClick](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1
     import { DxChartModule } from "devextreme-angular";
     // ...
     export class AppComponent {
-        chart_onLegendClick (e) {
+        cancelSeriesClick (e) {
             e.event.cancel = true;
         }
     }
@@ -70,8 +70,55 @@ The [onSeriesClick](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1
     })
 
     <!--HTML--><dx-chart ...
-        (onLegendClick)="chart_onLegendClick($event)">
+        (onLegendClick)="cancelSeriesClick($event)">
     </dx-chart>
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxChart ...
+            @legend-click="cancelSeriesClick">
+        </DxChart>
+    </template>
+
+    <script>
+    import DxChart from 'devextreme-vue/chart';
+
+    export default {
+        components: {
+            DxChart
+        },
+        methods: {
+            cancelSeriesClick (e) {
+                e.event.cancel = true;
+            }
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import Chart from 'devextreme-react/chart';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <Chart ...
+                    onLegendClick={this.cancelSeriesClick}>
+                </Chart>
+            );
+        }
+
+        cancelSeriesClick (e) {
+            e.event.cancel = true;
+        }
+    }
+
+    export default App;
 
 ---
 

--- a/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/valueAxis/minorTickInterval/minorTickInterval.md
+++ b/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/valueAxis/minorTickInterval/minorTickInterval.md
@@ -44,6 +44,56 @@ If the axis displays numbers, set the **minorTickInterval** to a number. This nu
         // ...
     })
 
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxChart ... >
+            <DxValueAxis>
+                <DxMinorTickInterval :days="5" />
+            </DxValueAxis>
+        </DxChart>
+    </template>
+
+    <script>
+    import DxChart, {
+        DxValueAxis,
+        DxMinorTickInterval
+    } from 'devextreme-vue/chart';
+
+    export default {
+        components: {
+            DxChart,
+            DxValueAxis,
+            DxMinorTickInterval
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import Chart, {
+        ValueAxis,
+        MinorTickInterval
+    } from 'devextreme-react/chart';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <Chart ... >
+                    <ValueAxis>
+                        <MinorTickInterval days={5} />
+                    </ValueAxis>
+                </Chart>
+            );
+        }
+    }
+
+    export default App;     
+
 ---
 
 When using the widget as an <a href="https://docs.devexpress.com/DevExtremeAspNetMvc/400943/devextreme-aspnet-mvc-controls" target="_blank">ASP.NET MVC 5 Control</a> or a <a href="https://docs.devexpress.com/AspNetCore/400263/aspnet-core-controls#devextreme-based-aspnet-core-controls" target="_blank">DevExtreme-Based ASP.NET Core Control</a>, you can specify this option with the `VizTimeInterval` enum which accepts the same predefined values, but they start with an upper-case letter, for example, *'day'* becomes `Day`.

--- a/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/valueAxis/tickInterval/tickInterval.md
+++ b/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/valueAxis/tickInterval/tickInterval.md
@@ -44,6 +44,56 @@ If the axis displays numbers, set the **tickInterval** to a number. This number 
         // ...
     })
 
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxChart ... >
+            <DxValueAxis>
+                <DxTickInterval :days="5" />
+            </DxValueAxis>
+        </DxChart>
+    </template>
+
+    <script>
+    import DxChart, {
+        DxValueAxis,
+        DxTickInterval
+    } from 'devextreme-vue/chart';
+
+    export default {
+        components: {
+            DxChart,
+            DxValueAxis,
+            DxTickInterval
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import Chart, {
+        ValueAxis,
+        TickInterval
+    } from 'devextreme-react/chart';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <Chart ... >
+                    <ValueAxis>
+                        <TickInterval days={5} />
+                    </ValueAxis>
+                </Chart>
+            );
+        }
+    }
+
+    export default App;     
+    
 ---
 
 When you use a *"logarithmic"* [type](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1%20Configuration/valueAxis/type.md '/Documentation/ApiReference/Data_Visualization_Widgets/dxChart/Configuration/valueAxis/#type') axis, ticks are generated as an exponentiation. For example, assuming that the [logarithm base](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1%20Configuration/valueAxis/logarithmBase.md '/Documentation/ApiReference/Data_Visualization_Widgets/dxChart/Configuration/valueAxis/#logarithmBase') is 10 and the tick interval is 1, ticks are generated at 10<sup>-2</sup>, 10<sup>-1</sup>, 10<sup>0</sup>, 10<sup>1</sup>, 10<sup>2</sup>, 10<sup>3</sup>, etc. If the tick interval is 2, ticks are generated at 10<sup>-1</sup>, 10<sup>1</sup>, 10<sup>3</sup>, etc.

--- a/api-reference/20 Data Visualization Widgets/dxChart/5 Series Types/CommonSeries/aggregation/calculate.md
+++ b/api-reference/20 Data Visualization Widgets/dxChart/5 Series Types/CommonSeries/aggregation/calculate.md
@@ -76,4 +76,77 @@ One or several aggregated data objects. Should have the same structure as the or
         // ...
     })
 
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxChart ... >
+            <DxSeries ... >
+                <DxAggregation
+                    :calculate="customAggregateFunc"
+                />
+            </DxSeries>
+        </DxChart>
+    </template>
+
+    <script>
+    import DxChart, {
+        DxSeries,
+        DxAggregation
+    } from 'devextreme-vue/chart';
+
+    export default {
+        components: {
+            DxChart,
+            DxSeries,
+            DxAggregation
+        },
+        methods: {
+            customAggregateFunc (aggregationInfo, series) {
+                const dataObjects = aggregationInfo.data;
+                let result = { }; // or [ ]
+                // ...
+                // Aggregate the data objects here
+                // ...
+                return result;
+            }
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import Chart, {
+        Series,
+        Aggregation
+    } from 'devextreme-react/chart';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <Chart ... >
+                    <Series ... >
+                        <Aggregation
+                            calculate={this.customAggregateFunc}
+                        />
+                    </Series>
+                </Chart>
+            );
+        }
+
+        customAggregateFunc (aggregationInfo, series) {
+            let dataObjects = aggregationInfo.data;
+            let result = { }; // or [ ]
+
+            // Aggregate the data objects here
+            
+            return result;
+        }
+    }
+
+    export default App;
+
 ---

--- a/api-reference/20 Data Visualization Widgets/dxFunnel/1 Configuration/onItemClick.md
+++ b/api-reference/20 Data Visualization Widgets/dxFunnel/1 Configuration/onItemClick.md
@@ -72,6 +72,53 @@ This function is often used to implement item selection as shown in the followin
         // ...
     })
 
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxFunnel ...
+            @item-click="selectItem">
+        </DxFunnel>
+    </template>
+
+    <script>
+    import DxFunnel from 'devextreme-vue/funnel';
+
+    export default {
+        components: {
+            DxFunnel
+        },
+        methods: {
+            selectItem (e) {
+                e.item.select(!e.item.isSelected())
+            }
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import Funnel from 'devextreme-react/funnel';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <Funnel ...
+                    onItemClick={this.selectItem}>
+                </Funnel>
+            );
+        }
+
+        selectItem (e) {
+            e.item.select(!e.item.isSelected())
+        }
+    }
+
+    export default App;
+
 ---
 
 #####See Also#####

--- a/api-reference/20 Data Visualization Widgets/dxPolarChart/1 Configuration/onLegendClick.md
+++ b/api-reference/20 Data Visualization Widgets/dxPolarChart/1 Configuration/onLegendClick.md
@@ -57,7 +57,7 @@ The [onSeriesClick](/api-reference/20%20Data%20Visualization%20Widgets/dxPolarCh
     import { DxPolarChartModule } from "devextreme-angular";
     // ...
     export class AppComponent {
-        polarChart_onLegendClick (e) {
+        cancelSeriesClick (e) {
             e.event.cancel = true;
         }
     }
@@ -70,8 +70,55 @@ The [onSeriesClick](/api-reference/20%20Data%20Visualization%20Widgets/dxPolarCh
     })
 
     <!--HTML--><dx-polar-chart ...
-        (onLegendClick)="polarChart_onLegendClick($event)">
+        (onLegendClick)="cancelSeriesClick($event)">
     </dx-polar-chart>
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxPolarChart ...
+            @legend-click="cancelSeriesClick">
+        </DxPolarChart>
+    </template>
+
+    <script>
+    import DxPolarChart from 'devextreme-vue/polar-chart';
+
+    export default {
+        components: {
+            DxPolarChart
+        },
+        methods: {
+            cancelSeriesClick (e) {
+                e.event.cancel = true;
+            }
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import PolarChart from 'devextreme-react/polar-chart';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <PolarChart ...
+                    onLegendClick={this.cancelSeriesClick}>
+                </PolarChart>
+            );
+        }
+
+        cancelSeriesClick (e) {
+            e.event.cancel = true;
+        }
+    }
+
+    export default App;
 
 ---
 

--- a/api-reference/20 Data Visualization Widgets/dxRangeSelector/1 Configuration/scale/aggregationInterval/aggregationInterval.md
+++ b/api-reference/20 Data Visualization Widgets/dxRangeSelector/1 Configuration/scale/aggregationInterval/aggregationInterval.md
@@ -51,6 +51,60 @@ If the scale displays numbers, assign a number to this option. For example, an *
         // ...
     })
 
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxRangeSelector ... >
+            <DxScale
+                aggregation-interval="day">     <!-- Interval of one day -->
+                <DxAggregationInterval 
+                    :days="5" />                <!-- Interval of five days -->
+            </DxScale>
+        </DxRangeSelector>
+    </template>
+
+    <script>
+    import DxRangeSelector, {
+        DxScale,
+        DxAggregationInterval
+    } from 'devextreme-vue/range-selector';
+
+    export default {
+        components: {
+            DxRangeSelector,
+            DxScale,
+            DxAggregationInterval
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import RangeSelector, {
+        Scale,
+        AggregationInterval
+    } from 'devextreme-react/range-selector';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <RangeSelector ... >
+                    <Scale
+                        aggregationInterval="day">    {/* Interval of one day */}
+                        <AggregationInterval 
+                            days={5} />                 {/* Interval of five days */}
+                    </Scale>
+                </RangeSelector>
+            );
+        }
+    }
+
+    export default App;     
+
 ---
 
 On a [logarithmic scale](/api-reference/20%20Data%20Visualization%20Widgets/dxRangeSelector/1%20Configuration/scale/type.md '/Documentation/ApiReference/Data_Visualization_Widgets/dxRangeSelector/Configuration/scale/#type'), intervals are based on powers. For example, if the [logarithmBase](/api-reference/20%20Data%20Visualization%20Widgets/dxRangeSelector/1%20Configuration/scale/logarithmBase.md '/Documentation/ApiReference/Data_Visualization_Widgets/dxRangeSelector/Configuration/scale/#logarithmBase') is 10 and the **aggregationInterval** is 1, the following intervals are produced: 10<sup>0</sup> to 10<sup>1</sup>, 10<sup>1</sup> to 10<sup>2</sup>, 10<sup>2</sup> to 10<sup>3</sup>, etc. If the **aggregationInterval** becomes 2, intervals become longer: 10<sup>0</sup> to 10<sup>2</sup>, 10<sup>2</sup> to 10<sup>4</sup>, 10<sup>4</sup> to 10<sup>6</sup>, etc.

--- a/api-reference/20 Data Visualization Widgets/dxSankey/1 Configuration/alignment.md
+++ b/api-reference/20 Data Visualization Widgets/dxSankey/1 Configuration/alignment.md
@@ -43,6 +43,50 @@ A string value aligns all node columns uniformly. An array of strings allows you
         // ...
     })
 
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxSankey ... 
+            :alignment="['top', 'bottom', 'bottom']">
+        </DxSankey>
+    </template>
+
+    <script>
+    import DxSankey from 'devextreme-vue/sankey';
+
+    export default {
+        components: {
+            DxSankey
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import Sankey from 'devextreme-react/sankey';
+
+    const alignmentValues = [
+        'top', 
+        'bottom', 
+        'bottom'
+    ];
+
+    class App extends React.Component {
+        render() {
+            return (
+                <Sankey ... 
+                    alignment={alignmentValues}>
+                </Sankey>
+            );
+        }
+    }
+
+    export default App;     
+
 ---
 
 With this setting, the leftmost node column is aligned to the top, and the next two columns are aligned to the bottom. The rightmost column does not have a value in the **alignment** array and is aligned to the center (according to the default value).

--- a/api-reference/20 Data Visualization Widgets/dxTreeMap/1 Configuration/onClick.md
+++ b/api-reference/20 Data Visualization Widgets/dxTreeMap/1 Configuration/onClick.md
@@ -72,6 +72,53 @@ This function is often used to implement item selection as shown in the followin
         // ...
     })
 
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxTreeMap ...
+            @click="selectItem">
+        </DxTreeMap>
+    </template>
+
+    <script>
+    import DxTreeMap from 'devextreme-vue/tree-map';
+
+    export default {
+        components: {
+            DxTreeMap
+        },
+        methods: {
+            selectItem (e) {
+                e.node.select(!e.node.isSelected())
+            }
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import TreeMap from 'devextreme-react/tree-map';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <TreeMap ...
+                    onClick={this.selectItem}>
+                </TreeMap>
+            );
+        }
+
+        selectItem (e) {
+            e.node.select(!e.node.isSelected())
+        }
+    }
+
+    export default App;
+
 ---
 
 To identify whether the clicked node is a single tile or a group of tiles, use the node's [isLeaf()](/api-reference/20%20Data%20Visualization%20Widgets/dxTreeMap/6%20Node/3%20Methods/isLeaf().md '/Documentation/ApiReference/Data_Visualization_Widgets/dxTreeMap/Node/Methods/#isLeaf') method.


### PR DESCRIPTION
* Add Vue and React snippets to the dataviz widgets - part 1

* Add the second part of the snippets and apply review suggestions

* Apply suggestions from code review

Co-Authored-By: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

* Update api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/argumentAxis/categories.md

Co-Authored-By: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

* Address Roman's comments

* Fix a typo

* Apply suggestions from code review

Co-Authored-By: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>
(cherry picked from commit a9f372010b011d5ee67a7dcfe2da7b21398e8426)