### PR TITLE
Adding a note related to difference about data handling (with pagination) between postProcess and CustomStore.load

### DIFF
--- a/api-reference/30 Data Layer/DataSource/1 Configuration/postProcess.md
+++ b/api-reference/30 Data Layer/DataSource/1 Configuration/postProcess.md
@@ -13,7 +13,7 @@ Data loaded in the **DataSource**.
 Data after processing.
 
 ---
-When the [paginate](/Documentation/ApiReference/Data_Layer/DataSource/Configuration/#paginate) option is enabled, the **postProcess** function handles only the data available for the selected page. If you need to access all data, process the data before it is passed to the store.
+When the [paginate](/Documentation/ApiReference/Data_Layer/DataSource/Configuration/#paginate) option is enabled, the **postProcess** function handles only data available for the selected page. If you need to access all data, process data before it is passed to the store.
 
 ---
 ##### jQuery

--- a/api-reference/30 Data Layer/DataSource/1 Configuration/postProcess.md
+++ b/api-reference/30 Data Layer/DataSource/1 Configuration/postProcess.md
@@ -4,7 +4,9 @@ type: function(data)
 ---
 ---
 ##### shortDescription
-Specifies a post processing function.
+Specifies a post processing function. 
+
+Important note: When using together with pagination, **postProcess** handles the data available in current page of pagination. In order to handle all the data from origin/source, may be a better choice use the [**CustomStore.load**](/api-reference/30%20Data%20Layer/CustomStore/1%20Configuration/load.md '/Documentation/ApiReference/Data_Layer/CustomStore/Configuration/#load') function.
 
 ##### param(data): Array<any>
 The data loaded in the **DataSource**.

--- a/api-reference/30 Data Layer/DataSource/1 Configuration/postProcess.md
+++ b/api-reference/30 Data Layer/DataSource/1 Configuration/postProcess.md
@@ -7,7 +7,7 @@ type: function(data)
 Specifies a post processing function. 
 
 ##### param(data): Array<any>
-The data loaded in the **DataSource**.
+Data loaded in the **DataSource**.
 
 ##### return: Array<any>
 Data after processing.

--- a/api-reference/30 Data Layer/DataSource/1 Configuration/postProcess.md
+++ b/api-reference/30 Data Layer/DataSource/1 Configuration/postProcess.md
@@ -10,7 +10,7 @@ Specifies a post processing function.
 The data loaded in the **DataSource**.
 
 ##### return: Array<any>
-The data after processing.
+Data after processing.
 
 ---
 When the [paginate](/Documentation/ApiReference/Data_Layer/DataSource/Configuration/#paginate) option is enabled, the **postProcess** function handles only the data available for the selected page. If you need to access all data, process the data before it is passed to the store.

--- a/api-reference/30 Data Layer/DataSource/1 Configuration/postProcess.md
+++ b/api-reference/30 Data Layer/DataSource/1 Configuration/postProcess.md
@@ -6,8 +6,6 @@ type: function(data)
 ##### shortDescription
 Specifies a post processing function. 
 
-Important note: When using together with pagination, **postProcess** handles the data available in current page of pagination. In order to handle all the data from origin/source, may be a better choice to use the [**CustomStore.load**](/api-reference/30%20Data%20Layer/CustomStore/1%20Configuration/load.md '/Documentation/ApiReference/Data_Layer/CustomStore/Configuration/#load') function.
-
 ##### param(data): Array<any>
 The data loaded in the **DataSource**.
 
@@ -15,6 +13,8 @@ The data loaded in the **DataSource**.
 The data after processing.
 
 ---
+When the [paginate](/Documentation/ApiReference/Data_Layer/DataSource/Configuration/#paginate) option is enabled, the **postProcess** function handles only the data available for the selected page. If you need to access all data, process the data before it is passed to the store.
+
 ---
 ##### jQuery
 

--- a/api-reference/30 Data Layer/DataSource/1 Configuration/postProcess.md
+++ b/api-reference/30 Data Layer/DataSource/1 Configuration/postProcess.md
@@ -6,7 +6,7 @@ type: function(data)
 ##### shortDescription
 Specifies a post processing function. 
 
-Important note: When using together with pagination, **postProcess** handles the data available in current page of pagination. In order to handle all the data from origin/source, may be a better choice use the [**CustomStore.load**](/api-reference/30%20Data%20Layer/CustomStore/1%20Configuration/load.md '/Documentation/ApiReference/Data_Layer/CustomStore/Configuration/#load') function.
+Important note: When using together with pagination, **postProcess** handles the data available in current page of pagination. In order to handle all the data from origin/source, may be a better choice to use the [**CustomStore.load**](/api-reference/30%20Data%20Layer/CustomStore/1%20Configuration/load.md '/Documentation/ApiReference/Data_Layer/CustomStore/Configuration/#load') function.
 
 ##### param(data): Array<any>
 The data loaded in the **DataSource**.


### PR DESCRIPTION
Adding a note related to difference about data handling (with pagination) between postProcess and CustomStore.load

URL for reference: https://supportcenter.devexpress.com/ticket/details/t892443/datagrid-how-to-remove-duplicated-items-if-paging-is-enabled