### PR TITLE
Scheduler: Cherry pick 20_1: recurrenceRuleExpr - remove the line about setting the option to null

### DIFF
--- a/api-reference/10 UI Widgets/dxScheduler/1 Configuration/recurrenceRuleExpr.md
+++ b/api-reference/10 UI Widgets/dxScheduler/1 Configuration/recurrenceRuleExpr.md
@@ -8,7 +8,6 @@ default: 'recurrenceRule'
 Specifies the name of the data source item field that defines a recurrence rule for generating recurring appointments.
 
 ---
-If the option value is null, the widget does not support recurring appointments. It displays only initial appointments without generating appointment series.
 
 #####See Also#####
 - [Appointment Types](/concepts/05%20Widgets/Scheduler/030%20Appointments/015%20Appointment%20Types/030%20Recurring%20Appointments.md '/Documentation/Guide/Widgets/Scheduler/Appointments/Appointment_Types/#Recurring_Appointments')

--- a/api-reference/_hidden/dxDataGridColumn/groupCellTemplate.md
+++ b/api-reference/_hidden/dxDataGridColumn/groupCellTemplate.md
@@ -13,10 +13,10 @@ Specifies a custom template for group cells (group rows).
 The current group cell's properties.
 
 ##### field(cellInfo.column): dxDataGridColumn
-The settings of the column the cell belongs to.
+The settings of the column to which the cell belongs.
 
 ##### field(cellInfo.columnIndex): Number
-The index of the column the cell belongs to.        
+The index of the column to which the cell belongs.       
 Refer to the [Column and Row Indexes](/concepts/05%20Widgets/DataGrid/15%20Columns/12%20Column%20and%20Row%20Indexes.md '/Documentation/Guide/Widgets/DataGrid/Columns/Column_and_Row_Indexes/') topic for more information on how this index is calculated.
 
 ##### field(cellInfo.component): dxDataGrid
