### PR TITLE
Clarify that only values of the cells that use NumberBox can be forma…

### DIFF
--- a/api-reference/_hidden/GridBaseColumn/format.md
+++ b/api-reference/_hidden/GridBaseColumn/format.md
@@ -128,7 +128,7 @@ In the following code, the *"fixedPoint"* [format type](/api-reference/50%20Comm
 
 ---
 
-The **format** option also controls the user input in cells that use the [DateBox](/concepts/05%20Widgets/DateBox/00%20Overview.md '/Documentation/Guide/Widgets/DateBox/Overview/') widget for editing. For cells that use other widgets, you can specify the [editorOptions](/api-reference/_hidden/GridBaseColumn/editorOptions.md '{basewidgetpath}/Configuration/columns/#editorOptions').**format** option, as shown in the following demo:
+The **format** option also limits user input in cells that use the [DateBox](/concepts/05%20Widgets/DateBox/00%20Overview.md '/Documentation/Guide/Widgets/DateBox/Overview/') widget for editing. For cells that use the [NumberBox](/api-reference/10%20UI%20Widgets/dxNumberBox '/Documentation/ApiReference/UI_Widgets/dxNumberBox/') widget, you can specify the [editorOptions](/api-reference/_hidden/GridBaseColumn/editorOptions.md '{basewidgetpath}/Configuration/columns/#editorOptions').**format** option, as shown in the following demo:
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/DataGrid/RecalculateWhileEditing/"


### PR DESCRIPTION
…tted (#274)

* Clarify that only values of the cells that use NumberBox can be formatted

* Update api-reference/_hidden/GridBaseColumn/format.md

Co-Authored-By: DirkPieterse <dirk.pieterse@devexpress.com>

Co-authored-by: DirkPieterse <dirk.pieterse@devexpress.com>
(cherry picked from commit b357f00aea7a93331b72c9c4d069de65d255c8db)