### PR TITLE
 Scheduler: Cherry pick 21_1: recurrenceRuleExpr - remove the line about setting the option to null

### DIFF
--- a/api-reference/10 UI Widgets/dxScheduler/1 Configuration/recurrenceRuleExpr.md
+++ b/api-reference/10 UI Widgets/dxScheduler/1 Configuration/recurrenceRuleExpr.md
@@ -8,7 +8,6 @@ default: 'recurrenceRule'
 Specifies the name of the data source item field that defines a recurrence rule for generating recurring appointments.
 
 ---
-If the option value is null, the widget does not support recurring appointments. It displays only initial appointments without generating appointment series.
 
 #####See Also#####
 - [Appointment Types](/concepts/05%20Widgets/Scheduler/030%20Appointments/015%20Appointment%20Types/030%20Recurring%20Appointments.md '/Documentation/Guide/Widgets/Scheduler/Appointments/Appointment_Types/#Recurring_Appointments')


### PR DESCRIPTION
This feature is extra. To display the initial appointment only, users have to remove a recurrence rule from the appointment or use any other solution.
The decision to remove this line was made during a daily meeting.