### PR TITLE
Move indicator type snippets to include and add missing approaches (#…

### DIFF
--- a/api-reference/20 Data Visualization Widgets/dxCircularGauge/5 Indicator Types/RangeBar/RangeBar.md
+++ b/api-reference/20 Data Visualization Widgets/dxCircularGauge/5 Indicator Types/RangeBar/RangeBar.md
@@ -10,66 +10,10 @@ An object that defines a gauge indicator of the **rangeBar** type.
 ##### hidePropertyOf
 
 ---
----
-##### jQuery  
-
-    <!--JavaScript-->
-    $(function() {
-        $("#circularGaugeContainer").dxCircularGauge({
-            value: 40,
-            valueIndicator: { // or subvalueIndicator
-                type: "rangeBar",
-                // ...
-                // The rest of the indicator options go here
-                // ...
-            }
-        });
-    });
-
-    <!--HTML-->
-    <div id="circularGaugeContainer"></div>
-
-##### Angular  
-
-    <!--HTML-->
-    <dx-circular-gauge [value]="40">
-        <dxo-value-indicator <!-- or dxo-subvalue-indicator -->
-            type="rangeBar"
-            <!-- ... -->
-            <!-- The rest of the indicator options go here -->
-            <!-- ... -->>
-        </dxo-value-indicator>
-    </dx-circular-gauge>
-
-    <!--TypeScript-->
-    import { DxCircularGaugeModule } from "devextreme-angular";
-    // ...
-    export class AppComponent {
-        // ...
-    }
-    @NgModule({
-        imports: [
-            // ...
-            DxCircularGaugeModule
-        ],
-        // ...
-    })
-
-##### ASP.NET MVC Controls
-    
-    <!--Razor C#-->
-    @(Html.DevExtreme().CircularGauge()
-        .ID("circularGauge")
-        .Value(40)
-        .ValueIndicator(vi => vi // or .SubvalueIndicator
-            .Type(GaugeIndicatorType.RangeBar)
-            // ...
-            // The rest of the indicator options go here
-            // ...
-        )
-    )
-
----
+#include dataviz-ref-gauges-indicator-types-snippet with {
+    indicatorTypeCamelCase: "rangeBar",
+    indicatorTypePascalCase: "RangeBar"
+}
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Gauges/DifferentValueIndicatorTypes/"

--- a/api-reference/20 Data Visualization Widgets/dxCircularGauge/5 Indicator Types/RectangleNeedle/RectangleNeedle.md
+++ b/api-reference/20 Data Visualization Widgets/dxCircularGauge/5 Indicator Types/RectangleNeedle/RectangleNeedle.md
@@ -10,66 +10,10 @@ An object that defines a gauge indicator of the **rectangleNeedle** type.
 ##### hidePropertyOf
 
 ---
----
-##### jQuery  
-
-    <!--JavaScript-->
-    $(function() {
-        $("#circularGaugeContainer").dxCircularGauge({
-            value: 40,
-            valueIndicator: { // or subvalueIndicator
-                type: "rectangleNeedle",
-                // ...
-                // The rest of the indicator options go here
-                // ...
-            }
-        });
-    });
-
-    <!--HTML-->
-    <div id="circularGaugeContainer"></div>
-
-##### Angular  
-
-    <!--HTML-->
-    <dx-circular-gauge [value]="40">
-        <dxo-value-indicator <!-- or dxo-subvalue-indicator -->
-            type="rectangleNeedle"
-            <!-- ... -->
-            <!-- The rest of the indicator options go here -->
-            <!-- ... -->>
-        </dxo-value-indicator>
-    </dx-circular-gauge>
-
-    <!--TypeScript-->
-    import { DxCircularGaugeModule } from "devextreme-angular";
-    // ...
-    export class AppComponent {
-        // ...
-    }
-    @NgModule({
-        imports: [
-            // ...
-            DxCircularGaugeModule
-        ],
-        // ...
-    })
-
-##### ASP.NET MVC Controls
-    
-    <!--Razor C#-->
-    @(Html.DevExtreme().CircularGauge()
-        .ID("circularGauge")
-        .Value(40)
-        .ValueIndicator(vi => vi // or .SubvalueIndicator
-            .Type(GaugeIndicatorType.RectangleNeedle)
-            // ...
-            // The rest of the indicator options go here
-            // ...
-        )
-    )
-
----
+#include dataviz-ref-gauges-indicator-types-snippet with {
+    indicatorTypeCamelCase: "rectangleNeedle",
+    indicatorTypePascalCase: "RectangleNeedle"
+}
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Gauges/DifferentValueIndicatorTypes/"

