### PR TITLE
Delete extra semicolon

### DIFF
--- a/concepts/Common/Localization/01 Dictionaries/05 Add Strings to a Dictionary.md
+++ b/concepts/Common/Localization/01 Dictionaries/05 Add Strings to a Dictionary.md
@@ -16,7 +16,7 @@ In the following example, the [loadMessages(messages)](/api-reference/50%20Commo
         });
         DevExpress.localization.locale(navigator.language);
         $("#greeting").text(
-            DevExpress.localization.formatMessage("greetingMessage", userName);
+            DevExpress.localization.formatMessage("greetingMessage", userName)
         )
     })
 


### PR DESCRIPTION
Semicolons are not allowed to separate function arguments.