### PR TITLE
Fix T968043 - Quill script reference should be before dx.all.js (#1802)

### DIFF
--- a/concepts/05 UI Components/HtmlEditor/00 Overview.md
+++ b/concepts/05 UI Components/HtmlEditor/00 Overview.md
@@ -131,6 +131,13 @@ Follow the steps below to add the **HtmlEditor** to a page.
 ##### ASP.NET MVC Controls
 
     <!--Razor C#-->
+    <script src="https://cdn3.devexpress.com/jslib/minor_21_1/js/dx-quill.min.js"></script>
+    // Required if valueType is "markdown"
+    // <script src="https://unpkg.com/turndown/dist/turndown.js"></script>
+    // <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.8.7/showdown.min.js"></script>
+
+    // Reference the DevExtreme sources here
+
     @(Html.DevExtreme().HtmlEditor()
         .ValueType(HtmlEditorValueType.Html) // or HtmlEditorValueType.Markdown
         .Content(@<text>
@@ -141,10 +148,6 @@ Follow the steps below to add the **HtmlEditor** to a page.
         </text>)
     )
     
-    <script src="https://cdn3.devexpress.com/jslib/minor_21_1/js/dx-quill.min.js"></script>
-    // Required if valueType is "markdown"
-    // <script src="https://unpkg.com/turndown/dist/turndown.js"></script>
-    // <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.8.7/showdown.min.js"></script>
 
 ---
 


### PR DESCRIPTION
Co-authored-by: Alexander Yakovlev <alexander.yakovlev@devexpress.com>
(cherry picked from commit e006cd831e5f7346d19e51020a4e4b1a0787de8d)