### PR TITLE
Widgets\Drawer - add Vue approach to each snippet

### DIFF
--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
@@ -177,14 +177,12 @@ In addition, you can specify the [minSize](/api-reference/10%20UI%20Widgets/dxDr
 
     <!-- tab: App.vue -->
     <template>
-        <div>
-            <DxDrawer opened="true" :minSize="37" :height="250" template="template" reveal-mode="expand">
-                <template #template>
-                    <div style="width: 150px">Drawer content</div>
-                </template>
-                <div id="view">View content</div>
-            </DxDrawer>
-        </div>
+        <DxDrawer opened="true" :minSize="37" :height="250" template="template" reveal-mode="expand">
+            <template #template>
+                <div style="width: 150px">Drawer content</div>
+            </template>
+            <div id="view">View content</div>
+        </DxDrawer>
     </template>
 
     <style>

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
@@ -178,7 +178,7 @@ In addition, you can specify the [minSize](/api-reference/10%20UI%20Widgets/dxDr
     <!-- tab: App.vue -->
     <template>
     <div>
-        <DxDrawer :opened="true" template="template">
+        <DxDrawer opened="true" minSize="37" height="250" template="template">
             <template #template>
                 <div style="width: 150px">Drawer content</div>
             </template>

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
@@ -173,6 +173,30 @@ In addition, you can specify the [minSize](/api-reference/10%20UI%20Widgets/dxDr
     }
     export default App;
 
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+    <div>
+        <DxDrawer :opened.sync="openState" template="template">
+            <template #template>
+                <div style="width: 150px">Drawer content</div>
+            </template>
+            <div id="view">View content</div>
+        </DxDrawer>
+    </div>
+    </template>
+
+    <style>
+    .dx-drawer-panel-content, .dx-overlay-content {
+        background-color: lightgray;
+    }
+    #view {
+        margin-left: 10px;
+        margin-top: 10px;
+    }
+    </style>
+
 ---
 
 If you run the code, you should see a partially visible **Drawer** and a view that displays *View content*.

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
@@ -178,7 +178,7 @@ In addition, you can specify the [minSize](/api-reference/10%20UI%20Widgets/dxDr
     <!-- tab: App.vue -->
     <template>
     <div>
-        <DxDrawer :opened.sync="openState" template="template">
+        <DxDrawer :opened.sync="isDrawerOpened" template="template">
             <template #template>
                 <div style="width: 150px">Drawer content</div>
             </template>

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
@@ -178,7 +178,7 @@ In addition, you can specify the [minSize](/api-reference/10%20UI%20Widgets/dxDr
     <!-- tab: App.vue -->
     <template>
     <div>
-        <DxDrawer :opened.sync="isDrawerOpened" template="template">
+        <DxDrawer :opened="true" template="template">
             <template #template>
                 <div style="width: 150px">Drawer content</div>
             </template>

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
@@ -178,7 +178,7 @@ In addition, you can specify the [minSize](/api-reference/10%20UI%20Widgets/dxDr
     <!-- tab: App.vue -->
     <template>
     <div>
-        <DxDrawer opened="true" minSize="37" height="250" template="template">
+        <DxDrawer opened="true" minSize="37" height="250" template="template" reveal-mode="expand">
             <template #template>
                 <div style="width: 150px">Drawer content</div>
             </template>

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
@@ -177,14 +177,14 @@ In addition, you can specify the [minSize](/api-reference/10%20UI%20Widgets/dxDr
 
     <!-- tab: App.vue -->
     <template>
-    <div>
-        <DxDrawer opened="true" minSize="37" height="250" template="template" reveal-mode="expand">
-            <template #template>
-                <div style="width: 150px">Drawer content</div>
-            </template>
-            <div id="view">View content</div>
-        </DxDrawer>
-    </div>
+        <div>
+            <DxDrawer opened="true" minSize="37" height="250" template="template" reveal-mode="expand">
+                <template #template>
+                    <div style="width: 150px">Drawer content</div>
+                </template>
+                <div id="view">View content</div>
+            </DxDrawer>
+        </div>
     </template>
 
     <style>

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
@@ -178,7 +178,7 @@ In addition, you can specify the [minSize](/api-reference/10%20UI%20Widgets/dxDr
     <!-- tab: App.vue -->
     <template>
         <div>
-            <DxDrawer opened="true" minSize="37" height="250" template="template" reveal-mode="expand">
+            <DxDrawer opened="true" :minSize="37" :height="250" template="template" reveal-mode="expand">
                 <template #template>
                     <div style="width: 150px">Drawer content</div>
                 </template>

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/10 Open and Close the Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/10 Open and Close the Drawer.md
@@ -211,17 +211,17 @@ In the following code, a toolbar button outside the **Drawer** opens and closes 
 
     <!-- tab: App.vue -->
     <template>
-    <div>
-        <DxToolbar id="toolbar">
-            <DxItem :options="buttonOptions" location="before" widget="dxButton"/>
-        </DxToolbar>
-        <DxDrawer :opened.sync="isDrawerOpened" template="template">
-            <template #template>
-                <div style="width: 150px">Drawer content</div>
-            </template>
-            <div id="view">View content</div>
-        </DxDrawer>
-    </div>
+        <div>
+            <DxToolbar id="toolbar">
+                <DxItem :options="buttonOptions" location="before" widget="dxButton"/>
+            </DxToolbar>
+            <DxDrawer :opened.sync="isDrawerOpened" template="template">
+                <template #template>
+                    <div style="width: 150px">Drawer content</div>
+                </template>
+                <div id="view">View content</div>
+            </DxDrawer>
+        </div>
     </template>
 
     <script>

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/10 Open and Close the Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/10 Open and Close the Drawer.md
@@ -207,4 +207,59 @@ In the following code, a toolbar button outside the **Drawer** opens and closes 
         margin-left: -7px;
     }
 
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+    <div>
+        <DxToolbar id="toolbar">
+            <DxItem :options="buttonOptions" location="before" widget="dxButton"/>
+        </DxToolbar>
+        <DxDrawer :opened.sync="isDrawerOpened" template="template">
+            <template #template>
+                <div style="width: 150px">Drawer content</div>
+            </template>
+            <div id="view">View content</div>
+        </DxDrawer>
+    </div>
+    </template>
+
+    <script>
+    import { DxDrawer } from "devextreme-vue";
+    import DxToolbar, { DxItem } from "devextreme-vue/toolbar";
+
+    export default {
+    components: {
+        DxDrawer,
+        DxToolbar,
+        DxItem
+    },
+    data() {
+        return {
+            buttonOptions: {
+                icon: "menu",
+                onClick: () => {
+                    this.isDrawerOpened = !this.isDrawerOpened;
+                }
+            },
+            isDrawerOpened: true
+        };
+    }
+    };
+    </script>
+
+    <style>
+    #toolbar {
+        background-color: rgba(191, 191, 191, 0.15);
+        padding: 5px 10px;
+    }
+    .dx-toolbar-button .dx-button {
+        background-color: rgba(191, 191, 191, -0.15);
+        border: none;
+    }
+    .dx-toolbar-button > .dx-toolbar-item-content {
+        margin-left: -7px;
+    }
+    </style>
+
 ---

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/15 Implement Navigation.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/15 Implement Navigation.md
@@ -450,41 +450,6 @@ In this tutorial, we use the **List**:
         </div>
     </template>
 
-    <script>
-    import { DxDrawer } from "devextreme-vue";
-    import DxToolbar, { DxItem } from "devextreme-vue/toolbar";
-    import NavigationList from "./NavigationList.vue";
-    import { text } from "./data.js";
-
-    export default {
-        components: {
-            DxDrawer,
-            DxToolbar,
-            DxItem,
-            NavigationList
-        },
-        data() {
-            return {
-                text,
-                buttonOptions: {
-                    icon: "menu",
-                    onClick: () => {
-                        this.isDrawerOpened = !this.isDrawerOpened;
-                    }
-                },
-                isDrawerOpened: false
-            };
-        }
-    };
-    </script>
-
-    <style>
-    /* ... */
-    .dx-list-item-icon {
-        margin-right: 10px;
-    }
-    </style>
-
     <!-- tab: NavigationList.vue -->
     <template>
         <div style="width: 200px">

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/15 Implement Navigation.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/15 Implement Navigation.md
@@ -453,7 +453,7 @@ In this tutorial, we use the **List**:
     <!-- tab: NavigationList.vue -->
     <template>
         <DxList
-            width="200"
+            :width="200"
             selection-mode="single"
             :data-source="navigation"
             @selection-changed="loadView($event)"

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/15 Implement Navigation.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/15 Implement Navigation.md
@@ -452,14 +452,12 @@ In this tutorial, we use the **List**:
 
     <!-- tab: NavigationList.vue -->
     <template>
-        <div style="width: 200px">
-            <DxList
-                width="200"
-                selection-mode="single"
-                :data-source="navigation"
-                @selection-changed="loadView($event)"
-            />
-        </div>
+        <DxList
+            width="200"
+            selection-mode="single"
+            :data-source="navigation"
+            @selection-changed="loadView($event)"
+        />
     </template>
     <script>
     import { DxList } from "devextreme-vue/list";

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/15 Implement Navigation.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/15 Implement Navigation.md
@@ -401,6 +401,163 @@ In this tutorial, we use the **List**:
     }
     export default Trash;
 
+##### Vue
+
+    <!-- tab: index.js -->
+    import Vue from "vue";
+    import VueRouter from "vue-router";
+    import App from "./App.vue";
+    import InboxComponent from "./inbox.vue";
+    import SentMailComponent from "./sent-mail.vue";
+    import TrashComponent from "./trash.vue";
+    import SpamComponent from "./spam.vue";
+
+    Vue.use(VueRouter);
+
+    const routes = [
+        { path: "", redirect: "/inbox" },
+        { path: "/inbox", component: InboxComponent },
+        { path: "/sent-mail", component: SentMailComponent },
+        { path: "/trash", component: TrashComponent },
+        { path: "/spam", component: SpamComponent }
+    ];
+
+    const router = new VueRouter({
+        mode: "history",
+        routes
+    });
+
+    new Vue({
+        el: "#app",
+        components: { App },
+        template: "<App/>",
+        router
+    });
+
+    <!-- tab: App.vue -->
+    <template>
+        <div>
+            <DxToolbar id="toolbar">
+                <DxItem :options="buttonOptions" location="before" widget="dxButton"/>
+            </DxToolbar>
+            <DxDrawer ...
+                template="listMenu" >
+
+                <div id="view">
+                    <router-view></router-view>
+                </div>
+            </DxDrawer>
+        </div>
+    </template>
+
+    <script>
+    import { DxDrawer } from "devextreme-vue";
+    import DxToolbar, { DxItem } from "devextreme-vue/toolbar";
+    import NavigationList from "./NavigationList.vue";
+    import { text } from "./data.js";
+
+    export default {
+        components: {
+            DxDrawer,
+            DxToolbar,
+            DxItem,
+            NavigationList
+        },
+        data() {
+            return {
+                text,
+                buttonOptions: {
+                    icon: "menu",
+                    onClick: () => {
+                        this.isDrawerOpened = !this.isDrawerOpened;
+                    }
+                },
+                isDrawerOpened: false
+            };
+        }
+    };
+    </script>
+
+    <style>
+    /* ... */
+    .dx-list-item-icon {
+        margin-right: 10px;
+    }
+    </style>
+
+    <!-- tab: NavigationList.vue -->
+    <template>
+        <div style="width: 200px">
+            <DxList
+                width="200"
+                selection-mode="single"
+                :data-source="navigation"
+                @selection-changed="loadView($event)"
+            />
+        </div>
+    </template>
+    <script>
+    import { DxList } from "devextreme-vue/list";
+
+    export default {
+        components: {
+            DxList
+        },
+        data() {
+            const navigation = [
+                { id: 1, text: "Inbox", icon: "message", filePath: "inbox" },
+                { id: 2, text: "Sent Mail", icon: "check", filePath: "sent-mail" },
+                { id: 3, text: "Trash", icon: "trash", filePath: "trash" },
+                { id: 4, text: "Spam", icon: "mention", filePath: "spam" }
+            ];
+            return {
+                navigation
+            };
+        },
+        methods: {
+            loadView(e) {
+                this.$router.push(e.addedItems[0].filePath);
+            }
+        }
+    };
+    </script>
+
+    <!-- tab: Inbox.vue -->
+    <template>
+    <div>Inbox</div>
+    </template>
+
+    <script>
+    export default {};
+    </script>
+
+    <!-- tab: SentMail.vue -->
+    <template>
+    <div>Sent mail</div>
+    </template>
+
+    <script>
+    export default {};
+    </script>
+
+    <!-- tab: Spam.vue -->
+    <template>
+    <div>Spam</div>
+    </template>
+
+    <script>
+    export default {}
+    </script>
+
+    <!-- tab: Trash.vue -->
+    <template>
+    <div>Trash</div>
+    </template>
+
+    <script>
+    export default {}
+    </script>
+
 ---
 
 Run the code, open the **Drawer**, and click its items to change the views.

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/15 Implement Navigation.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/15 Implement Navigation.md
@@ -489,7 +489,7 @@ In this tutorial, we use the **List**:
 
     <!-- tab: Inbox.vue -->
     <template>
-    <div>Inbox</div>
+        <div>Inbox</div>
     </template>
 
     <script>
@@ -498,7 +498,7 @@ In this tutorial, we use the **List**:
 
     <!-- tab: SentMail.vue -->
     <template>
-    <div>Sent mail</div>
+        <div>Sent mail</div>
     </template>
 
     <script>
@@ -507,7 +507,7 @@ In this tutorial, we use the **List**:
 
     <!-- tab: Spam.vue -->
     <template>
-    <div>Spam</div>
+        <div>Spam</div>
     </template>
 
     <script>
@@ -516,7 +516,7 @@ In this tutorial, we use the **List**:
 
     <!-- tab: Trash.vue -->
     <template>
-    <div>Trash</div>
+        <div>Trash</div>
     </template>
 
     <script>

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/20 Configure the Reveal Behavior.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/20 Configure the Reveal Behavior.md
@@ -44,6 +44,17 @@ When you open the **Drawer**, it can slide in or expand from the closed position
     }
     export default DxComponent;
 
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <div>
+            <DxDrawer ...
+                reveal-mode="expand" >
+            </DxDrawer>
+        </div>
+    </template>
+
 ---
 
 Run the code and open the **Drawer**. You should see that the widget gets wider, but its content stays in place, creating an impression that the **Drawer** expands. 

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/20 Configure the Reveal Behavior.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/20 Configure the Reveal Behavior.md
@@ -50,8 +50,8 @@ When you open the **Drawer**, it can slide in or expand from the closed position
     <template>
         <div>
             <DxDrawer ...
-                reveal-mode="expand" >
-            </DxDrawer>
+                reveal-mode="expand"
+            />
         </div>
     </template>
 

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/30 Configure Interaction with the View.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/30 Configure Interaction with the View.md
@@ -46,7 +46,7 @@ When the **Drawer** opens, it can overlap, shrink, or partially displace the vie
 
 ##### Vue
 
-    <!-- tab: DxComponent.js -->
+    <!-- tab: App.vue -->
     <template>
     <div>
         <DxDrawer ...

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/30 Configure Interaction with the View.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/30 Configure Interaction with the View.md
@@ -44,6 +44,17 @@ When the **Drawer** opens, it can overlap, shrink, or partially displace the vie
     }
     export default DxComponent;
 
+##### Vue
+
+    <!-- tab: DxComponent.js -->
+    <template>
+    <div>
+        <DxDrawer ...
+            opened-state-mode="overlap" >
+        </DxDrawer>
+    </div>
+    </template>
+
 ---
 
 Run the code, open the **Drawer** and you should see that it overlaps the view's text.

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/30 Configure Interaction with the View.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/30 Configure Interaction with the View.md
@@ -48,11 +48,11 @@ When the **Drawer** opens, it can overlap, shrink, or partially displace the vie
 
     <!-- tab: App.vue -->
     <template>
-    <div>
-        <DxDrawer ...
-            opened-state-mode="overlap" >
-        </DxDrawer>
-    </div>
+        <div>
+            <DxDrawer ...
+                opened-state-mode="overlap"
+            />
+        </div>
     </template>
 
 ---

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/Getting Started with Navigation Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/Getting Started with Navigation Drawer.md
@@ -703,14 +703,12 @@ Refer to the subtopics for details on every configuration step. You can also see
 
     <!-- tab: NavigationList.vue -->
     <template>
-        <div style="width: 200px">
-            <DxList
-                width="200"
-                selection-mode="single"
-                :data-source="navigation"
-                @selection-changed="loadView($event)"
-            />
-        </div>
+        <DxList
+            :width="200"
+            selection-mode="single"
+            :data-source="navigation"
+            @selection-changed="loadView($event)"
+        />
     </template>
     <script>
     import { DxList } from "devextreme-vue/list";

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/Getting Started with Navigation Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/Getting Started with Navigation Drawer.md
@@ -591,4 +591,187 @@ Refer to the subtopics for details on every configuration step. You can also see
     }
     export default Trash;
 
