### PR TITLE
CherryPick - Add Vue and React code snippets to dxDataGrid/dxTreelist onFocusedCellChanging (#359)

### DIFF
--- a/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onFocusedCellChanging.md
+++ b/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onFocusedCellChanging.md
@@ -58,7 +58,7 @@ In the following code, the **onFocusedCellChanging** function is used to customi
 
     <!--JavaScript-->
     $(function() {
-        $("#dataGridContainer").dxDataGrid({
+        $("#{widgetName}Container").dx{WidgetName}({
             // ...
             onFocusedCellChanging: function (e) {
                 if (e.newColumnIndex == e.prevColumnIndex) {
@@ -71,7 +71,7 @@ In the following code, the **onFocusedCellChanging** function is used to customi
 ##### Angular
 
     <!--TypeScript-->
-    import { DxDataGridModule } from "devextreme-angular";
+    import { Dx{WidgetName}Module } from "devextreme-angular";
     // ...
     export class AppComponent {
         onFocusedCellChanging (e) { 
@@ -83,18 +83,76 @@ In the following code, the **onFocusedCellChanging** function is used to customi
     @NgModule({
         imports: [
             // ...
-            DxDataGridModule
+            Dx{WidgetName}Module
         ],
         // ...
     })
 
     <!--HTML-->
-    <dx-data-grid ...
+    <dx-{widget-name} ...
         (onFocusedCellChanging)="onFocusedCellChanging($event)">
-    </dx-data-grid>
-    
+    </dx-{widget-name}>
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <Dx{WidgetName} ...
+            @focused-cell-changing="onFocusedCellChanging"
+        > 
+        </Dx{WidgetName}>
+    </template>
+
+    <script>
+    import 'devextreme/dist/css/dx.common.css';
+    import 'devextreme/dist/css/dx.light.css';
+
+    import { Dx{WidgetName} } from 'devextreme-vue/{widget-name}';
+
+    export default {
+        components: {
+            Dx{WidgetName}
+        },
+        methods: {
+            onFocusedCellChanging(e) {
+                if (e.newColumnIndex == e.prevColumnIndex) {
+                    e.newColumnIndex = (e.newColumnIndex == 0 ? e.columns.length - 1 : 0);
+                }
+            }
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import 'devextreme/dist/css/dx.common.css';
+    import 'devextreme/dist/css/dx.light.css';
+
+    import {WidgetName} from 'devextreme-react/{widget-name}';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <{WidgetName} ...
+                    onFocusedCellChanging={this.onFocusedCellChanging}
+                >
+                </{WidgetName}>
+            );
+        }
+
+        onFocusedCellChanging(e) { 
+            if (e.newColumnIndex == e.prevColumnIndex) {
+                e.newColumnIndex = (e.newColumnIndex == 0 ? e.columns.length - 1 : 0);
+            }
+        }
+    }
+    export default App;
+
 ---
 
 #####See Also#####
-- [focusedRowIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowIndex.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/#focusedRowIndex') | [focusedRowKey](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowKey.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/#focusedRowKey')
-- [focusedColumnIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedColumnIndex.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/#focusedColumnIndex')
+- [focusedRowIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowIndex.md '/Documentation/ApiReference/UI_Widgets/dx{WidgetName}/Configuration/#focusedRowIndex') | [focusedRowKey](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowKey.md '/Documentation/ApiReference/UI_Widgets/dx{WidgetName}/Configuration/#focusedRowKey')
+- [focusedColumnIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedColumnIndex.md '/Documentation/ApiReference/UI_Widgets/dx{WidgetName}/Configuration/#focusedColumnIndex')

--- a/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onFocusedCellChanging.md
+++ b/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onFocusedCellChanging.md
@@ -51,50 +51,9 @@ The index of the previously focused cell's row.
 The visible rows' properties.
 
 ---
-In the following code, the **onFocusedCellChanging** function is used to customize keyboard navigation within a row. The cell navigation is looped in a single row because focus moves to the row's first cell after reaching the last cell and vice versa:
 
----
-##### jQuery
+<!-- %fullDescription% -->
 
-    <!--JavaScript-->
-    $(function() {
-        $("#treeListContainer").dxTreeList({
-            // ...
-            onFocusedCellChanging: function (e) {
-                if (e.newColumnIndex == e.prevColumnIndex) {
-                    e.newColumnIndex = (e.newColumnIndex == 0 ? e.columns.length - 1 : 0)
-                }
-            }
-        });
-    });
-
-##### Angular
-
-    <!--TypeScript-->
-    import { DxTreeListModule } from "devextreme-angular";
-    // ...
-    export class AppComponent {
-        onFocusedCellChanging (e) { 
-            if (e.newColumnIndex == e.prevColumnIndex) {
-                e.newColumnIndex = (e.newColumnIndex == 0 ? e.columns.length - 1 : 0)
-            }
-        }
-    }
-    @NgModule({
-        imports: [
-            // ...
-            DxTreeListModule
-        ],
-        // ...
-    })
-
-    <!--HTML-->
-    <dx-tree-list ...
-        (onFocusedCellChanging)="onFocusedCellChanging($event)">
-    </dx-tree-list>
+<!-- import * from 'api-reference\10 UI Widgets\dxDataGrid\1 Configuration\onFocusedCellChanging.md' -->
     
 ---
-
-#####See Also#####
-- [focusedRowIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowIndex.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedRowIndex') | [focusedRowKey](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowKey.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedRowKey')
-- [focusedColumnIndex](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedColumnIndex.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/#focusedColumnIndex')


### PR DESCRIPTION
* Add Vue and React code snippets to dxDataGrid/dxTreelist onFocusedCellChanging

* Update api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onFocusedCellChanging.md

Co-Authored-By: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

* Update api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onFocusedCellChanging.md

Co-Authored-By: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>
(cherry picked from commit f06d01f1b6005249dbc878a5f9678b65069bd576)