### PR TITLE
Describe the W1019 warning

### DIFF
--- a/api-reference/10 UI Components/Errors and Warnings/W1016.md
+++ b/api-reference/10 UI Components/Errors and Warnings/W1016.md
@@ -5,6 +5,8 @@ id: ErrorsUIWidgets.W1016
 ##### shortDescription
 Occurs if you specify the deprecated **formatName** and **formatValues** properties in the [items](/Documentation/ApiReference/UI_Components/dxHtmlEditor/Configuration/toolbar/items/) array within the [HtmlEditor](/Documentation/ApiReference/UI_Components/dxHtmlEditor)'s [toolbar](/Documentation/ApiReference/UI_Components/dxHtmlEditor/Configuration/toolbar/) property.
 
+---
+
 Use the **name** and **acceptedValues** properties instead:         
 
 ---

--- a/api-reference/10 UI Components/Errors and Warnings/W1016.md
+++ b/api-reference/10 UI Components/Errors and Warnings/W1016.md
@@ -7,7 +7,7 @@ Occurs if you specify the deprecated **formatName** and **formatValues** propert
 
 ---
 
-Use the **name** and **acceptedValues** properties instead:         
+Use the [name](/Documentation/ApiReference/UI_Components/dxHtmlEditor/Configuration/toolbar/items/#name) and [acceptedValues](m/Documentation/ApiReference/UI_Components/dxHtmlEditor/Configuration/toolbar/items/#acceptedValues) properties instead:                 
 
 ---
 ##### jQuery

--- a/api-reference/10 UI Components/Errors and Warnings/W1016.md
+++ b/api-reference/10 UI Components/Errors and Warnings/W1016.md
@@ -5,9 +5,9 @@ id: ErrorsUIWidgets.W1016
 ##### shortDescription
 Occurs if you specify the deprecated **formatName** and **formatValues** properties in the [items](/Documentation/ApiReference/UI_Components/dxHtmlEditor/Configuration/toolbar/items/) array within the [HtmlEditor](/Documentation/ApiReference/UI_Components/dxHtmlEditor)'s [toolbar](/Documentation/ApiReference/UI_Components/dxHtmlEditor/Configuration/toolbar/) property.
 
----
-Use the **name** and **acceptedValues** properties instead:
+Use the **name** and **acceptedValues** properties instead:         
 
+---
 ##### jQuery
 
     <!-- tab: index.js -->
@@ -29,8 +29,6 @@ Use the **name** and **acceptedValues** properties instead:
             }
         })
     })
-
-
 
 ##### Angular
 
@@ -74,7 +72,6 @@ Use the **name** and **acceptedValues** properties instead:
         </DxToolbar>
     </DxHtmlEditor>
 
-
 ##### React
 
     <!-- tab: App.js -->
@@ -93,6 +90,5 @@ Use the **name** and **acceptedValues** properties instead:
                 acceptedValues={['8pt', '10pt', '12pt']} />
         </Toolbar>
     </HtmlEditor>
-
 
 ---

--- a/api-reference/10 UI Components/Errors and Warnings/W1016.md
+++ b/api-reference/10 UI Components/Errors and Warnings/W1016.md
@@ -7,7 +7,7 @@ Occurs if you specify the deprecated **formatName** and **formatValues** propert
 
 ---
 
