### PR TITLE
Grids.columnAutoWidth: Fix awkward wording (#2416)

### DIFF
--- a/api-reference/10 UI Components/GridBase/1 Configuration/columnAutoWidth.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/columnAutoWidth.md
@@ -10,9 +10,9 @@ Specifies whether columns should adjust their widths to the content.
 ---
 When this property is set to **true**, all columns adjust their width to the content.
 
-If the UI component's overall content is narrower than the UI component's width, the columns are stretched to fit the UI component. To avoid this, set the **columns**.[width](/api-reference/_hidden/GridBaseColumn/headerFilter/width.md '/Documentation/ApiReference/UI_Components/dxDataGrid/Configuration/columns/headerFilter/#width') property to *"auto"*.
+If the {WidgetName} is wider than its overall content, the columns are stretched to occupy all available width. To avoid this, set the [columnWidth]({basewidgetpath}/Configuration/#columnWidth) or **columns**.[width]({basewidgetpath}/Configuration/columns/#width) property to *"auto"*.
 
-If the content is wider, the **columnAutoWidth** property set to **true** causes horizontal scrolling. You can set the [allowHiding](/api-reference/_hidden/GridBaseColumn/allowHiding.md '/Documentation/ApiReference/UI_Components/dxDataGrid/Configuration/columns/#allowHiding') property to **false** for columns you want to be displayed continuously.
+If the content is wider, the **columnAutoWidth** property set to **true** causes horizontal scrolling. You can set the [allowHiding]({basewidgetpath}/Configuration/columns/#allowHiding) property to **false** for columns you want to be displayed continuously.
 
 When the **columnAutoWidth** property is set to **false**, all columns have identical width, which in turn depends on the width of the UI component.
 


### PR DESCRIPTION
* Grids.columnAutoWidth: Fix awkward wording

* Update api-reference/10 UI Components/GridBase/1 Configuration/columnAutoWidth.md

Co-authored-by: Pavel Shikhov <66619750+pavel-2020@users.noreply.github.com>

Co-authored-by: Pavel Shikhov <66619750+pavel-2020@users.noreply.github.com>
(cherry picked from commit b3537f03ca0fa87144e7d659d54b2bce79b256a3)