### PR TITLE
Add a list of tags and attributes to HTML Editor Guide (#1872)

### DIFF
--- a/concepts/05 UI Components/HtmlEditor/05 Tags and Attributes.md
+++ b/concepts/05 UI Components/HtmlEditor/05 Tags and Attributes.md
@@ -1,0 +1,84 @@
+**HtmlEditor** generates the following HTML tags and attributes:
+
+**HTML Tags**
+
+<table class="dx-table full-width">
+ <tr>
+    <th>Type</th>
+    <th>Tags</th>
+ </tr>
+  <tr>
+    <td>Content sectioning</td>
+    <td>&lt;h1&gt; - &lt;h6&gt;</td>
+ </tr>
+   <tr>
+    <td>Text content</td>
+    <td>&lt;blockquote&gt;, &lt;div&gt;, &lt;ol&gt;, &lt;li&gt;, &lt;ul&gt;, &lt;p&gt;, &lt;pre&gt;</td>
+ </tr>
+   <tr>
+    <td>Inline text</td>
+    <td>&lt;a&gt;, &lt;b&gt;, &lt;br&gt;, &lt;code&gt;, &lt;em&gt;, &lt;i&gt;, &lt;s&gt;, &lt;span&gt;, &lt;strike&gt;, &lt;strong&gt;, &lt;sub&gt;, &lt;sup&gt;, &lt;u&gt;</td>
+ </tr>
+<tr>
+    <td>Images and frames</td>
+    <td>&lt;img&gt;, &lt;iframe&gt;</td>
+ </tr>
+ <tr>
+    <td>Table content</td>
+    <td>&lt;table&gt;,&lt;tbody&gt;,&lt;tr&gt;, &lt;td&gt;</td>
+ </tr>
+</table>
+
+**Attributes**
+
+<table class="multicolumn-list">
+ <tr>
+    <td>
+      <ul>
+         <li>
+            allowfullscreen
+         </li>
+         <li>
+            alt
+         </li>
+         <li>
+            class
+         </li>
+         <li>
+            data-*
+         </li>
+         <li>
+            frameborder
+         </li>
+         <li>
+            height
+         </li>
+         <li>
+            href
+         </li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+         <li>
+            rel
+         </li>
+         <li>
+            spellcheck
+         </li>
+         <li>
+            src
+         </li>
+         <li>
+            style
+         </li>
+         <li>
+            target
+         </li>
+         <li>
+            width
+         </li>
+      </ul>
+    </td>
+ </tr>
+</table>


### PR DESCRIPTION
* add HTML Edtior tag list

* Update HTML tags article

* Update tags article

* Revert "Update HTML tags article"

This reverts commit 5c8889c8a34a03625826343ea8e3d71513b9ffaa.

* Update the description and rename the file

* Rename 05 Tags and attributes.md to 05 Tags and Attributes.md

* Update concepts/05 UI Components/HtmlEditor/05 Tags and Attributes.md

Co-authored-by: Dmitry Levkovskiy <DokaRus@users.noreply.github.com>

* Update concepts/05 UI Components/HtmlEditor/05 Tags and Attributes.md

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

* Update formatting

Co-authored-by: Dmitry Levkovskiy <DokaRus@users.noreply.github.com>
Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>
(cherry picked from commit b80b31596f77a9f380092edb40652675d93b7ef5)