### PR TITLE
Fix descriptions of the selectedItems and similar properties in Accor…

### DIFF
--- a/api-reference/10 UI Components/dxAccordion/1 Configuration/onSelectionChanged.md
+++ b/api-reference/10 UI Components/dxAccordion/1 Configuration/onSelectionChanged.md
@@ -1,0 +1,12 @@
+---
+##### shortDescription
+[tags] expand
+
+A function that is executed when a collection item is expanded or collapsed.
+
+##### field(e.addedItems): Array<any>
+The data of the items that have been expanded.
+
+---
+
+<!-- import * from 'api-reference\10 UI Components\CollectionWidget\1 Configuration\onSelectionChanged.md' -->

--- a/api-reference/10 UI Components/dxAccordion/1 Configuration/selectedIndex.md
+++ b/api-reference/10 UI Components/dxAccordion/1 Configuration/selectedIndex.md
@@ -5,6 +5,9 @@ default: 0
 ---
 ---
 ##### shortDescription
-The index number of the currently selected item.
+[tags] expandedItem, expand
+
+The index number of the currently expanded item.
 
 ---
+

--- a/api-reference/10 UI Components/dxAccordion/1 Configuration/selectedItem.md
+++ b/api-reference/10 UI Components/dxAccordion/1 Configuration/selectedItem.md
@@ -1,0 +1,7 @@
+---
+##### shortDescription
+[tags] expandedItem, expand
+
+The expanded item object.
+
+---

--- a/api-reference/10 UI Components/dxAccordion/1 Configuration/selectedItemKeys.md
+++ b/api-reference/10 UI Components/dxAccordion/1 Configuration/selectedItemKeys.md
@@ -1,0 +1,7 @@
+---
+##### shortDescription
+[tags] expandedItem, expand
+
+Specifies an array of currently exapanded item keys.
+
+---

--- a/api-reference/10 UI Components/dxAccordion/1 Configuration/selectedItems.md
+++ b/api-reference/10 UI Components/dxAccordion/1 Configuration/selectedItems.md
@@ -1,0 +1,7 @@
+---
+##### shortDescription
+[tags] expandedItem, expand
+
+An array of currently expanded item objects.
+
+---

--- a/api-reference/10 UI Components/dxAccordion/4 Events/selectionChanged.md
+++ b/api-reference/10 UI Components/dxAccordion/4 Events/selectionChanged.md
@@ -1,0 +1,7 @@
+---
+##### shortDescription
+[tags] expand
+
+Raised when a collection item is expanded or collapsed.
+
+---


### PR DESCRIPTION
…dion (#2190)

* Fix descriptions of the selectedItems and similar properties in Accordion

* fix imports

* Move tags to the full description

* small fix

* Remove extra fragments

* Small fix

* Move tags to the full desc

Co-authored-by: Alexander Yakovlev <alexander.yakovlev@devexpress.com>
(cherry picked from commit 13bac14ae4dad35f7f23c3d2134e78cb0083fc55)