### PR TITLE
DataGrid: Fix filtering docissues (#2373)

### DIFF
--- a/api-reference/10 UI Components/BaseLegend/title/font/font.md
+++ b/api-reference/10 UI Components/BaseLegend/title/font/font.md
@@ -8,6 +8,8 @@ inherits: Font
 Specifies the legend title's font properties.
 
 ---
+The following code sample illustrates how to set this property:
+
 ---
 ##### jQuery
 

--- a/api-reference/10 UI Components/BaseLegend/title/subtitle/font/font.md
+++ b/api-reference/10 UI Components/BaseLegend/title/subtitle/font/font.md
@@ -8,6 +8,8 @@ inherits: Font
 Specifies the legend subtitle's font properties.
 
 ---
+The following code sample illustrates how to set this property:
+
 ---
 ##### jQuery
 

--- a/api-reference/10 UI Components/BaseWidget/1 Configuration/title/font/font.md
+++ b/api-reference/10 UI Components/BaseWidget/1 Configuration/title/font/font.md
@@ -8,6 +8,8 @@ inherits: Font
 Specifies font properties for the title.
 
 ---
+The following code sample illustrates how to set this property:
+
 ---
 ##### jQuery
 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/filterRow/operationDescriptions/operationDescriptions.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/filterRow/operationDescriptions/operationDescriptions.md
@@ -7,5 +7,108 @@ type: Object
 Specifies descriptions for filter operations on the filter list.
 
 ---
+The following code sample illustrates how to set this property:
+
+---
+##### jQuery
+
+    <!-- tab: index.js -->
+    $(function() {
+        $("#{widgetName}Container").dx{WidgetName}({
+            filterRow: {
+                // ...
+                operationDescriptions: {
+                    startsWith: "Begins with"
+                }
+            }
+        });
+    });
+
+##### Angular
+
+    <!-- tab: app.component.html -->
+    <dx-{widget-name} ... >
+        <dxo-filter-row ... >
+            <dxo-operation-descriptions
+                startsWith="Begins with">
+            </dxo-operation-descriptions>
+        </dxo-filter-row>
+    </dx-{widget-name}>
+
+    <!-- tab: app.module.ts -->
+    import { BrowserModule } from '@angular/platform-browser';
+    import { NgModule } from '@angular/core';
+    import { AppComponent } from './app.component';
+
+    import { Dx{WidgetName}Module } from 'devextreme-angular';
+
+    @NgModule({
+        declarations: [
+            AppComponent
+        ],
+        imports: [
+            BrowserModule,
+            Dx{WidgetName}Module
+        ],
+        providers: [ ],
+        bootstrap: [AppComponent]
+    })
+    export class AppModule { }
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <Dx{WidgetName} ... >
+            <DxFilterRow ... >
+                <DxOperationDescriptions
+                    starts-with="Begins with"
+                />
+            </DxFilterRow>
+        </Dx{WidgetName}>
+    </template>
+
+    <script>
+    import 'devextreme/dist/css/dx.light.css';
+
+    import Dx{WidgetName}, {
+        DxFilterRow,
+        DxOperationDescriptions
+    } from 'devextreme-vue/{widget-name}';
+
+    export default {
+        components: {
+            Dx{WidgetName},
+            DxFilterRow,
+            DxOperationDescriptions
+        },
+        // ...
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import 'devextreme/dist/css/dx.light.css';
+
+    import {WidgetName}, {
+        FilterRow,
+        OperationDescriptions
+    } from 'devextreme-react/{widget-name}';
+
+    export default function App() {
+        return (
+            <{WidgetName} ... >
+                <FilterRow ... >
+                    <OperationDescriptions
+                        startsWith="Begins with"
+                    />
+                </FilterRow>
+            </{WidgetName}>
+        );
+    }
+
+---
+
 #####See Also#####
 - **columns[]**.[filterOperations](/api-reference/_hidden/GridBaseColumn/filterOperations.md '{basewidgetpath}/Configuration/columns/#filterOperations')

--- a/api-reference/10 UI Components/GridBase/1 Configuration/filterRow/showOperationChooser.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/filterRow/showOperationChooser.md
@@ -8,3 +8,4 @@ default: true
 Specifies whether icons that open the filter lists are visible.
 
 ---
+[note] If a column does not display a filter icon, specify the column's [dataType]({basewidgetpath}/Configuration/columns/#dataType) and ensure that the column's [allowFiltering]({basewidgetpath}/Configuration/columns/#allowFiltering) property is not disabled.

--- a/api-reference/10 UI Components/GridBase/3 Methods/filter(filterExpr).md
+++ b/api-reference/10 UI Components/GridBase/3 Methods/filter(filterExpr).md
@@ -3,19 +3,42 @@ id: GridBase.filter(filterExpr)
 ---
 ---
 ##### shortDescription
-Applies a filter to the UI component's [data source](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/dataSource.md '{basewidgetpath}/Configuration/#dataSource').
+Applies a filter to the [dataSource](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/dataSource.md '{basewidgetpath}/Configuration/#dataSource').
 
 ##### param(filterExpr): any
-A [filter expression](/concepts/70%20Data%20Binding/5%20Data%20Layer/2%20Reading%20Data/15%20Filtering '/Documentation/Guide/Data_Binding/Data_Layer/#Reading_Data/Filtering').
+A [filter expression](/Documentation/ApiReference/Data_Layer/DataSource/Configuration/#filter).
 
 ---
-Pass an array with the following members to this method:
+#include common-demobutton with {
+    url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/DataGrid/FilteringAPI/"
+}
 
-1. The data source field by which data items are filtered.
-2. The comparison operator. The following operators are available: "=", "<>", ">", ">=", "<", "<=", "startswith", "endswith", "contains", "notcontains".
-3. The value with which data source field values should be compared.
+The filter passed to this method is not reflected in [any of the filtering UI elements](/concepts/05%20UI%20Components/DataGrid/30%20Filtering%20and%20Searching '/Documentation/Guide/UI_Components/{WidgetName}/Filtering_and_Searching/') and is applied before these elements' filters. To change UI filters in code, use the following properties instead:
 
-The filter passed to this method is not reflected in [any of the filtering UI elements](/concepts/05%20UI%20Components/DataGrid/30%20Filtering%20and%20Searching '/Documentation/Guide/UI_Components/{WidgetName}/Filtering_and_Searching/') and is applied before these elements' filters ([filterValue]({basewidgetpath}/Configuration/#filterValue), **columns[]**.[filterValue]({basewidgetpath}/Configuration/columns/#filterValue), **columns[]**.[filterValues]({basewidgetpath}/Configuration/columns/#filterValues), and **searchPanel**.[text]({basewidgetpath}/Configuration/searchPanel/#text)). To clear all filters applied in code and the UI, call the [clearFilter()](/api-reference/10%20UI%20Components/GridBase/3%20Methods/clearFilter().md '{basewidgetpath}/Methods/#clearFilter') method.
+<table class="dx-table">
+    <tr>
+        <th>Filtering UI Element</th>
+        <th>Property</th>
+    </tr>
+    <tr>
+        <td><a href="{basewidgetpath}/Configuration/filterRow/">Filter Row</a></td>
+        <td><b>columns[]</b>.<a href="{basewidgetpath}/Configuration/columns/#filterValue">filterValue</a> and <b>columns[]</b>.<a href="{basewidgetpath}/Configuration/columns/#selectedFilterOperation">selectedFilterOperation</a></td>
+    </tr>
+    <tr>
+        <td><a href="{basewidgetpath}/Configuration/headerFilter/">Header Filter</a></td>
+        <td><b>columns[]</b>.<a href="{basewidgetpath}/Configuration/columns/#filterValues">filterValues</a> and <b>columns[]</b>.<a href="{basewidgetpath}/Configuration/columns/#filterType">filterType</a></td>
+    </tr>
+    <tr>
+        <td><a href="{basewidgetpath}/Configuration/#filterBuilder">Intergrated Filter Builder</a></td>
+        <td><a href="{basewidgetpath}/Configuration/#filterValue">filterValue</a></td>
+    </tr>
+    <tr>
+        <td><a href="{basewidgetpath}/Configuration/searchPanel/">Search Panel</a></td>
+        <td><b>searchPanel</b>.<a href="{basewidgetpath}/Configuration/searchPanel/#text">text</a></td>
+    </tr>
+</table>
+
+To clear all filters applied in code and the UI, call the [clearFilter()](/api-reference/10%20UI%20Components/GridBase/3%20Methods/clearFilter().md '{basewidgetpath}/Methods/#clearFilter') method.
 
 #####See Also#####
 #include common-link-callmethods

--- a/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/filterOperationDescriptions/filterOperationDescriptions.md
+++ b/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/filterOperationDescriptions/filterOperationDescriptions.md
@@ -7,3 +7,97 @@ type: Object
 Specifies filter operation descriptions.
 
 ---
+The following code sample illustrates how to set this property:
+
+---
+##### jQuery
+
+    <!-- tab: index.js -->
+    $(function() {
+        $("#{widgetName}Container").dx{WidgetName}({
+            // ...
+            filterOperationDescriptions: {
+                startsWith: "Begins with"
+            }
+        });
+    });
+
+##### Angular
+
+    <!-- tab: app.component.html -->
+    <dx-{widget-name} ... >
+        <dxo-filter-operation-descriptions
+            startsWith="Begins with">
+        </dxo-filter-operation-descriptions>
+    </dx-{widget-name}>
+
+    <!-- tab: app.module.ts -->
+    import { BrowserModule } from '@angular/platform-browser';
+    import { NgModule } from '@angular/core';
+    import { AppComponent } from './app.component';
+
+    import { Dx{WidgetName}Module } from 'devextreme-angular';
+
+    @NgModule({
+        declarations: [
+            AppComponent
+        ],
+        imports: [
+            BrowserModule,
+            Dx{WidgetName}Module
+        ],
+        providers: [ ],
+        bootstrap: [AppComponent]
+    })
+    export class AppModule { }
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <Dx{WidgetName} ... >
+            <DxFilterOperationDescriptions
+                starts-with="Begins with"
+            />
+        </Dx{WidgetName}>
+    </template>
+
+    <script>
+    import 'devextreme/dist/css/dx.light.css';
+
+    import Dx{WidgetName}, {
+        DxFilterOperationDescriptions
+    } from 'devextreme-vue/{widget-name}';
+
+    export default {
+        components: {
+            Dx{WidgetName},
+            DxFilterOperationDescriptions
+        },
+        // ...
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import 'devextreme/dist/css/dx.light.css';
+
+    import {WidgetName}, {
+        FilterOperationDescriptions
+    } from 'devextreme-react/{widget-name}';
+
+    export default function App() {
+        return (
+            <{WidgetName} ... >
+                <FilterOperationDescriptions
+                    startsWith="Begins with"
+                />
+            </{WidgetName}>
+        );
+    }
+
+---
+
+#####See Also#####
+- **fields[]**.[filterOperations](/Documentation/ApiReference/UI_Components/dxFilterBuilder/Configuration/fields/#filterOperations)

--- a/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/groupOperationDescriptions/groupOperationDescriptions.md
+++ b/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/groupOperationDescriptions/groupOperationDescriptions.md
@@ -7,5 +7,98 @@ type: Object
 Specifies group operation descriptions.
 
 ---
+
+The following code sample illustrates how to set this property:
+
+---
+##### jQuery
+
+    <!-- tab: index.js -->
+    $(function() {
+        $("#{widgetName}Container").dx{WidgetName}({
+            // ...
+            groupOperationDescriptions: {
+                and: "Plus"
+            }
+        });
+    });
+
+##### Angular
+
+    <!-- tab: app.component.html -->
+    <dx-{widget-name} ... >
+        <dxo-group-operation-descriptions
+            and="Plus">
+        </dxo-group-operation-descriptions>
+    </dx-{widget-name}>
+
+    <!-- tab: app.module.ts -->
+    import { BrowserModule } from '@angular/platform-browser';
+    import { NgModule } from '@angular/core';
+    import { AppComponent } from './app.component';
+
+    import { Dx{WidgetName}Module } from 'devextreme-angular';
+
+    @NgModule({
+        declarations: [
+            AppComponent
+        ],
+        imports: [
+            BrowserModule,
+            Dx{WidgetName}Module
+        ],
+        providers: [ ],
+        bootstrap: [AppComponent]
+    })
+    export class AppModule { }
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <Dx{WidgetName} ... >
+            <DxGroupOperationDescriptions
+                and="Plus"
+            />
+        </Dx{WidgetName}>
+    </template>
+
+    <script>
+    import 'devextreme/dist/css/dx.light.css';
+
+    import Dx{WidgetName}, {
+        DxGroupOperationDescriptions
+    } from 'devextreme-vue/{widget-name}';
+
+    export default {
+        components: {
+            Dx{WidgetName},
+            DxGroupOperationDescriptions
+        },
+        // ...
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import 'devextreme/dist/css/dx.light.css';
+
+    import {WidgetName}, {
+        GroupOperationDescriptions
+    } from 'devextreme-react/{widget-name}';
+
+    export default function App() {
+        return (
+            <{WidgetName} ... >
+                <GroupOperationDescriptions
+                    and="Plus"
+                />
+            </{WidgetName}>
+        );
+    }
+
+---
+
 #####See Also#####
 - [groupOperations](/api-reference/10%20UI%20Components/dxFilterBuilder/1%20Configuration/groupOperations.md '/Documentation/ApiReference/UI_Components/dxFilterBuilder/Configuration/#groupOperations')

--- a/api-reference/30 Data Layer/CustomStore/LoadOptions/filter.md
+++ b/api-reference/30 Data Layer/CustomStore/LoadOptions/filter.md
@@ -9,25 +9,7 @@ A filter expression.
 ---
 Defines filtering parameters. Possible variants:
 
-* Binary filter
-
-        [ "field", "=", 3 ]
-
-* Unary filter
-
-        [ "!", [ "field", "=", 3 ] ]
-
-* Complex filter
-
-        [
-            [ "field", "=", 10 ],
-            "and",
-            [
-                [ "otherField", "<", 3 ],
-                "or",
-                [ "otherField", ">", 11 ]
-            ]
-        ]
+#include datalayer-ref-filter-acceptedvalues
 
 #####See Also#####
 - [DataLayer - Filtering](/concepts/70%20Data%20Binding/5%20Data%20Layer/2%20Reading%20Data/15%20Filtering '/Documentation/Guide/Data_Binding/Data_Layer/#Reading_Data/Filtering')

--- a/api-reference/30 Data Layer/DataSource/1 Configuration/filter.md
+++ b/api-reference/30 Data Layer/DataSource/1 Configuration/filter.md
@@ -9,25 +9,7 @@ Specifies data filtering conditions.
 ---
 Possible variants:
 
-* Binary filter
-
-        [ "field", "=", 3 ]
-
-* Unary filter
-
-        [ "!", [ "field", "=", 3 ] ]
-
-* Complex filter
-
-        [
-            [ "field", "=", 10 ],
-            "and",
-            [
-                [ "otherField", "<", 3 ],
-                "or",
-                [ "otherField", ">", 11 ]
-            ]
-        ]
+#include datalayer-ref-filter-acceptedvalues
 
 ---
 ##### jQuery

--- a/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/filter.md
+++ b/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/filter.md
@@ -9,25 +9,7 @@ Specifies data filtering conditions. Cannot be used with an [XmlaStore](/api-ref
 ---
 Possible variants:
 
-* Binary filter
-
-        [ "dataField", "=", 3 ]
-
-* Unary filter
-
-        [ "!", [ "dataField", "=", 3 ] ]
-
-* Complex filter
-
-        [
-            [ "dataField", "=", 10 ],
-            "and",
-            [
-                [ "otherDataField", "<", 3 ],
-                "or",
-                [ "otherDataField", ">", 11 ]
-            ]
-        ]
+#include datalayer-ref-filter-acceptedvalues
 
 ---
 ##### jQuery

--- a/api-reference/_hidden/GridBaseColumn/filterOperations.md
+++ b/api-reference/_hidden/GridBaseColumn/filterOperations.md
@@ -6,10 +6,10 @@ default: undefined
 ---
 ---
 ##### shortDescription
-Specifies the available filter operations. Applies if [allowFiltering](/api-reference/_hidden/GridBaseColumn/allowFiltering.md '{basewidgetpath}/Configuration/columns/#allowFiltering') is **true** and the [filterRow](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/filterRow '{basewidgetpath}/Configuration/filterRow/') and/or [filterPanel](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/filterPanel '{basewidgetpath}/Configuration/filterPanel/') are visible.
+Specifies available filter operations. Applies if [allowFiltering](/api-reference/_hidden/GridBaseColumn/allowFiltering.md '{basewidgetpath}/Configuration/columns/#allowFiltering') is **true** and the [filterRow](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/filterRow '{basewidgetpath}/Configuration/filterRow/') and/or [filterPanel](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/filterPanel '{basewidgetpath}/Configuration/filterPanel/') are visible.
 
 ---
-The following table lists the available filter operations by [data types](/api-reference/_hidden/GridBaseColumn/dataType.md '{basewidgetpath}/Configuration/columns/#dataType'). Users can apply these filter operations in the filter row and nested [filterBuilder](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/filterBuilder.md '{basewidgetpath}/Configuration/#filterBuilder') component. The same operations are assigned to columns of a specific data type.
+The following table lists available filter operations by [data type](/api-reference/_hidden/GridBaseColumn/dataType.md '{basewidgetpath}/Configuration/columns/#dataType'). Users can apply these filter operations in the filter row and nested [filterBuilder](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/filterBuilder.md '{basewidgetpath}/Configuration/#filterBuilder') component. The {WidgetName} uses the first operation in each array as the default operation for the specified data type.
 
 <table class="dx-table">
   <tr>
@@ -30,9 +30,9 @@ The following table lists the available filter operations by [data types](/api-r
   </tr>
 </table>
 
-The nested filter builder also allows users to select from an extended set of operations that include *"anyof"*, *"noneof"*, *"isblank"*, *"isnotblank"*, and [names](/api-reference/_hidden/dxFilterBuilderCustomOperation/name.md '/Documentation/ApiReference/UI_Components/dxFilterBuilder/Configuration/customOperations/#name') of custom operations (if there are any).
+The nested filter builder also allows users to select from an extended set of operations that include *"anyof"*, *"noneof"*, *"isblank"*, *"isnotblank"*, and [names](/api-reference/_hidden/dxFilterBuilderCustomOperation/name.md '/Documentation/ApiReference/UI_Components/dxFilterBuilder/Configuration/customOperations/#name') of custom operations (if any).
 
-The **filterOperations** property can also accept an empty array. In this case, the selected filter operation is *"="* for all data types, and a user cannot change it.
+The **filterOperations** property can also accept an empty array. In this case, the [selectedFilterOperation]({basewidgetpath}/Configuration/columns/#selectedFilterOperation) applies, and users cannot change it.
 
 #include common-ref-enum with {
     enum: "`FilterOperations`",

--- a/api-reference/_hidden/GridBaseColumn/headerFilter/groupInterval.md
+++ b/api-reference/_hidden/GridBaseColumn/headerFilter/groupInterval.md
@@ -6,12 +6,165 @@ default: undefined
 ---
 ---
 ##### shortDescription
-Specifies how the header filter combines values into groups.
+Specifies how the header filter combines values into groups. Does not apply if you [specify a custom header filter data source](/Documentation/Guide/UI_Components/DataGrid/How_To/Customize_Header_Filter_Data_Source/#Specify_a_Custom_Data_Source).
 
 ---
-For date columns, set this property to one of the string values. Groups in date columns are hierarchical, and the string value indicates up to which level the hierarchy is formed. The default level is *"day"*, which means that each group has the following structure: *"year" &rarr; "months" &rarr; "days"*.
+For numeric columns, assign a number to this property. This number designates a step with which to generate groups. Column values are classified into these groups.
 
-For numeric columns, assign a number to this property. This number designates a step with which groups should be generated. Column values are classified into these groups.
+#include common-demobutton with {
+    url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/DataGrid/Filtering/"
+}
+
+For date columns, set this property to one of the accepted string values above. Dates are grouped into a hierarchy, and the string value indicates its lowest level. The default level is *"day"* which means that the header filter forms the following hierarchy: Year &rarr; Month &rarr; Day. You can disable the hierarchical display if you set the **groupInterval** to **null**. In this case, you also need to implement the column's [calculateFilterExpression](/Documentation/ApiReference/UI_Components/dxDataGrid/Configuration/columns/#calculateFilterExpression) function as follows:
+
+---
+##### jQuery
+
+    <!-- tab: index.js -->
+    $(function() {
+        $("#{widgetName}Container").dx{WidgetName}({
+            // ...
+            columns: [{
+                // ...
+                headerFilter: {
+                    groupInterval: null
+                },
+                calculateFilterExpression(value, operation, target) {
+                    if(value && target === "headerFilter") {
+                        return [this.dataField, operation, value];
+                    }
+                    return this.defaultCalculateFilterExpression.apply(this, arguments);
+                }
+            }]
+        });
+    });
+
+##### Angular
+
+    <!-- tab: app.component.html -->
+    <dx-{widget-name} ... >
+        <dxi-column ...
+            [calculateFilterExpression]="calculateFilterExpression">
+            <dxo-header-filter
+                [groupInterval]="null">
+            </dxo-header-filter>
+        </dxi-column>
+    </dx-{widget-name}>
+
+    <!-- tab: app.component.ts -->
+    import { Component } from '@angular/core';
+
+    @Component({
+        selector: 'app-root',
+        templateUrl: './app.component.html',
+        styleUrls: ['./app.component.css']
+    })
+    export class AppComponent {
+        calculateFilterExpression(value, operation, target) {
+            const column = this as any;
+
+            if(value && target === "headerFilter") {
+                return [column.dataField, operation, value];
+            }
+            return column.defaultCalculateFilterExpression.apply(column, arguments);
+        }
+    }
+
+    <!-- tab: app.module.ts -->
+    import { BrowserModule } from '@angular/platform-browser';
+    import { NgModule } from '@angular/core';
+    import { AppComponent } from './app.component';
+
+    import { Dx{WidgetName}Module } from 'devextreme-angular';
+
+    @NgModule({
+        declarations: [
+            AppComponent
+        ],
+        imports: [
+            BrowserModule,
+            Dx{WidgetName}Module
+        ],
+        providers: [ ],
+        bootstrap: [AppComponent]
+    })
+    export class AppModule { }
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <Dx{WidgetName} ... >
+            <DxColumn ...
+                :calculate-filter-expression="calculateFilterExpression">
+                <DxHeaderFilter
+                    :group-interval="null"
+                />
+            </DxColumn>
+        </Dx{WidgetName}>
+    </template>
+
+    <script>
+    import 'devextreme/dist/css/dx.light.css';
+
+    import Dx{WidgetName}, {
+        DxColumn,
+        DxHeaderFilter
+    } from 'devextreme-vue/{widget-name}';
+
+    export default {
+        components: {
+            Dx{WidgetName},
+            DxColumn,
+            DxHeaderFilter
+        },
+        data() {
+            return {
+                calculateFilterExpression(value, operation, target) {
+                    const column = this as any;
+
+                    if(value && target === "headerFilter") {
+                        return [column.dataField, operation, value];
+                    }
+                    return column.defaultCalculateFilterExpression.apply(column, arguments);
+                }
+            }
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+    import 'devextreme/dist/css/dx.light.css';
+
+    import {WidgetName}, {
+        Column,
+        HeaderFilter
+    } from 'devextreme-react/{widget-name}';
+
+    function calculateFilterExpression (value, operation, target) {
+        if(value && target === "headerFilter") {
+            return [this.dataField, operation, value];
+        }
+        return this.defaultCalculateFilterExpression.apply(this, arguments);
+    }
+
+    export default function App() {
+        return (
+            <{WidgetName} ... >
+                <Column ...
+                    calculateFilterExpression={calculateFilterExpression}>
+                    <HeaderFilter
+                        groupInterval={null}
+                    />
+                </Column>
+            </{WidgetName}>
+        );
+    }
+
+---
 
 #include common-ref-enum with {
     enum: "`HeaderFilterGroupInterval`",

--- a/api-reference/_hidden/GridBaseColumn/lookup/valueExpr.md
+++ b/api-reference/_hidden/GridBaseColumn/lookup/valueExpr.md
@@ -5,9 +5,9 @@ default: undefined
 ---
 ---
 ##### shortDescription
-Specifies the data source field whose values must be replaced.
+Specifies the data field whose values should be replaced with values from the [displayExpr]({basewidgetpath}/Configuration/columns/lookup/#displayExpr) field.
 
 ---
-Values from this field will be replaced with values from the **displayExpr** field.
+Values from this data field must have the same type as the column's [dataField]({basewidgetpath}/Configuration/columns/#dataField) values.
 
 #include uiwidgets-ref-valueExpr-functionnote

--- a/api-reference/_hidden/GridBaseColumn/selectedFilterOperation.md
+++ b/api-reference/_hidden/GridBaseColumn/selectedFilterOperation.md
@@ -7,10 +7,10 @@ firedEvents: optionChanged
 ---
 ---
 ##### shortDescription
-Specifies the column's filter operation displayed in the [filter row](/concepts/05%20UI%20Components/DataGrid/30%20Filtering%20and%20Searching/1%20Filter%20Row.md '/Documentation/Guide/UI_Components/{WidgetName}/Filtering_and_Searching/#Filter_Row').
+Specifies a filter operation that applies when users use the [filter row](/Documentation/ApiReference/UI_Components/dxDataGrid/Configuration/filterRow/) to filter the column.
 
 ---
-The following table lists default filter operations by [data type](/api-reference/_hidden/GridBaseColumn/dataType.md '{basewidgetpath}/Configuration/columns/#dataType'):
+The following table lists default selected filter operations by [data type](/api-reference/_hidden/GridBaseColumn/dataType.md '{basewidgetpath}/Configuration/columns/#dataType'):
 
 <table class="dx-table">
   <tr>

--- a/api-reference/_hidden/dxFilterBuilderField/filterOperations.md
+++ b/api-reference/_hidden/dxFilterBuilderField/filterOperations.md
@@ -9,7 +9,7 @@ default: undefined
 Specifies a set of available filter operations.
 
 ---
-The following table lists default operations by [data type](/api-reference/_hidden/dxFilterBuilderField/dataType.md '/Documentation/ApiReference/UI_Components/dxFilterBuilder/Configuration/fields/#dataType'):
+The following table lists available filter operations by [data type](/api-reference/_hidden/dxFilterBuilderField/dataType.md '/Documentation/ApiReference/UI_Components/dxFilterBuilder/Configuration/fields/#dataType'). The {WidgetName} uses the first operation in each array as the default operation for the specified data type.
 
 <table class="dx-table">
   <tr>

--- a/api-reference/_hidden/dxFilterBuilderField/lookup/valueExpr.md
+++ b/api-reference/_hidden/dxFilterBuilderField/lookup/valueExpr.md
@@ -5,7 +5,7 @@ default: undefined
 ---
 ---
 ##### shortDescription
-Specifies the data source field whose values should be replaced.
+Specifies the data field whose values should be replaced with values from the [displayExpr]({basewidgetpath}/Configuration/fields/lookup/#displayExpr) field.
 
 ##### param(data): Object
 The current item's data object.
@@ -14,6 +14,6 @@ The current item's data object.
 A unique item identifier.
 
 ---
-This field's values are replaced with the **displayExpr** field's values.
+Values from this data field must have the same type as [dataField]({basewidgetpath}/Configuration/fields/#dataField) values.
 
 #include uiwidgets-ref-valueExpr-functionnote

--- a/includes/datalayer-ref-filter-acceptedvalues.md
+++ b/includes/datalayer-ref-filter-acceptedvalues.md
@@ -1,0 +1,25 @@
+* **Binary filter**     
+    Supported operators: *"=", "<>", ">", ">=", "<", "<=", "startswith", "endswith", "contains", "notcontains"*.        
+    Example:
+
+        [ "dataField", "=", 3 ]
+
+* **Unary filter**      
+    Supported operators: binary operators, *"!"*.       
+    Example: 
+
+        [ "!", [ "dataField", "=", 3 ] ]
+
+* **Complex filter**        
+    Supported operators: binary and unary operators, *"and"*, *"or"*.       
+    Example:
+
+        [
+            [ "dataField", "=", 10 ],
+            "and",
+            [
+                [ "anotherDataField", "<", 3 ],
+                "or",
+                [ "anotherDataField", ">", 11 ]
+            ]
+        ]


### PR DESCRIPTION
* Fix headerFilter docissues T884624, T896965, T942522, T855042 (#2346)

* Fix headerFilter docissues T884624, T896965, T942522, T855042

* Add a demo link

* Fix calculateFilterExpression

* Remove info about pagination

* Update api-reference/_hidden/GridBaseColumn/headerFilter/groupInterval.md

Co-authored-by: DirkPieterse <dirk.pieterse@devexpress.com>

Co-authored-by: DirkPieterse <dirk.pieterse@devexpress.com>
(cherry picked from commit da9c265bd8526bf719a990f4a8f8ad85e8ac89f8)

* Fix T855409: Data types of the lookup's ValueExpr and the column's dataField must be the same (#2365)

(cherry picked from commit 93e7eb1fd6f2b900010b06eb6e37e98213b606a5)

* Grids: Fix filterRow and filter(filterExpr) docissues (#2366)

* Grids: Fix filterRow and filter(filterExpr) docissues

* Addition

* Update filter(filterExpr)

* Address Armina's comments

(cherry picked from commit 7fb867424aebaed7b410c2d4e96125c2c6e40bed)
(cherry picked from commit 00193bdfd6ab9750c5eb8eb2ccb22387a3042462)