### PR TITLE
Fix T865352 - calculateFilterExpression - Incorrect return statement in Angular (#509)

### DIFF
--- a/api-reference/_hidden/GridBaseColumn/calculateCellValue.md
+++ b/api-reference/_hidden/GridBaseColumn/calculateCellValue.md
@@ -269,7 +269,7 @@ The following features are disabled in an unbound column, but you can enable the
     </table>
 </div>
 
-To invoke the default behavior, call the **this.defaultCalculateCellValue(rowData)** function and return its result.
+To invoke the default behavior, call the **defaultCalculateCellValue** function and return its result.
 
 ---
 ##### jQuery
@@ -299,7 +299,7 @@ To invoke the default behavior, call the **this.defaultCalculateCellValue(rowDat
     export class AppComponent {
         calculateCellValue(rowData) {
             // ...
-            let column = this as any;
+            const column = this as any;
             return column.defaultCalculateCellValue(rowData);
         }
     }
@@ -329,7 +329,7 @@ To invoke the default behavior, call the **this.defaultCalculateCellValue(rowDat
         methods: {
             calculateCellValue(rowData) {
                 // ...
-                let column = this as any;
+                const column = this as any;
                 return column.defaultCalculateCellValue(rowData);
             }
         }
@@ -343,7 +343,7 @@ To invoke the default behavior, call the **this.defaultCalculateCellValue(rowDat
     class App extends React.Component {
         calculateCellValue(rowData) {
             // ...
-            let column = this as any;
+            const column = this as any;
             return column.defaultCalculateCellValue(rowData);
         }
 

--- a/api-reference/_hidden/GridBaseColumn/calculateFilterExpression.md
+++ b/api-reference/_hidden/GridBaseColumn/calculateFilterExpression.md
@@ -79,7 +79,7 @@ In the following code, the **calculateFilterExpression** function implements an 
                 return filterExpression;
             }
             // Invokes the default filtering behavior
-            return column.defaultCalculateFilterExpression(arguments);
+            return column.defaultCalculateFilterExpression.apply(column, arguments);
         }
     }
     @NgModule({

--- a/api-reference/_hidden/dxFilterBuilderField/calculateFilterExpression.md
+++ b/api-reference/_hidden/dxFilterBuilderField/calculateFilterExpression.md
@@ -75,7 +75,7 @@ In the following code, the **calculateFilterExpression** function implements an 
                 return filterExpression;
             }
             // Invokes the default filtering behavior
-            return field.defaultCalculateFilterExpression(arguments);
+            return field.defaultCalculateFilterExpression.apply(field, arguments);
         }
     }
     @NgModule({


### PR DESCRIPTION

* Fix T865352 - calculateFilterExpression - Incorrect return statement in Angular

* .apply is needed only with "arguments"

(cherry picked from commit 6da6d8255e654192bf98831d0bfacb6cacf44097)