+##### Vue
+
+    <!-- tab: index.js -->
+    import Vue from "vue";
+    import VueRouter from "vue-router";
+    import App from "./App.vue";
+    import InboxComponent from "./inbox.vue";
+    import SentMailComponent from "./sent-mail.vue";
+    import TrashComponent from "./trash.vue";
+    import SpamComponent from "./spam.vue";
+
+    Vue.use(VueRouter);
+
+    const routes = [
+        { path: "", redirect: "/inbox" },
+        { path: "/inbox", component: InboxComponent },
+        { path: "/sent-mail", component: SentMailComponent },
+        { path: "/trash", component: TrashComponent },
+        { path: "/spam", component: SpamComponent }
+    ];
+
+    const router = new VueRouter({
+        mode: "history",
+        routes
+    });
+
+    new Vue({
+        el: "#app",
+        components: { App },
+        template: "<App/>",
+        router
+    });
+
+    <!-- tab: App.vue -->
+    <template>
+        <div>
+            <DxToolbar id="toolbar">
+                <DxItem :options="buttonOptions" location="before" widget="dxButton"/>
+            </DxToolbar>
+            <DxDrawer
+                opened-state-mode="overlap"
+                reveal-mode="expand"
+                :opened.sync="isDrawerOpened"
+                minSize="37"
+                height="250"
+                template="listMenu" >
+
+                <template #listMenu>
+                    <NavigationList/>
+                </template>
+                <div id="view">
+                    <router-view></router-view>
+                </div>
+            </DxDrawer>
+        </div>
+    </template>
+
+    <script>
+    import { DxDrawer } from "devextreme-vue";
+    import DxToolbar, { DxItem } from "devextreme-vue/toolbar";
+    import NavigationList from "./NavigationList.vue";
+    import { text } from "./data.js";
+
+    export default {
+        components: {
+            DxDrawer,
+            DxToolbar,
+            DxItem,
+            NavigationList
+        },
+        data() {
+            return {
+                text,
+                buttonOptions: {
+                    icon: "menu",
+                    onClick: () => {
+                        this.isDrawerOpened = !this.isDrawerOpened;
+                    }
+                },
+                isDrawerOpened: false
+            };
+        }
+    };
+    </script>
+
+    <style>
+    .dx-drawer-panel-content,
+    .dx-overlay-content {
+        background-color: lightgray;
+    }
+    #toolbar {
+        background-color: rgba(191, 191, 191, 0.15);
+        padding: 5px 10px;
+    }
+    .dx-toolbar-button .dx-button {
+        background-color: rgba(191, 191, 191, -0.15);
+        border: none;
+    }
+    .dx-toolbar-button > .dx-toolbar-item-content {
+        margin-left: -7px;
+    }
+    .dx-list-item-icon {
+        margin-right: 10px;
+    }
+    #view {
+        margin-left: 10px;
+        margin-top: 10px;
+    }
+    </style>
+
+    <!-- tab: NavigationList.vue -->
+    <template>
+        <div style="width: 200px">
+            <DxList
+                width="200"
+                selection-mode="single"
+                :data-source="navigation"
+                @selection-changed="loadView($event)"
+            />
+        </div>
+    </template>
+    <script>
+    import { DxList } from "devextreme-vue/list";
+
+    export default {
+        components: {
+            DxList
+        },
+        data() {
+            const navigation = [
+                { id: 1, text: "Inbox", icon: "message", filePath: "inbox" },
+                { id: 2, text: "Sent Mail", icon: "check", filePath: "sent-mail" },
+                { id: 3, text: "Trash", icon: "trash", filePath: "trash" },
+                { id: 4, text: "Spam", icon: "mention", filePath: "spam" }
+            ];
+            return {
+                navigation
+            };
+        },
+        methods: {
+            loadView(e) {
+                this.$router.push(e.addedItems[0].filePath);
+            }
+        }
+    };
+    </script>
+
+    <!-- tab: Inbox.vue -->
+    <template>
+    <div>Inbox</div>
+    </template>
+
+    <script>
+    export default {};
+    </script>
+
+    <!-- tab: SentMail.vue -->
+    <template>
+    <div>Sent mail</div>
+    </template>
+
+    <script>
+    export default {};
+    </script>
+
+    <!-- tab: Spam.vue -->
+    <template>
+    <div>Spam</div>
+    </template>
+
+    <script>
+    export default {}
+    </script>
+
+    <!-- tab: Trash.vue -->
+    <template>
+    <div>Trash</div>
+    </template>
+
+    <script>
+    export default {}
+    </script>
+
 ---

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/Getting Started with Navigation Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/Getting Started with Navigation Drawer.md
@@ -634,8 +634,8 @@ Refer to the subtopics for details on every configuration step. You can also see
                 opened-state-mode="overlap"
                 reveal-mode="expand"
                 :opened.sync="isDrawerOpened"
