### PR TITLE
CherryPick - DataGrid and TreeList: Add React and Vue snippets for onToolbarPreparing (#423)

### DIFF
--- a/api-reference/10 UI Widgets/GridBase/1 Configuration/onToolbarPreparing.md
+++ b/api-reference/10 UI Widgets/GridBase/1 Configuration/onToolbarPreparing.md
@@ -47,11 +47,11 @@ The following code shows how you can customize the toolbar using this function.
             onToolbarPreparing: function (e) {
                 var toolbarItems = e.toolbarOptions.items;
                 // Modifies an existing item
-                $.each(toolbarItems, function(_, item) {
-                    if(item.name === "saveButton") {
+                toolbarItems.forEach(function(item) {
+                    if (item.name === "saveButton") {
                         // Change the item options here
                     }
-                }); 
+                });
 
                 // Adds a new item
                 toolbarItems.push({
@@ -99,7 +99,95 @@ The following code shows how you can customize the toolbar using this function.
     <dx-data-grid ...
         (onToolbarPreparing)="onToolbarPreparing($event)">
     </dx-data-grid>
-    
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxDataGrid ...
+            @toolbar-preparing="onToolbarPreparing"
+        />
+    </template>
+
+    <script>
+    import 'devextreme/dist/css/dx.common.css';
+    import 'devextreme/dist/css/dx.light.css';
+
+    import { DxDataGrid } from 'devextreme-vue/data-grid';
+
+    export default {
+        components: {
+            DxDataGrid
+        },
+        methods: {
+            onToolbarPreparing(e) {
+                let toolbarItems = e.toolbarOptions.items;
+                // Modifies an existing item
+                toolbarItems.forEach(function(item) {
+                    if (item.name === "saveButton") {
+                        // Change the item options here
+                    }
+                });
+
+                // Adds a new item
+                toolbarItems.push({
+                    widget: 'dxButton',
+                    options: {
+                        icon: 'user',
+                        onClick: function() {
+                            // ...
+                        }
+                    },
+                    location: 'after'
+                });
+            }
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import 'devextreme/dist/css/dx.common.css';
+    import 'devextreme/dist/css/dx.light.css';
+
+    import DataGrid from 'devextreme-react/data-grid';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <DataGrid ...
+                    onToolbarPreparing={this.onToolbarPreparing}
+                />
+            );
+        }
+
+        onToolbarPreparing(e) {
+            let toolbarItems = e.toolbarOptions.items;
+            // Modifies an existing item
+            toolbarItems.forEach(function(item) {
+                if (item.name === "saveButton") {
+                    // Change the item options here
+                }
+            });
+
+            // Adds a new item
+            toolbarItems.push({
+                widget: 'dxButton',
+                options: {
+                    icon: 'user',
+                    onClick: function() {
+                        // ...
+                    }
+                },
+                location: 'after'
+            });
+        }
+    }
+    export default App;
+
 ---
 
 #include common-demobutton with {

--- a/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onToolbarPreparing.md
+++ b/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onToolbarPreparing.md
@@ -24,7 +24,7 @@ The following code shows how you can customize the toolbar using this function.
                     if (item.name === "saveButton") {
                         // Change the item options here
                     }
-                });
+                }); 
 
                 // Adds a new item
                 toolbarItems.push({
@@ -72,5 +72,93 @@ The following code shows how you can customize the toolbar using this function.
     <dx-tree-list ...
         (onToolbarPreparing)="onToolbarPreparing($event)">
     </dx-tree-list>
-    
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxTreeList ...
+            @toolbar-preparing="onToolbarPreparing"
+        />
+    </template>
+
+    <script>
+    import 'devextreme/dist/css/dx.common.css';
+    import 'devextreme/dist/css/dx.light.css';
+
+    import { DxTreeList } from 'devextreme-vue/tree-list';
+
+    export default {
+        components: {
+            DxTreeList
+        },
+        methods: {
+            onToolbarPreparing(e) {
+                let toolbarItems = e.toolbarOptions.items;
+                // Modifies an existing item
+                toolbarItems.forEach(function(item) {
+                    if (item.name === "saveButton") {
+                        // Change the item options here
+                    }
+                });
+
+                // Adds a new item
+                toolbarItems.push({
+                    widget: 'dxButton',
+                    options: {
+                        icon: 'user',
+                        onClick: function() {
+                            // ...
+                        }
+                    },
+                    location: 'after'
+                });
+            }
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import 'devextreme/dist/css/dx.common.css';
+    import 'devextreme/dist/css/dx.light.css';
+
+    import TreeList from 'devextreme-react/tree-list';
+
+    class App extends React.Component {
+        render() {
+            return (
+                <TreeList ...
+                    onToolbarPreparing={this.onToolbarPreparing}
+                />
+            );
+        }
+
+        onToolbarPreparing(e) {
+            let toolbarItems = e.toolbarOptions.items;
+            // Modifies an existing item
+            toolbarItems.forEach(function(item) {
+                if (item.name === "saveButton") {
+                    // Change the item options here
+                }
+            });
+
+            // Adds a new item
+            toolbarItems.push({
+                widget: 'dxButton',
+                options: {
+                    icon: 'user',
+                    onClick: function() {
+                        // ...
+                    }
+                },
+                location: 'after'
+            });
+        }
+    }
+    export default App;
+
 ---


### PR DESCRIPTION
* DataGrid and TreeList: Add React and Vue snippets for onToolbarPreparing

* Fix React and Vue snuppets in onToolbarPrepared

* Fix jQuery snippet

* Small fix onToolbarPreparing

* Add proposed fixes

* Remove unnecessary imports in onToolbarPreparing

* Update api-reference/10 UI Widgets/dxTreeList/1 Configuration/onToolbarPreparing.md

Co-Authored-By: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>
(cherry picked from commit a618a25b81e0d052941bdb14cb59c10d54cddb71)