### PR TITLE
Fix T942849: Tooltip - show() description references a nonexistent option (#1460)

### DIFF
--- a/api-reference/10 UI Widgets/dxOverlay/3 Methods/show().md
+++ b/api-reference/10 UI Widgets/dxOverlay/3 Methods/show().md
@@ -9,7 +9,5 @@ Shows the widget.
 A Promise that is resolved after the widget is shown. It is a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise" target="_blank">native Promise</a> or a <a href="http://api.jquery.com/Types/#Promise" target="_blank">jQuery.Promise</a> when you use jQuery.
 
 ---
-The widget is automatically hidden after the time specified in the [displayTime](/api-reference/10%20UI%20Widgets/dxToast/1%20Configuration/displayTime.md '{basewidgetpath}/Configuration/#displayTime') option.
-
 #####See Also#####
 #include common-link-callmethods

--- a/api-reference/10 UI Widgets/dxToast/3 Methods/Methods.md
+++ b/api-reference/10 UI Widgets/dxToast/3 Methods/Methods.md
@@ -1,0 +1,5 @@
+---
+##### shortDescription
+This section describes members used to manipulate the widget.
+
+---

--- a/api-reference/10 UI Widgets/dxToast/3 Methods/show().md
+++ b/api-reference/10 UI Widgets/dxToast/3 Methods/show().md
@@ -1,0 +1,4 @@
+The widget is automatically hidden after the time specified in the [displayTime](/api-reference/10%20UI%20Widgets/dxToast/1%20Configuration/displayTime.md '/Documentation/ApiReference/UI_Widgets/dxToast/Configuration/#displayTime') option.
+
+#####See Also#####
+#include common-link-callmethods


### PR DESCRIPTION

(cherry picked from commit 07e68153908c7689c5e5ded982869d47a6cfde0f)