### PR TITLE
Fix T981988: DataGrid - autoNavigateToFocusedRow doesn't work with in…

### DIFF
--- a/api-reference/10 UI Components/GridBase/1 Configuration/autoNavigateToFocusedRow.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/autoNavigateToFocusedRow.md
@@ -5,7 +5,7 @@ default: true
 ---
 ---
 ##### shortDescription
-Automatically scrolls to the focused row when the [focusedRowKey](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowKey.md '/Documentation/ApiReference/UI_Components/dxDataGrid/Configuration/#focusedRowKey') is changed.
+Automatically scrolls to the focused row when the [focusedRowKey](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowKey.md '{basewidgetpath}/Configuration/#focusedRowKey') is changed.
 
 ---
 <!-- Description goes here -->

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/autoNavigateToFocusedRow.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/autoNavigateToFocusedRow.md
@@ -1,0 +1,5 @@
+---
+##### shortDescription
+Automatically scrolls to the focused row when the [focusedRowKey](/api-reference/10%20UI%20Widgets/GridBase/1%20Configuration/focusedRowKey.md '/Documentation/ApiReference/UI_Components/dxDataGrid/Configuration/#focusedRowKey') is changed. Incompatible with infinite [scrolling mode](/Documentation/ApiReference/UI_Components/dxDataGrid/Configuration/scrolling/#mode).
+
+---


### PR DESCRIPTION
…finite scrolling (#2017)

(cherry picked from commit 7109b1b1b7b49af313dc7bb0704f684c68545f35)