--- a/api-reference/20 Data Visualization Widgets/dxCircularGauge/5 Indicator Types/TextCloud/TextCloud.md
+++ b/api-reference/20 Data Visualization Widgets/dxCircularGauge/5 Indicator Types/TextCloud/TextCloud.md
@@ -10,66 +10,10 @@ An object that defines a gauge indicator of the **textCloud** type.
 ##### hidePropertyOf
 
 ---
----
-##### jQuery  
-
-    <!--JavaScript-->
-    $(function() {
-        $("#circularGaugeContainer").dxCircularGauge({
-            value: 40,
-            valueIndicator: { // or subvalueIndicator
-                type: "textCloud",
-                // ...
-                // The rest of the indicator options go here
-                // ...
-            }
-        });
-    });
-
-    <!--HTML-->
-    <div id="circularGaugeContainer"></div>
-
-##### Angular  
-
-    <!--HTML-->
-    <dx-circular-gauge [value]="40">
-        <dxo-value-indicator <!-- or dxo-subvalue-indicator -->
-            type="textCloud"
-            <!-- ... -->
-            <!-- The rest of the indicator options go here -->
-            <!-- ... -->>
-        </dxo-value-indicator>
-    </dx-circular-gauge>
-
-    <!--TypeScript-->
-    import { DxCircularGaugeModule } from "devextreme-angular";
-    // ...
-    export class AppComponent {
-        // ...
-    }
-    @NgModule({
-        imports: [
-            // ...
-            DxCircularGaugeModule
-        ],
-        // ...
-    })
-
-##### ASP.NET MVC Controls
-    
-    <!--Razor C#-->
-    @(Html.DevExtreme().CircularGauge()
-        .ID("circularGauge")
-        .Value(40)
-        .ValueIndicator(vi => vi // or .SubvalueIndicator
-            .Type(GaugeIndicatorType.TextCloud)
-            // ...
-            // The rest of the indicator options go here
-            // ...
-        )
-    )
-
----
+#include dataviz-ref-gauges-indicator-types-snippet with {
+    indicatorTypeCamelCase: "textCloud",
+    indicatorTypePascalCase: "TextCloud"
+}
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Gauges/DifferentValueIndicatorTypes/"

--- a/api-reference/20 Data Visualization Widgets/dxCircularGauge/5 Indicator Types/TriangleMarker/TriangleMarker.md
+++ b/api-reference/20 Data Visualization Widgets/dxCircularGauge/5 Indicator Types/TriangleMarker/TriangleMarker.md
@@ -10,66 +10,10 @@ An object that defines a gauge indicator of the **triangleMarker** type.
 ##### hidePropertyOf
 
 ---
----
-##### jQuery  
-
-    <!--JavaScript-->
-    $(function() {
-        $("#circularGaugeContainer").dxCircularGauge({
-            value: 40,
-            valueIndicator: { // or subvalueIndicator
-                type: "triangleMarker",
-                // ...
-                // The rest of the indicator options go here
-                // ...
-            }
-        });
-    });
-
-    <!--HTML-->
-    <div id="circularGaugeContainer"></div>
-
-##### Angular  
-
-    <!--HTML-->
-    <dx-circular-gauge [value]="40">
-        <dxo-value-indicator <!-- or dxo-subvalue-indicator -->
-            type="triangleMarker"
-            <!-- ... -->
-            <!-- The rest of the indicator options go here -->
-            <!-- ... -->>
-        </dxo-value-indicator>
-    </dx-circular-gauge>
-
-    <!--TypeScript-->
-    import { DxCircularGaugeModule } from "devextreme-angular";
-    // ...
-    export class AppComponent {
-        // ...
-    }
-    @NgModule({
-        imports: [
-            // ...
-            DxCircularGaugeModule
-        ],
-        // ...
-    })
-
-##### ASP.NET MVC Controls
-    
-    <!--Razor C#-->
-    @(Html.DevExtreme().CircularGauge()
-        .ID("circularGauge")
-        .Value(40)
-        .ValueIndicator(vi => vi // or .SubvalueIndicator
-            .Type(GaugeIndicatorType.TriangleMarker)
-            // ...
-            // The rest of the indicator options go here
-            // ...
-        )
-    )
-
----
+#include dataviz-ref-gauges-indicator-types-snippet with {
+    indicatorTypeCamelCase: "triangleMarker",
+    indicatorTypePascalCase: "TriangleMarker"
+}
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Gauges/DifferentValueIndicatorTypes/"