@@ -47,7 +47,7 @@ Contains the **grouping**.[groupContinuesMessage](/api-reference/10%20UI%20Widge
 The cell's row.
 
 ##### field(cellInfo.rowIndex): Number
-The index of the row the cell belongs to. Begins with 0 on each page. Group rows are included.      
+The index of the row to which the cell belongs. Begins with 0 on each page. Group rows are included.      
 Refer to the [Column and Row Indexes](/concepts/05%20Widgets/DataGrid/15%20Columns/12%20Column%20and%20Row%20Indexes.md '/Documentation/Guide/Widgets/DataGrid/Columns/Column_and_Row_Indexes/') topic for more information on row indexes.
 
 ##### field(cellInfo.summaryItems): Array<any>
@@ -60,6 +60,103 @@ The group cell's value with applied [format](/api-reference/_hidden/dxDataGridCo
 The group cell's value as it is specified in a data source.
 
 ---
+
+Group cells display the following data:
+
+* The caption and the value of the column by which data is grouped
+
+* [Group summary items](/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/summary/groupItems/)
+
+* [groupContinuesMessage](/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/grouping/texts/#groupContinuesMessage) and [groupContinuedMessage](/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/grouping/texts/#groupContinuedMessage) (if the group is spread across two or more pages)
+
+The following example shows how to display column value only:
+
+---
+##### jQuery
+
+    <!--JavaScript-->
+    $(function() {
+        $("#dataGridContainer").dxDataGrid({
+            // ...
+            columns: [ 
+                {
+                    dataField: "Country",
+                    groupIndex: 0,
+                    groupCellTemplate: function(element, options) {
+                        element.text(options.value);
+                    }
+                },
+            // ...
+            ]
+        });
+    });
+
+##### Angular
+    
+    <!--HTML-->
+    <dx-data-grid ... >
+        <dxi-column 
+            dataField="Country" 
+            [groupIndex]="0" 
+            groupCellTemplate="groupCellTemplate">
+        </dxi-column>
+
+        <div *dxTemplate="let data of 'groupCellTemplate'">
+            <div>{{data.value}}</div>
+        </div>
+    </dx-data-grid>
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxDataGrid ... >
+            <DxColumn
+                data-field="Country"
+                :group-index="0"
+                group-cell-template="groupCellTemplate"
+            />
+
+            <template #groupCellTemplate="{ data }">
+                <div>{{data.value}}</div>
+            </template>
+        </DxDataGrid>
+    </template>
+    <script>
+    import { DxDataGrid, DxColumn } from 'devextreme-vue/data-grid';
+
+    export default {
+        components: {
+            DxDataGrid,
+            DxColumn
+        },
+        // ...
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+    import DataGrid, { Column } from 'devextreme-react/data-grid';
+
+    const GroupCell = options => <div>{options.value}</div>;
+
+    export default function App() {
+        // ...
+        return (
+            <DataGrid ...>
+                <Column
+                    dataField="Country"
+                    defaultGroupIndex={0}
+                    groupCellRender={GroupCell}
+                />
+            </DataGrid>
+        );
+    }
+
+---
+
 The following details should be taken into account when you use a **groupCellTemplate**:
 
 - When the **DataGrid** is [exported](/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/export/), it omits customizations made in the template. However, you can recreate them in the exported file using the ExcelJS API. To do so, use the [customizeCell](/Documentation/ApiReference/Common/Object_Structures/ExportDataGridProps/#customizeCell) function.
@@ -68,3 +165,4 @@ The following details should be taken into account when you use a **groupCellTem
 
 #####See Also#####
 - [Custom Templates](/concepts/05%20Widgets/zz%20Common/30%20Templates/10%20Custom%20Templates.md '/Documentation/Guide/Widgets/Common/Templates/#Custom_Templates')
+- [calculateGroupValue](/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/columns/#calculateGroupValue)

--- a/api-reference/_hidden/dxDataGridColumn/groupCellTemplate.md
+++ b/api-reference/_hidden/dxDataGridColumn/groupCellTemplate.md
@@ -13,10 +13,10 @@ Specifies a custom template for group cells (group rows).
 The current group cell's properties.
 
 ##### field(cellInfo.column): dxDataGridColumn
-The settings of the column to which the cell belongs.
+The settings of the column the cell belongs to.
 
 ##### field(cellInfo.columnIndex): Number
-The index of the column to which the cell belongs.       
+The index of the column the cell belongs to.        
 Refer to the [Column and Row Indexes](/concepts/05%20Widgets/DataGrid/15%20Columns/12%20Column%20and%20Row%20Indexes.md '/Documentation/Guide/Widgets/DataGrid/Columns/Column_and_Row_Indexes/') topic for more information on how this index is calculated.
 
 ##### field(cellInfo.component): dxDataGrid
@@ -47,7 +47,7 @@ Contains the **grouping**.[groupContinuesMessage](/api-reference/10%20UI%20Widge
 The cell's row.
 
 ##### field(cellInfo.rowIndex): Number
-The index of the row to which the cell belongs. Begins with 0 on each page. Group rows are included.      
+The index of the row the cell belongs to. Begins with 0 on each page. Group rows are included.      
 Refer to the [Column and Row Indexes](/concepts/05%20Widgets/DataGrid/15%20Columns/12%20Column%20and%20Row%20Indexes.md '/Documentation/Guide/Widgets/DataGrid/Columns/Column_and_Row_Indexes/') topic for more information on row indexes.
 
 ##### field(cellInfo.summaryItems): Array<any>
@@ -60,103 +60,6 @@ The group cell's value with applied [format](/api-reference/_hidden/dxDataGridCo
 The group cell's value as it is specified in a data source.
 
 ---
-
-Group cells display the following data:
-
-* The caption and the value of the column by which data is grouped
-
-* [Group summary items](/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/summary/groupItems/)
-
-* [groupContinuesMessage](/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/grouping/texts/#groupContinuesMessage) and [groupContinuedMessage](/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/grouping/texts/#groupContinuedMessage) (if the group is spread across two or more pages)
-
-The following example shows how to display column value only:
-
----
-##### jQuery
-
-    <!--JavaScript-->
-    $(function() {
-        $("#dataGridContainer").dxDataGrid({
-            // ...
-            columns: [ 
-                {
-                    dataField: "Country",
-                    groupIndex: 0,
-                    groupCellTemplate: function(element, options) {
-                        element.text(options.value);
-                    }
-                },
-            // ...
-            ]
-        });
-    });
-
-##### Angular
-    
-    <!--HTML-->
-    <dx-data-grid ... >
-        <dxi-column 
-            dataField="Country" 
-            [groupIndex]="0" 
-            groupCellTemplate="groupCellTemplate">
-        </dxi-column>
-
-        <div *dxTemplate="let data of 'groupCellTemplate'">
-            <div>{{data.value}}</div>
-        </div>
-    </dx-data-grid>
-
-##### Vue
-
-    <!-- tab: App.vue -->
-    <template>
-        <DxDataGrid ... >
-            <DxColumn
-                data-field="Country"
-                :group-index="0"
-                group-cell-template="groupCellTemplate"
-            />
-
-            <template #groupCellTemplate="{ data }">
-                <div>{{data.value}}</div>
-            </template>
-        </DxDataGrid>
-    </template>
-    <script>
-    import { DxDataGrid, DxColumn } from 'devextreme-vue/data-grid';
-
-    export default {
-        components: {
-            DxDataGrid,
-            DxColumn
-        },
-        // ...
-    }
-    </script>
-
-##### React
-
-    <!-- tab: App.js -->
-    import React from 'react';
-    import DataGrid, { Column } from 'devextreme-react/data-grid';
-
-    const GroupCell = options => <div>{options.value}</div>;
-
-    export default function App() {
-        // ...
-        return (
-            <DataGrid ...>
-                <Column
-                    dataField="Country"
-                    defaultGroupIndex={0}
-                    groupCellRender={GroupCell}
-                />
-            </DataGrid>
-        );
-    }
-
----
-
 The following details should be taken into account when you use a **groupCellTemplate**:
 
 - When the **DataGrid** is [exported](/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/export/), it omits customizations made in the template. However, you can recreate them in the exported file using the ExcelJS API. To do so, use the [customizeCell](/Documentation/ApiReference/Common/Object_Structures/ExportDataGridProps/#customizeCell) function.
@@ -165,4 +68,3 @@ The following details should be taken into account when you use a **groupCellTem
 
 #####See Also#####
 - [Custom Templates](/concepts/05%20Widgets/zz%20Common/30%20Templates/10%20Custom%20Templates.md '/Documentation/Guide/Widgets/Common/Templates/#Custom_Templates')
-- [calculateGroupValue](/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/columns/#calculateGroupValue)


### PR DESCRIPTION
This feature is extra. To display the initial appointment only, users have to remove a recurrence rule from the appointment or use any other solution.
The decision to remove this line was made during a daily meeting.