### PR TITLE
Fix T861260: editing.popup forbids to specify options that actually c…

### DIFF
--- a/api-reference/10 UI Widgets/GridBase/1 Configuration/editing/popup.md
+++ b/api-reference/10 UI Widgets/GridBase/1 Configuration/editing/popup.md
@@ -7,7 +7,7 @@ type: dxPopup_Options
 Configures the popup. Used only if **editing**.[mode](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/editing/mode.md '{basewidgetpath}/Configuration/editing/#mode') is *"popup"*.
 
 ---
-You can specify most of the [Popup options](/api-reference/10%20UI%20Widgets/dxPopup/1%20Configuration '/Documentation/ApiReference/UI_Widgets/dxPopup/Configuration/') in this object except those listed below. The **{WidgetName}** overrides these options.
+You can specify any [Popup option](/api-reference/10%20UI%20Widgets/dxPopup/1%20Configuration '/Documentation/ApiReference/UI_Widgets/dxPopup/Configuration/') in this object, but note that the following options override the **{WidgetName}**'s internal logic:
 
 - [contentTemplate](/api-reference/10%20UI%20Widgets/dxOverlay/1%20Configuration/contentTemplate.md '/Documentation/ApiReference/UI_Widgets/dxPopup/Configuration/#contentTemplate')
 - [fullScreen](/api-reference/10%20UI%20Widgets/dxPopup/1%20Configuration/fullScreen.md '/Documentation/ApiReference/UI_Widgets/dxPopup/Configuration/#fullScreen')


### PR DESCRIPTION
…an be specified (#522)

* Fix T861260: editing.popup forbids to specify options that actually can be specified

* Update api-reference/10 UI Widgets/GridBase/1 Configuration/editing/popup.md

Co-Authored-By: arminal <arminal@devexpress.com>

Co-authored-by: arminal <arminal@devexpress.com>
(cherry picked from commit 81f8271002441f77d83da0facd8a87af083a706a)