--- a/api-reference/20 Data Visualization Widgets/dxCircularGauge/5 Indicator Types/TriangleNeedle/TriangleNeedle.md
+++ b/api-reference/20 Data Visualization Widgets/dxCircularGauge/5 Indicator Types/TriangleNeedle/TriangleNeedle.md
@@ -10,66 +10,10 @@ An object that defines a gauge indicator of the **triangleNeedle** type.
 ##### hidePropertyOf
 
 ---
----
-##### jQuery  
-
-    <!--JavaScript-->
-    $(function() {
-        $("#circularGaugeContainer").dxCircularGauge({
-            value: 40,
-            valueIndicator: { // or subvalueIndicator
-                type: "triangleNeedle",
-                // ...
-                // The rest of the indicator options go here
-                // ...
-            }
-        });
-    });
-
-    <!--HTML-->
-    <div id="circularGaugeContainer"></div>
-
-##### Angular  
-
-    <!--HTML-->
-    <dx-circular-gauge [value]="40">
-        <dxo-value-indicator <!-- or dxo-subvalue-indicator -->
-            type="triangleNeedle"
-            <!-- ... -->
-            <!-- The rest of the indicator options go here -->
-            <!-- ... -->>
-        </dxo-value-indicator>
-    </dx-circular-gauge>
-
-    <!--TypeScript-->
-    import { DxCircularGaugeModule } from "devextreme-angular";
-    // ...
-    export class AppComponent {
-        // ...
-    }
-    @NgModule({
-        imports: [
-            // ...
-            DxCircularGaugeModule
-        ],
-        // ...
-    })
-
-##### ASP.NET MVC Controls
-    
-    <!--Razor C#-->
-    @(Html.DevExtreme().CircularGauge()
-        .ID("circularGauge")
-        .Value(40)
-        .ValueIndicator(vi => vi // or .SubvalueIndicator
-            .Type(GaugeIndicatorType.TriangleNeedle)
-            // ...
-            // The rest of the indicator options go here
-            // ...
-        )
-    )
-
----
+#include dataviz-ref-gauges-indicator-types-snippet with {
+    indicatorTypeCamelCase: "triangleNeedle",
+    indicatorTypePascalCase: "TriangleNeedle"
+}
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Gauges/DifferentValueIndicatorTypes/"

--- a/api-reference/20 Data Visualization Widgets/dxCircularGauge/5 Indicator Types/TwoColorNeedle/TwoColorNeedle.md
+++ b/api-reference/20 Data Visualization Widgets/dxCircularGauge/5 Indicator Types/TwoColorNeedle/TwoColorNeedle.md
@@ -10,66 +10,10 @@ An object that defines a gauge indicator of the **twoColorNeedle** type.
 ##### hidePropertyOf
 
 ---
----
-##### jQuery  
-
-    <!--JavaScript-->
-    $(function() {
-        $("#circularGaugeContainer").dxCircularGauge({
-            value: 40,
-            valueIndicator: { // or subvalueIndicator
-                type: "twoColorNeedle",
-                // ...
-                // The rest of the indicator options go here
-                // ...
-            }
-        });
-    });
-
-    <!--HTML-->
-    <div id="circularGaugeContainer"></div>
-
-##### Angular  
-
-    <!--HTML-->
-    <dx-circular-gauge [value]="40">
-        <dxo-value-indicator <!-- or dxo-subvalue-indicator -->
-            type="twoColorNeedle"
-            <!-- ... -->
-            <!-- The rest of the indicator options go here -->
-            <!-- ... -->>
-        </dxo-value-indicator>
-    </dx-circular-gauge>
-
-    <!--TypeScript-->
-    import { DxCircularGaugeModule } from "devextreme-angular";
-    // ...
-    export class AppComponent {
-        // ...
-    }
-    @NgModule({
-        imports: [
-            // ...
-            DxCircularGaugeModule
-        ],
-        // ...
-    })
-
-##### ASP.NET MVC Controls
-    
-    <!--Razor C#-->
-    @(Html.DevExtreme().CircularGauge()
-        .ID("circularGauge")
-        .Value(40)
-        .ValueIndicator(vi => vi // or .SubvalueIndicator
-            .Type(GaugeIndicatorType.TwoColorNeedle)
-            // ...
-            // The rest of the indicator options go here
-            // ...
-        )
-    )
-
----
+#include dataviz-ref-gauges-indicator-types-snippet with {
+    indicatorTypeCamelCase: "twoColorNeedle",
+    indicatorTypePascalCase: "TwoColorNeedle"
+}
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Gauges/DifferentValueIndicatorTypes/"

