### PR TITLE
Fix T938810: Tooltip - There is no a list of usually used events to show tooltip (#1420)

### DIFF
--- a/api-reference/10 UI Widgets/dxContextMenu/1 Configuration/showEvent/showEvent.md
+++ b/api-reference/10 UI Widgets/dxContextMenu/1 Configuration/showEvent/showEvent.md
@@ -11,4 +11,4 @@ Specifies options for displaying the widget.
 If you assign only a string that specifies event names on which the widget is shown, the widget will not apply any delay.
 
     <!--JavaScript-->
-    showEvent: "dxclick"
+    showEvent: "mouseenter"

--- a/api-reference/10 UI Widgets/dxPopover/1 Configuration/hideEvent/hideEvent.md
+++ b/api-reference/10 UI Widgets/dxPopover/1 Configuration/hideEvent/hideEvent.md
@@ -11,4 +11,4 @@ Specifies options of popover hiding.
 If you assign only a string that specifies event names on which the widget is hidden, the widget will not apply any delay.
 
     <!--JavaScript-->
-    hideEvent: "dxhoverend"
+    hideEvent: "mouseleave"

--- a/api-reference/10 UI Widgets/dxPopover/1 Configuration/showEvent/showEvent.md
+++ b/api-reference/10 UI Widgets/dxPopover/1 Configuration/showEvent/showEvent.md
@@ -11,4 +11,4 @@ Specifies options for displaying the widget.
 If you assign only a string that specifies event names on which the widget is shown, the widget will not apply any delay.
 
     <!--JavaScript-->
-    showEvent: "dxclick"
+    showEvent: "mouseenter"


### PR DESCRIPTION
(cherry picked from commit 8b59d53cf083df4ec3e6495e23e377a9ab8e8cbd)