### PR TITLE
Fix T1001631 - Chart - scale breaks are not visible if its range exce…

### DIFF
--- a/api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/breaks/breaks.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/breaks/breaks.md
@@ -10,11 +10,11 @@ notUsedInTheme:
 Declares a scale break collection. Applies only if the axis' [type](/api-reference/10%20UI%20Components/dxChart/1%20Configuration/argumentAxis/type.md '/Documentation/ApiReference/UI_Components/dxChart/Configuration/argumentAxis/#type') is *"continuous"* or *"logarithmic"*.
 
 ---
-A scale break allows breaking off a part of the axis to improve the readability of a chart with high amplitude values.
+A scale break is an area across an axis that is displayed instead of a section of an axis range. Scale breaks improve the readability of chart sections with large gaps in their ranges.
 
 ![DevExtreme HTML5 JavaScript Charts Scale Breaks](/images/ChartJS/visual_elements/scale-breaks_arg-axis.png)
 
-Each object in the **breaks** array configures a single scale break. Note that a scale break is visible only if its range exceeds the tick interval.
+Each object in the **breaks** array configures a single scale break. A scale break range should be at least two tick intervals. Otherwise, the scale break might not be visible.
 
 #####See Also#####
 - [breakStyle](/api-reference/10%20UI%20Components/dxChart/1%20Configuration/commonAxisSettings/breakStyle '/Documentation/ApiReference/UI_Components/dxChart/Configuration/argumentAxis/breakStyle/')

--- a/api-reference/10 UI Components/dxChart/1 Configuration/valueAxis/breaks/breaks.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/valueAxis/breaks/breaks.md
@@ -10,11 +10,11 @@ notUsedInTheme:
 Declares a custom scale break collection. Applies only if the axis' [type](/api-reference/10%20UI%20Components/dxChart/1%20Configuration/valueAxis/type.md '/Documentation/ApiReference/UI_Components/dxChart/Configuration/valueAxis/#type') is *"continuous"* or *"logarithmic"*.
 
 ---
-A scale break allows breaking off a part of the axis to improve the readability of a chart with high amplitude values.
+A scale break is an area across an axis that is displayed instead of a section of an axis range. Scale breaks improve the readability of chart sections with large gaps in their ranges.
 
 ![DevExtreme HTML5 JavaScript Charts Scale Breaks](/images/ChartJS/visual_elements/scale-breaks_val-axis.png)
 
-Each object in the **breaks** array configures a single scale break. Note that a scale break is visible only if its range exceeds the tick interval.
+Each object in the **breaks** array configures a single scale break. A scale break range should be at least two tick intervals. Otherwise, the scale break might not be visible.
 
 #####See Also#####
 - [breakStyle](/api-reference/10%20UI%20Components/dxChart/1%20Configuration/commonAxisSettings/breakStyle '/Documentation/ApiReference/UI_Components/dxChart/Configuration/argumentAxis/breakStyle/')

--- a/api-reference/10 UI Components/dxRangeSelector/1 Configuration/scale/breaks/breaks.md
+++ b/api-reference/10 UI Components/dxRangeSelector/1 Configuration/scale/breaks/breaks.md
@@ -10,11 +10,11 @@ notUsedInTheme:
 Declares a scale break collection. Applies only if the scale's [type](/api-reference/10%20UI%20Components/dxRangeSelector/1%20Configuration/scale/type.md '/Documentation/ApiReference/UI_Components/dxRangeSelector/Configuration/scale/#type') is *"continuous"* or *"logarithmic"*.
 
 ---
-A scale break allows breaking off a part of the scale to improve the readability of a range selector with high amplitude values.
+A scale break is an area across an axis that is displayed instead of a section of an axis range. Scale breaks improve the readability of chart sections with large gaps in their ranges.
 
 ![DevExtreme HTML5 JavaScript Charts Scale Breaks](/images/ChartJS/visual_elements/scale-breaks_range-selector.png)
 
-Each object in the **breaks** array configures a single scale break. Note that a scale break is visible only if its range exceeds the tick interval.
+Each object in the **breaks** array configures a single scale break.A scale break range should be at least two tick intervals. Otherwise, the break might not be visible.
 
 #####See Also#####
 - [breakStyle](/api-reference/10%20UI%20Components/dxRangeSelector/1%20Configuration/scale/breakStyle '/Documentation/ApiReference/UI_Components/dxRangeSelector/Configuration/scale/breakStyle/')