--- a/api-reference/20 Data Visualization Widgets/dxLinearGauge/5 Indicator Types/Circle/Circle.md
+++ b/api-reference/20 Data Visualization Widgets/dxLinearGauge/5 Indicator Types/Circle/Circle.md
@@ -10,66 +10,10 @@ An object that defines a gauge indicator of the **circle** type.
 ##### hidePropertyOf
 
 ---
----
-##### jQuery  
-
-    <!--JavaScript-->
-    $(function() {
-        $("#linearGaugeContainer").dxLinearGauge({
-            value: 40,
-            valueIndicator: { // or subvalueIndicator
-                type: "circle",
-                // ...
-                // The rest of the indicator options go here
-                // ...
-            }
-        });
-    });
-
-    <!--HTML-->
-    <div id="linearGaugeContainer"></div>
-
-##### Angular  
-
-    <!--HTML-->
-    <dx-linear-gauge [value]="40">
-        <dxo-value-indicator <!-- or dxo-subvalue-indicator -->
-            type="circle"
-            <!-- ... -->
-            <!-- The rest of the indicator options go here -->
-            <!-- ... -->>
-        </dxo-value-indicator>
-    </dx-linear-gauge>
-
-    <!--TypeScript-->
-    import { DxLinearGaugeModule } from "devextreme-angular";
-    // ...
-    export class AppComponent {
-        // ...
-    }
-    @NgModule({
-        imports: [
-            // ...
-            DxLinearGaugeModule
-        ],
-        // ...
-    })
-
-##### ASP.NET MVC Controls
-    
-    <!--Razor C#-->
-    @(Html.DevExtreme().LinearGauge()
-        .ID("linearGauge")
-        .Value(40)
-        .ValueIndicator(vi => vi // or .SubvalueIndicator
-            .Type(GaugeIndicatorType.Circle)
-            // ...
-            // The rest of the indicator options go here
-            // ...
-        )
-    )
-
----
+#include dataviz-ref-gauges-indicator-types-snippet with {
+    indicatorTypeCamelCase: "circle",
+    indicatorTypePascalCase: "Circle"
+}
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Gauges/DifferentValueIndicatorTypesLinearGauge/"

--- a/api-reference/20 Data Visualization Widgets/dxLinearGauge/5 Indicator Types/RangeBar/RangeBar.md
+++ b/api-reference/20 Data Visualization Widgets/dxLinearGauge/5 Indicator Types/RangeBar/RangeBar.md
@@ -10,66 +10,11 @@ An object that defines a gauge indicator of the **rangeBar** type.
 ##### hidePropertyOf
 
 ---
----
-##### jQuery  
 
