### PR TITLE
Grids closeEditCell also works in the 'cell' edit mode

### DIFF
--- a/api-reference/10 UI Components/GridBase/3 Methods/closeEditCell().md
+++ b/api-reference/10 UI Components/GridBase/3 Methods/closeEditCell().md
@@ -3,7 +3,7 @@ id: GridBase.closeEditCell()
 ---
 ---
 ##### shortDescription
-Switches the cell being edited back to the normal state. Takes effect only if **editing**.[mode](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/editing/mode.md '{basewidgetpath}/Configuration/editing/#mode') is *batch* and [showEditorAlways](/api-reference/_hidden/GridBaseColumn/showEditorAlways.md '{basewidgetpath}/Configuration/columns/#showEditorAlways') is **false**.
+Switches the cell being edited back to the normal state. Takes effect only if **editing**.[mode](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/editing/mode.md '{basewidgetpath}/Configuration/editing/#mode') is *batch* or *cell* and [showEditorAlways](/api-reference/_hidden/GridBaseColumn/showEditorAlways.md '{basewidgetpath}/Configuration/columns/#showEditorAlways') is **false**.
 
 ---
 #####See Also#####


### PR DESCRIPTION
[Trello](https://trello.com/c/f4OBYvqO/1750-datagrid-closeeditcell-also-works-in-cell-mode)
CPs: https://github.com/DevExpress/devextreme-documentation/pull/2390, https://github.com/DevExpress/devextreme-documentation/pull/2391