-                minSize="37"
-                height="250"
+                :minSize="37"
+                :height="250"
                 template="listMenu" >
 
                 <template #listMenu>

--- a/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/Getting Started with Navigation Drawer.md
+++ b/concepts/05 Widgets/Drawer/Getting Started with Navigation Drawer/Getting Started with Navigation Drawer.md
@@ -740,7 +740,7 @@ Refer to the subtopics for details on every configuration step. You can also see
 
     <!-- tab: Inbox.vue -->
     <template>
-    <div>Inbox</div>
+        <div>Inbox</div>
     </template>
 
     <script>
@@ -749,7 +749,7 @@ Refer to the subtopics for details on every configuration step. You can also see
 
     <!-- tab: SentMail.vue -->
     <template>
-    <div>Sent mail</div>
+        <div>Sent mail</div>
     </template>
 
     <script>
@@ -758,7 +758,7 @@ Refer to the subtopics for details on every configuration step. You can also see
 
     <!-- tab: Spam.vue -->
     <template>
-    <div>Spam</div>
+        <div>Spam</div>
     </template>
 
     <script>
@@ -767,7 +767,7 @@ Refer to the subtopics for details on every configuration step. You can also see
 
     <!-- tab: Trash.vue -->
     <template>
-    <div>Trash</div>
+        <div>Trash</div>
     </template>
 
     <script>


### PR DESCRIPTION
See these snippets applications in action:

- Getting started 
  - jQuery - https://codesandbox.io/s/dxdrawer-jquery-with-router-82dkm
  - Angular - https://codesandbox.io/s/dxdrawer-angular-router-3hzmd
  - React - https://codesandbox.io/s/dxdrawer-reactrouter-ugedo
  - Vue - https://codesandbox.io/s/dxdrawer-with-vuerouter-2syjp
 - Create the Drawer (Vue) - https://codesandbox.io/s/dxdrawer-create-drawer-sy1fh
 - Open and Close the Drawer (Vue) - https://codesandbox.io/s/dxdrawer-createdrawer-lw8bk
 - Implement Navigation (Vue) - https://codesandbox.io/s/dxdrawer-with-vuerouter-2syjp
 - Configure the Reveal Behavior (Vue) - https://codesandbox.io/s/dxdrawer-createdrawer-lw8bk
 - Configure Interaction with the View (Vue) - https://codesandbox.io/s/dxdrawer-openedstatemode-6o7u1