### PR TITLE
Clarify how shading in popover works (#730)

### DIFF
--- a/api-reference/10 UI Widgets/dxPopover/1 Configuration/container.md
+++ b/api-reference/10 UI Widgets/dxPopover/1 Configuration/container.md
@@ -1,0 +1,1 @@
+The container is defined during the widget's initialization. The container by default is the viewport. If the viewport is not found, it is the body element. If the viewport and the body element are absent, the **container** is the parent element.

--- a/api-reference/10 UI Widgets/dxPopover/1 Configuration/position.md
+++ b/api-reference/10 UI Widgets/dxPopover/1 Configuration/position.md
@@ -9,11 +9,11 @@ default: 'bottom'
 An object defining widget [positioning options](/api-reference/50%20Common/Object%20Structures/positionConfig '/Documentation/ApiReference/Common/Object_Structures/positionConfig/').
 
 ---
+You can use the **position**.[of](/api-reference/50%20Common/Object%20Structures/positionConfig/of.md '/Documentation/ApiReference/Common/Object_Structures/positionConfig/#of') option and the **Popover**'s [target](/Documentation/ApiReference/UI_Widgets/dxPopover/Configuration/#target) option to specify the element against which the widget will be positioned. If you set both these options, **position**.**of** takes precedence.
+
 Besides the position configuration object, the option can take on the following string values, which are shortcuts for the corresponding position configuration.
 
 - "top" - places the popover over the target element
 - "bottom" - places the popover under the target element
 - "left" - places the popover to the left of the target element
 - "right" - places the popover to the right of the target element
-
-[note]To specify the element against which the widget will be positioned, use the [target](/api-reference/10%20UI%20Widgets/dxPopover/1%20Configuration/target.md '{basewidgetpath}/Configuration/#target') option instead of the [of](/api-reference/50%20Common/Object%20Structures/positionConfig/of.md '/Documentation/ApiReference/Common/Object_Structures/positionConfig/#of') field of the **position** object. If both **target** and **of** are specified, **target** will be used.

--- a/api-reference/10 UI Widgets/dxPopover/1 Configuration/shading.md
+++ b/api-reference/10 UI Widgets/dxPopover/1 Configuration/shading.md
@@ -3,3 +3,4 @@ id: dxPopover.Options.shading
 type: Boolean
 default: false
 ---
+Shading is applied to the first element with a <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/position" target="_blank">position</a> value different from `static`. The sequence is the following: [container](/Documentation/ApiReference/UI_Widgets/dxPopover/Configuration/#container) => parent elements => **window**.


### PR DESCRIPTION
* Remove mentions of container from the popover.shading description

* Address Roman's comment

* Update api-reference/10 UI Widgets/dxPopover/1 Configuration/shading.md

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

* Describe shading and positioning features

* Fix typos

* Address Anton's comment

* Update api-reference/10 UI Widgets/dxPopover/1 Configuration/container.md

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

* Address Roman's comments

* Address Armina's comment

* Add the missing article

* Address Armina's comments

* Restore the missing sentence

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>
Co-authored-by: Alexander Yakovlev <alexander.yakovlev@devexpress.com>
(cherry picked from commit 6bf2b1469bead20b0f87da0f6cff8116d97e65e2)