### PR TITLE
Fix the argumentAxis.categories description (T890311) (#847)

### DIFF
--- a/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/argumentAxis/categories.md
+++ b/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/argumentAxis/categories.md
@@ -4,57 +4,76 @@ type: Array<Number, String, Date>
 ---
 ---
 ##### shortDescription
-Specifies the order of categories on an axis of the *"discrete"* [type](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1%20Configuration/argumentAxis/type.md '/Documentation/ApiReference/Data_Visualization_Widgets/dxChart/Configuration/argumentAxis/#type').
+Specifies the order of categories on an axis of the *"discrete"* [type](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1%20Configuration/argumentAxis/type.md '/Documentation/ApiReference/Data_Visualization_Widgets/dx{WidgetName}/Configuration/argumentAxis/#type').
 
 ---
-By default, arguments on a discrete axis keep the order of objects in the data source. For example, objects in the following data source are sorted by decreasing **area** value. The resulting arguments will be sorted the same way.
-
-    <!--JavaScript-->var continentsByArea = [
-        { continent: 'Asia', area: 43820000 },
-        { continent: 'Africa', area: 30370000 },
-        { continent: 'North America', area: 24490000 },
-        { continent: 'South America', area: 17840000 },
-        { continent: 'Antarctica', area: 13720000 },
-        { continent: 'Europe', area: 10180000 },
-        { continent: 'Australia', area: 9008500 }
-    ];
-
-To sort the arguments, for example, alphabetically, you need to assign an array of properly sorted arguments to the **categories** option.
+Arguments of the `string` type on discrete axes maintain the order of objects in the data source. Arguments of the `number` and `date` types are sorted in ascending order regardless of their order within the data source. Specify the **categories** array to set the required order of arguments. In the following example, arguments are sorted alphabetically: 
 
 ---
 ##### jQuery
 
-    <!--JavaScript-->$(function() {
-        $("#chartContainer").dxChart({
+    <!--JavaScript-->
+    $(function() {
+        $('#{widgetName}Container').dx{WidgetName}({
             // ...
+            dataSource: dataSource,
             argumentAxis: {
-                categories: [
-                    'Africa', 
-                    'Antarctica', 
-                    'Asia', 
-                    'Australia',
-                    'Europe',
-                    'North America',
-                    'South America'
-                ]
+                categories: continentNames,
+                argumentField: 'continent'
             }
         });
+
+        const dataSource = [
+            { continent: 'Asia', area: 43820000 },
+            { continent: 'Africa', area: 30370000 },
+            { continent: 'North America', area: 24490000 },
+            { continent: 'South America', area: 17840000 },
+            { continent: 'Antarctica', area: 13720000 },
+            { continent: 'Europe', area: 10180000 },
+            { continent: 'Australia', area: 9008500 }
+        ];
+
+        const continentNames = [
+            'Africa', 
+            'Antarctica', 
+            'Asia', 
+            'Australia',
+            'Europe',
+            'North America',
+            'South America'
+        ];
     });
 
 ##### Angular
 
-    <!--HTML--><dx-chart ... >
+    <!-- tab: app.component.html -->
+    <dx-{widget-name} ...
+        [dataSource]="dataSource">
         <dxo-argument-axis
-            [categories]="continents">
+            [categories]="continentNames"
+            argumentField="continent">
         </dxo-argument-axis>
-    </dx-chart>
+    </dx-{widget-name}>
 
-    <!--TypeScript-->
-    import { DxChartModule } from "devextreme-angular";
-    // ...
+    <!-- tab: app.component.ts -->
+    import { Component } from '@angular/core';
+    @Component({
+        selector: 'app-root',
+        templateUrl: './app.component.html',
+        styleUrls: ['./app.component.css']
+    })
     export class AppComponent {
-        // ...
-        continents = [
+        dataSource = [
+            { continent: 'Asia', area: 43820000 },
+            { continent: 'Africa', area: 30370000 },
+            { continent: 'North America', area: 24490000 },
+            { continent: 'South America', area: 17840000 },
+            { continent: 'Antarctica', area: 13720000 },
+            { continent: 'Europe', area: 10180000 },
+            { continent: 'Australia', area: 9008500 }
+        ];
+
+        continentNames = [
             'Africa', 
             'Antarctica', 
             'Asia', 
@@ -64,38 +83,63 @@ To sort the arguments, for example, alphabetically, you need to assign an array 
             'South America'
         ];
     }
+
+    <!-- tab: app.module.ts -->
+    import { BrowserModule } from '@angular/platform-browser';
+    import { NgModule } from '@angular/core';
+    import { AppComponent } from './app.component';
+
+    import { Dx{WidgetName}Module } from 'devextreme-angular';
+
     @NgModule({
-        imports: [
-            // ...
-            DxChartModule
+        declarations: [
+            AppComponent
         ],
-        // ...
+        imports: [
+            BrowserModule,
+            Dx{WidgetName}Module
+        ],
+        providers: [ ],
+        bootstrap: [AppComponent]
     })
+    export class AppModule { }
 
 ##### Vue
 
     <!-- tab: App.vue -->
     <template>
-        <DxChart ... >
+        <Dx{WidgetName} ... 
+            :data-source="dataSource">
             <DxArgumentAxis 
-                :categories="continents" 
+                :categories="continentNames"
+                argument-field="continent" 
             />
-        </DxChart>
+        </Dx{WidgetName}>
     </template>
 
     <script>
-    import DxChart, {
+    import Dx{WidgetName}, {
         DxArgumentAxis
-    } from 'devextreme-vue/chart'; 
+    } from 'devextreme-vue/{widget-name}'; 
 
     export default {
         components: {
-            DxChart,
+            Dx{WidgetName},
             DxArgumentAxis
         },
         data() {
             return {
-                continents: [
+                dataSource: [
+                    { continent: 'Asia', area: 43820000 },
+                    { continent: 'Africa', area: 30370000 },
+                    { continent: 'North America', area: 24490000 },
+                    { continent: 'South America', area: 17840000 },
+                    { continent: 'Antarctica', area: 13720000 },
+                    { continent: 'Europe', area: 10180000 },
+                    { continent: 'Australia', area: 9008500 }
+                ],
+                
+                continentNames: [
                     'Africa', 
                     'Antarctica', 
                     'Asia', 
@@ -114,11 +158,21 @@ To sort the arguments, for example, alphabetically, you need to assign an array 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import Chart, {
+    import {WidgetName}, {
         ArgumentAxis
-    } from 'devextreme-react/chart';
+    } from 'devextreme-react/{widget-name}';
     
-    const continents = [
+    const dataSource = [
+        { continent: 'Asia', area: 43820000 },
+        { continent: 'Africa', area: 30370000 },
+        { continent: 'North America', area: 24490000 },
+        { continent: 'South America', area: 17840000 },
+        { continent: 'Antarctica', area: 13720000 },
+        { continent: 'Europe', area: 10180000 },
+        { continent: 'Australia', area: 9008500 }
+    ];
+
+    const continentNames = [
         'Africa', 
         'Antarctica', 
         'Asia', 
@@ -131,11 +185,13 @@ To sort the arguments, for example, alphabetically, you need to assign an array 
     class App extends React.Component {
         render() {
             return (
-                <Chart ... >
+                <{WidgetName} ... 
+                    dataSource={dataSource}>
                     <ArgumentAxis
-                        categories={continents}
+                        categories={continentNames}
+                        argumentField="continent"
                     />
-                </Chart>
+                </{WidgetName}>
             );
         }
     }
@@ -143,5 +199,3 @@ To sort the arguments, for example, alphabetically, you need to assign an array 
     export default App;     
 
 ---
-
-[note]Arguments missing from the **categories** array will be added to its end automatically.

--- a/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/valueAxis/categories.md
+++ b/api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/valueAxis/categories.md
@@ -6,7 +6,197 @@ type: Array<Number, String, Date>
 ##### shortDescription
 Specifies the order of categories on an axis of the *"discrete"* [type](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1%20Configuration/valueAxis/type.md '/Documentation/ApiReference/Data_Visualization_Widgets/dxChart/Configuration/valueAxis/#type').
 
----
-By default, values on a discrete axis keep the order of objects in the data source. To change it, assign an array of properly sorted values to the **categories** option.
+--- 
 
-[note]Values missing from the **categories** array will be added to its end automatically.
+Values of the `string` type on discrete axes maintain the order of objects in the data source. Values of the `number` and `date` types are sorted in ascending order regardless of their order within the data source. Specify the **categories** array to set the required order of values. In the following example, the values are sorted alphabetically: 
+
+---
+##### jQuery
+
+    <!--JavaScript-->
+    $(function() {
+        $('#{widgetName}Container').dx{WidgetName}({
+            // ...
+            dataSource: dataSource,
+            valueAxis: {
+                categories: continentNames,
+                valueField: 'continent'
+            }
+        });
+
+        const dataSource = [
+            { continent: 'Asia', area: 43820000 },
+            { continent: 'Africa', area: 30370000 },
+            { continent: 'North America', area: 24490000 },
+            { continent: 'South America', area: 17840000 },
+            { continent: 'Antarctica', area: 13720000 },
+            { continent: 'Europe', area: 10180000 },
+            { continent: 'Australia', area: 9008500 }
+        ];
+
+        const continentNames = [
+            'Africa', 
+            'Antarctica', 
+            'Asia', 
+            'Australia',
+            'Europe',
+            'North America',
+            'South America'
+        ];
+    });
+
+##### Angular
+
+    <!-- tab: app.component.html -->
+    <dx-{widget-name} ...
+        [dataSource]="dataSource">
+        <dxo-value-axis
+            [categories]="continentNames"
+            valueField="continent">
+        </dxo-value-axis>
+    </dx-{widget-name}>
+
+    <!-- tab: app.component.ts -->
+    import { Component } from '@angular/core';
+    @Component({
+        selector: 'app-root',
+        templateUrl: './app.component.html',
+        styleUrls: ['./app.component.css']
+    })
+    export class AppComponent {
+        dataSource = [
+            { continent: 'Asia', area: 43820000 },
+            { continent: 'Africa', area: 30370000 },
+            { continent: 'North America', area: 24490000 },
+            { continent: 'South America', area: 17840000 },
+            { continent: 'Antarctica', area: 13720000 },
+            { continent: 'Europe', area: 10180000 },
+            { continent: 'Australia', area: 9008500 }
+        ];
+
+        continentNames = [
+            'Africa', 
+            'Antarctica', 
+            'Asia', 
+            'Australia',
+            'Europe',
+            'North America',
+            'South America'
+        ];
+    }
+
+    <!-- tab: app.module.ts -->
+    import { BrowserModule } from '@angular/platform-browser';
+    import { NgModule } from '@angular/core';
+    import { AppComponent } from './app.component';
+
+    import { Dx{WidgetName}Module } from 'devextreme-angular';
+
+    @NgModule({
+        declarations: [
+            AppComponent
+        ],
+        imports: [
+            BrowserModule,
+            Dx{WidgetName}Module
+        ],
+        providers: [ ],
+        bootstrap: [AppComponent]
+    })
+    export class AppModule { }
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <Dx{WidgetName} ... 
+            :data-source="dataSource">
+            <DxValueAxis 
+                :categories="continentNames"
+                value-field="continent" 
+            />
+        </Dx{WidgetName}>
+    </template>
+
+    <script>
+    import Dx{WidgetName}, {
+        DxValueAxis
+    } from 'devextreme-vue/{widget-name}'; 
+
+    export default {
+        components: {
+            Dx{WidgetName},
+            DxValueAxis
+        },
+        data() {
+            return {
+                dataSource: [
+                    { continent: 'Asia', area: 43820000 },
+                    { continent: 'Africa', area: 30370000 },
+                    { continent: 'North America', area: 24490000 },
+                    { continent: 'South America', area: 17840000 },
+                    { continent: 'Antarctica', area: 13720000 },
+                    { continent: 'Europe', area: 10180000 },
+                    { continent: 'Australia', area: 9008500 }
+                ],
+                
+                continentNames: [
+                    'Africa', 
+                    'Antarctica', 
+                    'Asia', 
+                    'Australia',
+                    'Europe',
+                    'North America',
+                    'South America'
+                ]
+            };
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+
+    import {WidgetName}, {
+        ValueAxis
+    } from 'devextreme-react/{widget-name}';
+    
+    const dataSource = [
+        { continent: 'Asia', area: 43820000 },
+        { continent: 'Africa', area: 30370000 },
+        { continent: 'North America', area: 24490000 },
+        { continent: 'South America', area: 17840000 },
+        { continent: 'Antarctica', area: 13720000 },
+        { continent: 'Europe', area: 10180000 },
+        { continent: 'Australia', area: 9008500 }
+    ];
+
+    const continentNames = [
+        'Africa', 
+        'Antarctica', 
+        'Asia', 
+        'Australia',
+        'Europe',
+        'North America',
+        'South America'
+    ];
+
+    class App extends React.Component {
+        render() {
+            return (
+                <{WidgetName} ... 
+                    dataSource={dataSource}>
+                    <ValueAxis
+                        categories={continentNames}
+                        valueField="continent"
+                    />
+                </{WidgetName}>
+            );
+        }
+    }
+
+    export default App;     
+
+---

--- a/api-reference/20 Data Visualization Widgets/dxPolarChart/1 Configuration/argumentAxis/categories.md
+++ b/api-reference/20 Data Visualization Widgets/dxPolarChart/1 Configuration/argumentAxis/categories.md
@@ -4,7 +4,9 @@ type: Array<Number, String, Date>
 ---
 ---
 ##### shortDescription
-Specifies the order in which arguments (categories) are arranged on the discrete argument axis.
+Specifies the order of categories on an axis of the *"discrete"* [type](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1%20Configuration/argumentAxis/type.md '/Documentation/ApiReference/Data_Visualization_Widgets/dxPolarChart/Configuration/argumentAxis/#type').
 
 ---
-If you specify the chart's data using a common array of objects, these objects may be displayed in a random order. If you set the chart's data for each series individually, the order in which the series are positioned in the [series](/api-reference/20%20Data%20Visualization%20Widgets/dxPolarChart/1%20Configuration/series '/Documentation/ApiReference/Data_Visualization_Widgets/dxPolarChart/Configuration/series/') array can also be random. In these instances, the resulting argument order on the discrete argument axis may not be appropriate. To specify the order of categories (arguments on a discrete argument axis), assign an array of category names to the **categories** property.
+<!-- %fullDescription% -->
+ 
+<!-- import * from 'api-reference\20 Data Visualization Widgets\dxChart\1 Configuration\argumentAxis\categories.md' -->

--- a/api-reference/20 Data Visualization Widgets/dxPolarChart/1 Configuration/valueAxis/categories.md
+++ b/api-reference/20 Data Visualization Widgets/dxPolarChart/1 Configuration/valueAxis/categories.md
@@ -4,7 +4,9 @@ type: Array<Number, String, Date>
 ---
 ---
 ##### shortDescription
-Specifies the order in which discrete values are arranged on the value axis.
+Specifies the order of categories on an axis of the *"discrete"* [type](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1%20Configuration/valueAxis/type.md '/Documentation/ApiReference/Data_Visualization_Widgets/dxPolarChart/Configuration/valueAxis/#type').
 
 ---
-If you specify the chart's data using a common array of objects, these objects may be displayed in a random order. If you set the chart's data for each series individually, the order in which the series are positioned in the [series](/api-reference/20%20Data%20Visualization%20Widgets/dxPolarChart/1%20Configuration/series '/Documentation/ApiReference/Data_Visualization_Widgets/dxPolarChart/Configuration/series/') array can also be random. In these instances, the resulting value order on the discrete value axis may not be appropriate. To specify the order of categories (values on a discrete value axis), assign an array of category names to the **categories** property.
+<!-- %fullDescription% -->
+ 
+<!-- import * from 'api-reference\20 Data Visualization Widgets\dxChart\1 Configuration\valueAxis\categories.md' -->


### PR DESCRIPTION
* Fix the argumentAxis.categories description (T890311)

* Apply Pavel's corrections

* fix typo

* Apply more review suggestions

* Shuffle continent names

* Add the second snippet

* Apply the changes to the polarchart.argumentaxis.category

* Apply Roma's review suggestions

* Apply suggestions from code review

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

* Extend the changes to the value axes in Chart and Polar chart

* Apply suggestions from the group discussion

* Address Roman's comment

* Update api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/argumentAxis/categories.md

Co-authored-by: albertov05 <49917542+albertov05@users.noreply.github.com>

* Update api-reference/20 Data Visualization Widgets/dxChart/1 Configuration/valueAxis/categories.md

Co-authored-by: albertov05 <49917542+albertov05@users.noreply.github.com>

Co-authored-by: Alexander Yakovlev <alexander.yakovlev@devexpress.com>
Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>
Co-authored-by: albertov05 <49917542+albertov05@users.noreply.github.com>
(cherry picked from commit 8096e00aae6f43a7fe2f19de3cf8ef567f7ae179)