### PR TITLE
Fix T863090: Add a link to Selection to DataGrid.getSelectedRowKeys (…

### DIFF
--- a/api-reference/10 UI Widgets/dxDataGrid/3 Methods/getSelectedRowKeys().md
+++ b/api-reference/10 UI Widgets/dxDataGrid/3 Methods/getSelectedRowKeys().md
@@ -14,4 +14,5 @@ The whole data object is considered a key if the field providing keys is not spe
 Note that when selection is [deferred](/api-reference/10%20UI%20Widgets/dxDataGrid/1%20Configuration/selection/deferred.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/selection/#deferred'), the method returns a Promise (a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise" target="_blank">native Promise</a> or a <a href="http://api.jquery.com/Types/#Promise" target="_blank">jQuery.Promise</a> when you use jQuery) that should be resolved with an array of keys.
 
 #####See Also#####
+- [Initial and Runtime Selection](/concepts/05%20Widgets/DataGrid/50%20Selection/20%20API/1%20Initial%20and%20Runtime%20Selection.md '/Documentation/Guide/Widgets/DataGrid/Selection/#API/Initial_and_Runtime_Selection')
 #include common-link-callmethods


### PR DESCRIPTION
…#505)

(cherry picked from commit 4310d0bbd25114586274c1f39e54fd4e479e2a64)