--- a/concepts/05 UI Components/Chart/20 Axes/33 Scale Breaks.md
+++ b/concepts/05 UI Components/Chart/20 Axes/33 Scale Breaks.md
@@ -1,8 +1,8 @@
-A scale break allows breaking off a part of the axis to improve the readability of a chart with high amplitude values. Scale breaks are available for continuous or logarithmic [type](/api-reference/10%20UI%20Components/dxChart/1%20Configuration/valueAxis/type.md '/Documentation/ApiReference/UI_Components/dxChart/Configuration/valueAxis/#type') axes only.
+A scale break is an area across an axis that is displayed instead of a section of an axis range. Scale breaks improve the readability of chart sections with large gaps in their ranges. Scale breaks are available for continuous or logarithmic [type](/api-reference/10%20UI%20Components/dxChart/1%20Configuration/valueAxis/type.md '/Documentation/ApiReference/UI_Components/dxChart/Configuration/valueAxis/#type') axes only.
 
 ![DevExtreme HTML5 JavaScript Charts Scale Breaks](/images/ChartJS/visual_elements/scale-breaks_val-axis.png)
 
-Use an axis' [breaks](/api-reference/10%20UI%20Components/dxChart/1%20Configuration/valueAxis/breaks '/Documentation/ApiReference/UI_Components/dxChart/Configuration/valueAxis/breaks/') array to declare a scale break collection. Each object in this array must have the **startValue** and **endValue** fields that limit a single scale break. Note that a scale break is visible only if the range between the start and end values exceeds the tick interval.
+Use an axis' [breaks](/api-reference/10%20UI%20Components/dxChart/1%20Configuration/valueAxis/breaks '/Documentation/ApiReference/UI_Components/dxChart/Configuration/valueAxis/breaks/') array to declare a scale break collection. Each object in this array must have the **startValue** and **endValue** fields that limit a single scale break. A scale break range should be at least two tick intervals. Otherwise, the break might not be visible.
 
 ---
 ##### jQuery
@@ -108,7 +108,7 @@ Use an axis' [breaks](/api-reference/10%20UI%20Components/dxChart/1%20Configurat
 
 ---
 
-The value axis supports auto-calculated scale breaks, which can be enabled by setting the [autoBreaksEnabled](/api-reference/10%20UI%20Components/dxChart/1%20Configuration/valueAxis/autoBreaksEnabled.md '/Documentation/ApiReference/UI_Components/dxChart/Configuration/valueAxis/#autoBreaksEnabled') property to **true**. You can specify the [maxAutoBreakCount](/api-reference/10%20UI%20Components/dxChart/1%20Configuration/valueAxis/maxAutoBreakCount.md '/Documentation/ApiReference/UI_Components/dxChart/Configuration/valueAxis/#maxAutoBreakCount') property to limit the number of a scale breaks the UI component can generate.
+The value axis supports auto-calculated scale breaks, which can be enabled by setting the [autoBreaksEnabled](/api-reference/10%20UI%20Components/dxChart/1%20Configuration/valueAxis/autoBreaksEnabled.md '/Documentation/ApiReference/UI_Components/dxChart/Configuration/valueAxis/#autoBreaksEnabled') property to **true**. You can specify the [maxAutoBreakCount](/api-reference/10%20UI%20Components/dxChart/1%20Configuration/valueAxis/maxAutoBreakCount.md '/Documentation/ApiReference/UI_Components/dxChart/Configuration/valueAxis/#maxAutoBreakCount') property to limit the number of scale breaks the UI component can generate.
 
 ---
 ##### jQuery


### PR DESCRIPTION
…eds the tick interval (#2402)

* Fix T1001631 - Chart - scale breaks are not visible if its range exceeds the tick interval

* Update api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/breaks/breaks.md

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

* Address Albert's comments

* Adress Albert's comments

* Update api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/breaks/breaks.md

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

* Address Roman's comment

Co-authored-by: Alexander Yakovlev <alexander.yakovlev@devexpress.com>
Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>
(cherry picked from commit ea50820a067d143afcabe7de1d40189f929e39ad)