### PR TITLE
20_2 GridBase allowColumnReordering: remove "first" for "data object"

### DIFF
--- a/api-reference/10 UI Components/GridBase/1 Configuration/allowColumnReordering.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/allowColumnReordering.md
@@ -8,7 +8,7 @@ default: false
 Specifies whether a user can reorder columns.
 
 ---
-Initially, columns appear in the order specified by the [columns](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/columns '{basewidgetpath}/Configuration/columns/') array. If you do not specify this array, columns will mirror the order of fields in the data objects from the [dataSource](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/dataSource.md '{basewidgetpath}/Configuration/#dataSource'). You can allow a user to reorder columns at runtime by setting the **allowColumnReordering** property to **true**.
+Initially, columns appear in the order specified by the [columns](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/columns '{basewidgetpath}/Configuration/columns/') array. If you do not specify this array, columns will mirror the order of fields in the objects from the [dataSource](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/dataSource.md '{basewidgetpath}/Configuration/#dataSource'). You can allow a user to reorder columns at runtime by setting the **allowColumnReordering** property to **true**.
 
 #####See Also#####
 - **columns[]**.[allowReordering](/api-reference/_hidden/GridBaseColumn/allowReordering.md '{basewidgetpath}/Configuration/columns/#allowReordering')

--- a/api-reference/10 UI Components/GridBase/1 Configuration/allowColumnReordering.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/allowColumnReordering.md
@@ -8,7 +8,7 @@ default: false
 Specifies whether a user can reorder columns.
 
 ---
-Initially, columns appear in the order specified by the [columns](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/columns '{basewidgetpath}/Configuration/columns/') array. If you skip specifying this array, columns will mirror the order of fields in the first object from the [dataSource](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/dataSource.md '{basewidgetpath}/Configuration/#dataSource'). You can allow a user to reorder columns at runtime by setting the **allowColumnReordering** property to **true**.
+Initially, columns appear in the order specified by the [columns](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/columns '{basewidgetpath}/Configuration/columns/') array. If you do not specify this array, columns will mirror the order of fields in the data objects from the [dataSource](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/dataSource.md '{basewidgetpath}/Configuration/#dataSource'). You can allow a user to reorder columns at runtime by setting the **allowColumnReordering** property to **true**.
 
 #####See Also#####
 - **columns[]**.[allowReordering](/api-reference/_hidden/GridBaseColumn/allowReordering.md '{basewidgetpath}/Configuration/columns/#allowReordering')


### PR DESCRIPTION
Based on https://github.com/DevExpress/devextreme-demos/pull/795#discussion_r621915230