### PR TITLE
21_1 datagrid onEditingStart: add that e.column is also available in the cell editing mode

### DIFF
--- a/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onEditingStart.md
+++ b/api-reference/10 UI Widgets/dxDataGrid/1 Configuration/onEditingStart.md
@@ -14,7 +14,7 @@ Information about the event that caused the function's execution.
 Allows you to cancel row editing.
 
 ##### field(e.column): Object
-The [configuration](/api-reference/10%20UI%20Widgets/dxDataGrid/1%20Configuration/columns '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/columns/') of the column whose cell is switching to the editing state. Available in the *"batch"* [editing mode](/api-reference/10%20UI%20Widgets/dxDataGrid/1%20Configuration/editing/mode.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/editing/#mode').
+The [configuration](/api-reference/10%20UI%20Widgets/dxDataGrid/1%20Configuration/columns '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/columns/') of the column whose cell is switching to the editing state. Available in the *"cell"* and *"batch"* [editing modes](/api-reference/10%20UI%20Widgets/dxDataGrid/1%20Configuration/editing/mode.md '/Documentation/ApiReference/UI_Widgets/dxDataGrid/Configuration/editing/#mode').
 
 ##### field(e.component): {WidgetName}
 The UI component's instance.

--- a/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onEditingStart.md
+++ b/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onEditingStart.md
@@ -14,7 +14,7 @@ Information about the event that caused the function's execution.
 Allows you to cancel row editing.
 
 ##### field(e.column): Object
-The [configuration](/api-reference/10%20UI%20Widgets/dxTreeList/1%20Configuration/columns '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/columns/') of the column whose cell is switching to the editing state. Available in *"cell"* and *"batch"* [editing mode](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/editing/mode.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/editing/#mode').
+The [configuration](/api-reference/10%20UI%20Widgets/dxTreeList/1%20Configuration/columns '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/columns/') of the column whose cell is switching to the editing state. Available in *"cell"* and *"batch"* [editing modes](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/editing/mode.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/editing/#mode').
 
 ##### field(e.component): {WidgetName}
 The UI component's instance.

--- a/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onEditingStart.md
+++ b/api-reference/10 UI Widgets/dxTreeList/1 Configuration/onEditingStart.md
@@ -14,7 +14,7 @@ Information about the event that caused the function's execution.
 Allows you to cancel row editing.
 
 ##### field(e.column): Object
-The [configuration](/api-reference/10%20UI%20Widgets/dxTreeList/1%20Configuration/columns '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/columns/') of the column whose cell is switching to the editing state. Available in *"cell"* or *"batch"* [editing mode](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/editing/mode.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/editing/#mode').
+The [configuration](/api-reference/10%20UI%20Widgets/dxTreeList/1%20Configuration/columns '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/columns/') of the column whose cell is switching to the editing state. Available in *"cell"* and *"batch"* [editing mode](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/editing/mode.md '/Documentation/ApiReference/UI_Widgets/dxTreeList/Configuration/editing/#mode').
 
 ##### field(e.component): {WidgetName}
 The UI component's instance.


### PR DESCRIPTION
https://supportcenter.devexpress.com/internal/ticket/details/T964068
[Trello card](https://trello.com/c/E7TmbAhz/1596-t964068-datagrid-oneditingstart-doesnt-correctly-indicate-which-editing-modes-have-the-ecolumn-parameter)
Original PR: https://github.com/DevExpress/devextreme-documentation/pull/1690