-    <!--JavaScript-->
-    $(function() {
-        $("#linearGaugeContainer").dxLinearGauge({
-            value: 40,
-            valueIndicator: { // or subvalueIndicator
-                type: "rangeBar",
-                // ...
-                // The rest of the indicator options go here
-                // ...
-            }
-        });
-    });
-
-    <!--HTML-->
-    <div id="linearGaugeContainer"></div>
-
-##### Angular  
-
-    <!--HTML-->
-    <dx-linear-gauge [value]="40">
-        <dxo-value-indicator <!-- or dxo-subvalue-indicator -->
-            type="rangeBar"
-            <!-- ... -->
-            <!-- The rest of the indicator options go here -->
-            <!-- ... -->>
-        </dxo-value-indicator>
-    </dx-linear-gauge>
-
-    <!--TypeScript-->
-    import { DxLinearGaugeModule } from "devextreme-angular";
-    // ...
-    export class AppComponent {
-        // ...
-    }
-    @NgModule({
-        imports: [
-            // ...
-            DxLinearGaugeModule
-        ],
-        // ...
-    })
-
-##### ASP.NET MVC Controls
-    
-    <!--Razor C#-->
-    @(Html.DevExtreme().LinearGauge()
-        .ID("linearGauge")
-        .Value(40)
-        .ValueIndicator(vi => vi // or .SubvalueIndicator
-            .Type(GaugeIndicatorType.RangeBar)
-            // ...
-            // The rest of the indicator options go here
-            // ...
-        )
-    )
-
----
+#include dataviz-ref-gauges-indicator-types-snippet with {
+    indicatorTypeCamelCase: "rangeBar",
+    indicatorTypePascalCase: "RangeBar"
+}
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Gauges/DifferentValueIndicatorTypesLinearGauge/"

--- a/api-reference/20 Data Visualization Widgets/dxLinearGauge/5 Indicator Types/Rectangle/Rectangle.md
+++ b/api-reference/20 Data Visualization Widgets/dxLinearGauge/5 Indicator Types/Rectangle/Rectangle.md
@@ -10,66 +10,10 @@ An object defining a gauge indicator of the **rectangle** type.
 ##### hidePropertyOf
 
 ---
----
-##### jQuery  
-
-    <!--JavaScript-->
-    $(function() {
-        $("#linearGaugeContainer").dxLinearGauge({
-            value: 40,
-            valueIndicator: { // or subvalueIndicator
-                type: "rectangle",
-                // ...
-                // The rest of the indicator options go here
-                // ...
-            }
-        });
-    });
-
-    <!--HTML-->
-    <div id="linearGaugeContainer"></div>
-
-##### Angular  
-
-    <!--HTML-->
-    <dx-linear-gauge [value]="40">
-        <dxo-value-indicator <!-- or dxo-subvalue-indicator -->
-            type="rectangle"
-            <!-- ... -->
-            <!-- The rest of the indicator options go here -->
-            <!-- ... -->>
-        </dxo-value-indicator>
-    </dx-linear-gauge>
-
-    <!--TypeScript-->
-    import { DxLinearGaugeModule } from "devextreme-angular";
-    // ...
-    export class AppComponent {
-        // ...
-    }
-    @NgModule({
-        imports: [
-            // ...
-            DxLinearGaugeModule
-        ],
-        // ...
-    })
-
-##### ASP.NET MVC Controls
-    
-    <!--Razor C#-->
-    @(Html.DevExtreme().LinearGauge()
-        .ID("linearGauge")
-        .Value(40)
-        .ValueIndicator(vi => vi // or .SubvalueIndicator
-            .Type(GaugeIndicatorType.Rectangle)
-            // ...
-            // The rest of the indicator options go here
-            // ...
-        )
-    )
-
----
+#include dataviz-ref-gauges-indicator-types-snippet with {
+    indicatorTypeCamelCase: "rectangle",
+    indicatorTypePascalCase: "Rectangle"
+}
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Gauges/DifferentValueIndicatorTypesLinearGauge/"

--- a/api-reference/20 Data Visualization Widgets/dxLinearGauge/5 Indicator Types/Rhombus/Rhombus.md
+++ b/api-reference/20 Data Visualization Widgets/dxLinearGauge/5 Indicator Types/Rhombus/Rhombus.md
@@ -10,66 +10,10 @@ An object defining a gauge indicator of the **rhombus** type.
 ##### hidePropertyOf
 
 ---