-Use the [name](/Documentation/ApiReference/UI_Components/dxHtmlEditor/Configuration/toolbar/items/#name) and [acceptedValues](m/Documentation/ApiReference/UI_Components/dxHtmlEditor/Configuration/toolbar/items/#acceptedValues) properties instead:                 
+Use the [name](/Documentation/ApiReference/UI_Components/dxHtmlEditor/Configuration/toolbar/items/#name) and [acceptedValues](/Documentation/ApiReference/UI_Components/dxHtmlEditor/Configuration/toolbar/items/#acceptedValues) properties instead:                 
 
 ---
 ##### jQuery

--- a/api-reference/10 UI Components/Errors and Warnings/W1019.md
+++ b/api-reference/10 UI Components/Errors and Warnings/W1019.md
@@ -3,9 +3,8 @@ id: ErrorsUIWidgets.W1019
 ---
 ---
 ##### shortDescription
-Occurs if the maximum filter query length exceeds the value specified in the [maxFilterQueryLength](/Documentation/21_1/ApiReference/UI_Components/dxTagBox/Configuration/#maxFilterQueryLength) property of the [TagBox](/Documentation/21_1/ApiReference/UI_Components/dxTagBox/).
-
-Increase the **maxFilterQueryLength** value to meet your requirements.
+Occurs if the maximum filter query length exceeds the value specified in the [maxFilterQueryLength](/Documentation/ApiReference/UI_Components/dxTagBox/Configuration/#maxFilterQueryLength) property of the [TagBox](/Documentation/ApiReference/UI_Components/dxTagBox/).
 
 ---
-<!-- Description goes here -->
+
+Increase the **maxFilterQueryLength** value to meet your requirements.

--- a/api-reference/10 UI Components/Errors and Warnings/W1019.md
+++ b/api-reference/10 UI Components/Errors and Warnings/W1019.md
@@ -3,7 +3,9 @@ id: ErrorsUIWidgets.W1019
 ---
 ---
 ##### shortDescription
-<!-- Description goes here -->
+Occurs if the maximum filter query length exceeds the value specified in the [maxFilterQueryLength](/Documentation/21_1/ApiReference/UI_Components/dxTagBox/Configuration/#maxFilterQueryLength) property of the [TagBox](/Documentation/21_1/ApiReference/UI_Components/dxTagBox/).
+
+Increase the **maxFilterQueryLength** value to meet your requirements.
 
 ---
 <!-- Description goes here -->

--- a/api-reference/10 UI Components/Errors and Warnings/W1020.md
+++ b/api-reference/10 UI Components/Errors and Warnings/W1020.md
@@ -3,8 +3,7 @@ id: ErrorsUIWidgets.W1020
 ---
 ---
 ##### shortDescription
-Occurs if the [shading](/Documentation/ApiReference/UI_Components/dxPopover/Configuration/#shading) property is **true**. In this case, the [hideEvent](/Documentation/ApiReference/UI_Components/dxPopover/Configuration/hideEvent/) property's value is ignored.
+<!-- Description goes here -->
 
 ---
-
-Assign **true** to the **shading** property.
+<!-- Description goes here -->

--- a/api-reference/10 UI Components/Errors and Warnings/W1020.md
+++ b/api-reference/10 UI Components/Errors and Warnings/W1020.md
@@ -3,7 +3,7 @@ id: ErrorsUIWidgets.W1020
 ---
 ---
 ##### shortDescription
-Occurs if the [shading](/Documentation/ApiReference/UI_Components/dxPopover/Configuration/#shading) property is **false**. In this case, the [hideEvent](/Documentation/ApiReference/UI_Components/dxPopover/Configuration/hideEvent/) property's value is ignored.
+Occurs if the [shading](/Documentation/ApiReference/UI_Components/dxPopover/Configuration/#shading) property is **true**. In this case, the [hideEvent](/Documentation/ApiReference/UI_Components/dxPopover/Configuration/hideEvent/) property's value is ignored.
 
 ---
 

--- a/api-reference/10 UI Components/Errors and Warnings/W1020.md
+++ b/api-reference/10 UI Components/Errors and Warnings/W1020.md
@@ -3,9 +3,8 @@ id: ErrorsUIWidgets.W1020
 ---
 ---
 ##### shortDescription
-Occurs if the [shading](/Documentation/ApiReference/UI_Components/dxPopover/Configuration/#shading) property is **false**. [hideEvent](/Documentation/ApiReference/UI_Components/dxPopover/Configuration/hideEvent/) is ignored.
-
-Assign **true** to the **shading** property.
+Occurs if the [shading](/Documentation/ApiReference/UI_Components/dxPopover/Configuration/#shading) property is **false**. In this case, the [hideEvent](/Documentation/ApiReference/UI_Components/dxPopover/Configuration/hideEvent/) property's value is ignored.
 
 ---
-<!-- Description goes here -->
+
+Assign **true** to the **shading** property.

--- a/api-reference/10 UI Components/Errors and Warnings/W1020.md
+++ b/api-reference/10 UI Components/Errors and Warnings/W1020.md
@@ -3,7 +3,9 @@ id: ErrorsUIWidgets.W1020
 ---
 ---
 ##### shortDescription
-<!-- Description goes here -->
+Occurs if the [shading](/Documentation/ApiReference/UI_Components/dxPopover/Configuration/#shading) property is **false**. [hideEvent](/Documentation/ApiReference/UI_Components/dxPopover/Configuration/hideEvent/) is ignored.
+
+Assign **true** to the **shading** property.
 
 ---
 <!-- Description goes here -->


### PR DESCRIPTION
One cannot put snippets in the short description as it was done in W1016

![image](https://user-images.githubusercontent.com/33040934/118773381-72bfbd00-b88d-11eb-9ddf-943234dc8843.png)
