### PR TITLE
Update 20 Custom Format String.md

### DIFF
--- a/concepts/Common/Value Formatting/10 Format Widget Values/20 Custom Format String.md
+++ b/concepts/Common/Value Formatting/10 Format Widget Values/20 Custom Format String.md
@@ -135,7 +135,7 @@ The following code shows how to apply LDML patterns to format numbers and dates:
         });
         $("#dateBoxContainer").dxDateBox({
             value: new Date(),
-            displayFormat: "MMM d, YYYY" // "Jun 15, 2018"
+            displayFormat: "MMM d, yyyy" // "Jun 15, 2018"
         });
     });
 
@@ -149,7 +149,7 @@ The following code shows how to apply LDML patterns to format numbers and dates:
     </dx-number-box>
     <dx-date-box
         [(value)]="dateBoxValue"
-        format="MMM d, YYYY"> <!-- "Jun 15, 2018" -->
+        format="MMM d, yyyy"> <!-- "Jun 15, 2018" -->
     </dx-date-box>
 
     <!--TypeScript-->


### PR DESCRIPTION
[“Y” is] Year (in “Week of Year” based calendars). This year designation is used in ISO year-week calendar as defined by ISO 8601 but can be used in non-Gregorian based calendar systems where week date processing is desired. May not always be the same value as a calendar year.
http://unicode.org/reports/tr35/tr35-10.html#Date_Format_Patterns
A common mistake is to use YYYY. yyyy specifies the calendar year whereas YYYY specifies the year (of “Week of Year”), used in the ISO year-week calendar. In most cases, yyyy and YYYY yield the same number, however, they may be different. Typically you should use the calendar year.