----
-##### jQuery  
-
-    <!--JavaScript-->
-    $(function() {
-        $("#linearGaugeContainer").dxLinearGauge({
-            value: 40,
-            valueIndicator: { // or subvalueIndicator
-                type: "rhombus",
-                // ...
-                // The rest of the indicator options go here
-                // ...
-            }
-        });
-    });
-
-    <!--HTML-->
-    <div id="linearGaugeContainer"></div>
-
-##### Angular  
-
-    <!--HTML-->
-    <dx-linear-gauge [value]="40">
-        <dxo-value-indicator <!-- or dxo-subvalue-indicator -->
-            type="rhombus"
-            <!-- ... -->
-            <!-- The rest of the indicator options go here -->
-            <!-- ... -->>
-        </dxo-value-indicator>
-    </dx-linear-gauge>
-
-    <!--TypeScript-->
-    import { DxLinearGaugeModule } from "devextreme-angular";
-    // ...
-    export class AppComponent {
-        // ...
-    }
-    @NgModule({
-        imports: [
-            // ...
-            DxLinearGaugeModule
-        ],
-        // ...
-    })
-
-##### ASP.NET MVC Controls
-    
-    <!--Razor C#-->
-    @(Html.DevExtreme().LinearGauge()
-        .ID("linearGauge")
-        .Value(40)
-        .ValueIndicator(vi => vi // or .SubvalueIndicator
-            .Type(GaugeIndicatorType.Rhombus)
-            // ...
-            // The rest of the indicator options go here
-            // ...
-        )
-    )
-
----
+#include dataviz-ref-gauges-indicator-types-snippet with {
+    indicatorTypeCamelCase: "rhombus",
+    indicatorTypePascalCase: "Rhombus"
+}
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Gauges/DifferentValueIndicatorTypesLinearGauge/"

--- a/api-reference/20 Data Visualization Widgets/dxLinearGauge/5 Indicator Types/TextCloud/TextCloud.md
+++ b/api-reference/20 Data Visualization Widgets/dxLinearGauge/5 Indicator Types/TextCloud/TextCloud.md
@@ -10,66 +10,10 @@ An object that defines a gauge indicator of the **textCloud** type.
 ##### hidePropertyOf
 
 ---
----
-##### jQuery  
-
-    <!--JavaScript-->
-    $(function() {
-        $("#linearGaugeContainer").dxLinearGauge({
-            value: 40,
-            valueIndicator: { // or subvalueIndicator
-                type: "textCloud",
-                // ...
-                // The rest of the indicator options go here
-                // ...
-            }
-        });
-    });
-
-    <!--HTML-->
-    <div id="linearGaugeContainer"></div>
-
-##### Angular  
-
-    <!--HTML-->
-    <dx-linear-gauge [value]="40">
-        <dxo-value-indicator <!-- or dxo-subvalue-indicator -->
-            type="textCloud"
-            <!-- ... -->
-            <!-- The rest of the indicator options go here -->
-            <!-- ... -->>
-        </dxo-value-indicator>
-    </dx-linear-gauge>
-
-    <!--TypeScript-->
-    import { DxLinearGaugeModule } from "devextreme-angular";
-    // ...
-    export class AppComponent {
-        // ...
-    }
-    @NgModule({
-        imports: [
-            // ...
-            DxLinearGaugeModule
-        ],
-        // ...
-    })
-
-##### ASP.NET MVC Controls
-    
-    <!--Razor C#-->
-    @(Html.DevExtreme().LinearGauge()
-        .ID("linearGauge")
-        .Value(40)
-        .ValueIndicator(vi => vi // or .SubvalueIndicator
-            .Type(GaugeIndicatorType.TextCloud)
-            // ...
-            // The rest of the indicator options go here
-            // ...
-        )
-    )
-
----
+#include dataviz-ref-gauges-indicator-types-snippet with {
+    indicatorTypeCamelCase: "textCloud",
+    indicatorTypePascalCase: "TextCloud"
+}
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Gauges/DifferentValueIndicatorTypesLinearGauge/"

--- a/api-reference/20 Data Visualization Widgets/dxLinearGauge/5 Indicator Types/TriangleMarker/TriangleMarker.md
+++ b/api-reference/20 Data Visualization Widgets/dxLinearGauge/5 Indicator Types/TriangleMarker/TriangleMarker.md
@@ -10,66 +10,10 @@ An object that defines a gauge indicator of the **triangleMarker** type.
 ##### hidePropertyOf
 
 ---
