### PR TITLE
FileManager - fix descriptions for "download"-related members

### DIFF
--- a/api-reference/10 UI Widgets/dxFileManager/1 Configuration/permissions/download.md
+++ b/api-reference/10 UI Widgets/dxFileManager/1 Configuration/permissions/download.md
@@ -5,6 +5,6 @@ default: false
 ---
 ---
 ##### shortDescription
-Specifies whether a user is allowed to download files and folders.
+Specifies whether a user is allowed to download files.
 
 ---

--- a/api-reference/10 UI Widgets/dxFileManager/5 File System Providers/Custom/1 Configuration/downloadItems.md
+++ b/api-reference/10 UI Widgets/dxFileManager/5 File System Providers/Custom/1 Configuration/downloadItems.md
@@ -4,7 +4,7 @@ type: function(items)
 ---
 ---
 ##### shortDescription
-A function that downloads a file or folder.
+A function that downloads files.
 
 ##### param(items): Array<FileSystemItem>
 The file system items.


### PR DESCRIPTION
Currently, FileManager does not allow folder downloading. I updated documentation articles accordingly.