### PR TITLE
Fix T969248 - columnIndex in DataGrid onCellPrepared (#1862)

### DIFF
--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onCellPrepared.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onCellPrepared.md
@@ -18,7 +18,7 @@ Information about the event that caused the function's execution.
 This column's [configuration](/api-reference/10%20UI%20Widgets/dxDataGrid/1%20Configuration/columns '/Documentation/ApiReference/UI_Components/dxDataGrid/Configuration/columns/').
 
 ##### field(e.columnIndex): Number
-The index of the column to which the cell belongs. For details on indexes, see the [Column and Row Indexes](/concepts/05%20Widgets/DataGrid/15%20Columns/12%20Column%20and%20Row%20Indexes.md '/Documentation/Guide/UI_Components/DataGrid/Columns/Column_and_Row_Indexes/') topic.
+The visible column index described in the following topic: [Column and Row Indexes](/concepts/05%20Widgets/DataGrid/15%20Columns/12%20Column%20and%20Row%20Indexes.md '/Documentation/Guide/UI_Components/DataGrid/Columns/Column_and_Row_Indexes/').
 
 ##### field(e.component): {WidgetName}
 The UI component's instance.
@@ -67,7 +67,7 @@ The cell's [formatted](/api-reference/_hidden/dxDataGridColumn/format.md '/Docum
 The cell's raw value.
 
 ##### field(e.watch): function()
-Allows tracking a variable and performing actions when it changes. Applies when [repaintChangesOnly](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/repaintChangesOnly.md '/Documentation/ApiReference/UI_Components/dxDataGrid/Configuration/#repaintChangesOnly') is **true**.       
+Allows you to track a variable and execute actions when it changes. Applies when [repaintChangesOnly](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/repaintChangesOnly.md '/Documentation/ApiReference/UI_Components/dxDataGrid/Configuration/#repaintChangesOnly') is **true**.       
 This function has the following parameters:     
 
 - **getter(data)**: Function        

--- a/api-reference/10 UI Components/dxTreeList/1 Configuration/onCellPrepared.md
+++ b/api-reference/10 UI Components/dxTreeList/1 Configuration/onCellPrepared.md
@@ -18,7 +18,7 @@ Information about the event that caused the function's execution.
 This column's [configuration](/api-reference/10%20UI%20Widgets/dxTreeList/1%20Configuration/columns '/Documentation/ApiReference/UI_Components/dxTreeList/Configuration/columns/').
 
 ##### field(e.columnIndex): Number
-The index of the column to which the cell belongs.
+The visible column index described in the following topic: [Column and Row Indexes](/Documentation/Guide/UI_Components/TreeList/Columns/Column_and_Row_Indexes/).
 
 ##### field(e.component): {WidgetName}
 The UI component's instance.
@@ -68,7 +68,7 @@ The cell's [formatted](/api-reference/_hidden/GridBaseColumn/format.md '/Documen
 The cell's raw value. Available if the **rowType** is *"data"*.
 
 ##### field(e.watch): function()
-Allows tracking a variable and performing actions when it changes. Applies when [repaintChangesOnly](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/repaintChangesOnly.md '/Documentation/ApiReference/UI_Components/dxTreeList/Configuration/#repaintChangesOnly') is **true**.       
+Allows you to track a variable and execute actions when it changes. Applies when [repaintChangesOnly](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/repaintChangesOnly.md '/Documentation/ApiReference/UI_Components/dxTreeList/Configuration/#repaintChangesOnly') is **true**.       
 This function has the following parameters:     
 
 - **getter(data)**: Function        


### PR DESCRIPTION
* Fix T969248 - columnIndex in DataGrid onCellPrepared

* Add info about treelist

* Address Albert's comment

Co-authored-by: Alexander Yakovlev <alexander.yakovlev@devexpress.com>
(cherry picked from commit 9dce484ca048851aeb40a761ba97d63d6041089e)