----
-##### jQuery  
-
-    <!--JavaScript-->
-    $(function() {
-        $("#linearGaugeContainer").dxLinearGauge({
-            value: 40,
-            valueIndicator: { // or subvalueIndicator
-                type: "triangleMarker",
-                // ...
-                // The rest of the indicator options go here
-                // ...
-            }
-        });
-    });
-
-    <!--HTML-->
-    <div id="linearGaugeContainer"></div>
-
-##### Angular  
-
-    <!--HTML-->
-    <dx-linear-gauge [value]="40">
-        <dxo-value-indicator <!-- or dxo-subvalue-indicator -->
-            type="triangleMarker"
-            <!-- ... -->
-            <!-- The rest of the indicator options go here -->
-            <!-- ... -->>
-        </dxo-value-indicator>
-    </dx-linear-gauge>
-
-    <!--TypeScript-->
-    import { DxLinearGaugeModule } from "devextreme-angular";
-    // ...
-    export class AppComponent {
-        // ...
-    }
-    @NgModule({
-        imports: [
-            // ...
-            DxLinearGaugeModule
-        ],
-        // ...
-    })
-
-##### ASP.NET MVC Controls
-    
-    <!--Razor C#-->
-    @(Html.DevExtreme().LinearGauge()
-        .ID("linearGauge")
-        .Value(40)
-        .ValueIndicator(vi => vi // or .SubvalueIndicator
-            .Type(GaugeIndicatorType.TriangleMarker)
-            // ...
-            // The rest of the indicator options go here
-            // ...
-        )
-    )
-
----
+#include dataviz-ref-gauges-indicator-types-snippet with {
+    indicatorTypeCamelCase: "triangleMarker",
+    indicatorTypePascalCase: "TriangleMarker"
+}
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Gauges/DifferentValueIndicatorTypesLinearGauge/"

--- a/includes/dataviz-ref-gauges-indicator-types-snippet.md
+++ b/includes/dataviz-ref-gauges-indicator-types-snippet.md
@@ -1,0 +1,100 @@
+---
+##### jQuery
+
+    <!-- tab: index.js -->
+    $(function() {
+        $("#{widgetName}").dx{WidgetName}({
+            value: 40,
+            valueIndicator: { // or subvalueIndicator
+                type: "${{indicatorTypeCamelCase}}",
+                // The rest of the indicator options go here
+            }
+        });
+    });
+
+##### Angular
+
+    <!--HTML-->
+    <dx-{widget-name} [value]="40">
+        <dxo-value-indicator <!-- or dxo-subvalue-indicator -->
+            type="${{indicatorTypeCamelCase}}"          
+            <!-- The rest of the indicator options go here -->
+        ></dxo-value-indicator>
+    <dx-{widget-name}>
+
+    <!--TypeScript-->
+    import { Dx{WidgetName}Module } from "devextreme-angular";
+    // ...
+    export class AppComponent {
+        // ...
+    }
+    @NgModule({
+        imports: [
+            // ...
+            Dx{WidgetName}Module
+        ],
+        // ...
+    })
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <Dx{WidgetName} :value="40">
+            <DxValueIndicator <!-- or DxSubvalueIndicator -->
+                type="${{indicatorTypeCamelCase}}"
+                <!-- The rest of the indicator options go here -->
+            /> 
+        </Dx{WidgetName}>
+    </template>
+
+    <script>
+    import Dx{WidgetName}, {
+        DxValueIndicator
+    } from 'devextreme-vue/{widget-name}';
+
+    export default {
+        components: {
+            Dx{WidgetName},
+            DxValueIndicator
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import {WidgetName}, {
+        ValueIndicator
+    } from 'devextreme-react/{widget-name}';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <{WidgetName} value={40}>
+                    <ValueIndicator {/* or SubvalueIndicator */}                        
+                        type="${{indicatorTypeCamelCase}}"
+                        {/* The rest of the indicator options go here */}
+                    />
+                </{WidgetName}>
+            );
+        }
+    }
+    export default App;
+
+##### ASP.NET MVC Controls
+    
+    <!--Razor C#-->
+    @(Html.DevExtreme().{WidgetName}()
+        .ID("{widgetName}")
+        .Value(40)
+        .ValueIndicator(vi => vi // or .SubvalueIndicator
+            .Type(GaugeIndicatorType.${{indicatorTypePascalCase}})
+            // The rest of the indicator options go here
+        )
+    )
+
+
+---


### PR DESCRIPTION
…252)

* Move indicator type snippets to include and add missing approaches

* Add the snippet include to the circular gauge reference

* Apply suggestions from code review

Co-Authored-By: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>
(cherry picked from commit 83be358664c8ef227d20584a54f81410bc199e26)