### PR TITLE
Fix T1004510 - Specify placeholderSize along with wordWrap in Chart d…

### DIFF
--- a/api-reference/10 UI Components/dxChart/1 Configuration/commonAxisSettings/label/wordWrap.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/commonAxisSettings/label/wordWrap.md
@@ -9,6 +9,8 @@ default: 'normal'
 Specifies how to wrap texts that do not fit into a single line.
 
 ---
+This property affects the vertical axis only when the [placeholderSize](/Documentation/ApiReference/UI_Components/dxChart/Configuration/valueAxis/#placeholderSize) property limits space for labels.
+
 #include dataviz-ref-wordwrap with {
     textOverflow_link: "/Documentation/ApiReference/UI_Components/dxChart/Configuration/commonAxisSettings/label/#textOverflow"
 }


### PR DESCRIPTION
…ocs (#2406)

* Fix T1004510 - Specify placeholderSize along with wordWrap in Chart docs

* add info about vertical axis

* Update api-reference/10 UI Components/dxChart/1 Configuration/commonAxisSettings/label/wordWrap.md

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

* Update api-reference/10 UI Components/dxChart/1 Configuration/commonAxisSettings/label/wordWrap.md

Co-authored-by: DirkPieterse <dirk.pieterse@devexpress.com>

Co-authored-by: Alexander Yakovlev <alexander.yakovlev@devexpress.com>
Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>
Co-authored-by: DirkPieterse <dirk.pieterse@devexpress.com>
(cherry picked from commit 09d629ef9bdbadad27aeec6bbcc0fd279d1d25e1)