### PR TITLE
Fix the description of chart.commonSeriesSettings.point.visible (T970…

### DIFF
--- a/api-reference/10 UI Components/dxChart/5 Series Types/CommonSeries/point/visible.md
+++ b/api-reference/10 UI Components/dxChart/5 Series Types/CommonSeries/point/visible.md
@@ -11,4 +11,7 @@ Makes the series points visible.
 dxChartSeriesTypes.LineSeries,dxChartSeriesTypes.StackedLineSeries,dxChartSeriesTypes.FullStackedLineSeries,dxChartSeriesTypes.StackedSplineSeries,dxChartSeriesTypes.FullStackedSplineSeries,dxChartSeriesTypes.SplineSeries,dxChartSeriesTypes.StepLineSeries,dxChartSeriesTypes.AreaSeries,dxChartSeriesTypes.StackedAreaSeries,dxChartSeriesTypes.FullStackedAreaSeries,dxChartSeriesTypes.SplineAreaSeries,dxChartSeriesTypes.StepAreaSeries,dxChartSeriesTypes.RangeAreaSeries,dxChartSeriesTypes.ScatterSeries
 
 ---
-[note]When this property is set to **true**, some series points may still be hidden because of the [autoHidePointMarkers](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1%20Configuration/autoHidePointMarkers.md '/Documentation/ApiReference/UI_Components/dxChart/Configuration/#autoHidePointMarkers') property.
+
+This property's default value is **false** for series of *area* types. Set this option to **true** to display points in these series types.
+
+[note]When this property is set to **true**, some series points may still be hidden because of the [autoHidePointMarkers](/api-reference/20%20Data%20Visualization%20Widgets/dxChart/1%20Configuration/autoHidePointMarkers.md '/Documentation/ApiReference/UI_Components/dxChart/Configuration/#autoHidePointMarkers') property. 


### PR DESCRIPTION
…959) (#1860)

* Fix the description of chart.commonSeriesSettings.point.visible

* Move new info out of note

* Update api-reference/10 UI Components/dxChart/5 Series Types/CommonSeries/point/visible.md

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

Co-authored-by: Alexander Yakovlev <alexander.yakovlev@devexpress.com>
Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>
(cherry picked from commit 95b149c57075c1fab89e9dc424f9a9b5de1add68)