### PR TITLE
Fix broken layout in PivotGrid.onCellPrepared (#2430)

### DIFF
--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/export/export.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/export/export.md
@@ -168,7 +168,7 @@ The following instructions show how to enable and configure client-side export:
     ---
     ##### jQuery
 
-        <!--JavaScript-->
+        <!--tab: index.js-->
         $('#gridContainer').dxPivotGrid({
             export: {
                 enabled: true
@@ -319,7 +319,7 @@ The following instructions show how to enable and configure client-side export:
         export default function App() {
             return (
                 <PivotGrid ...
-                    onExporting={this.onExporting}>
+                    onExporting={onExporting}>
                     <Export enabled={true} />
                 </PivotGrid>
             );

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onCellPrepared.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onCellPrepared.md
@@ -73,9 +73,9 @@ This function allows you to customize cells and modify their content. Common use
         })
         export class AppComponent {
             onCellPrepared(e) {          
-                if(e.cell.rowPath === "rowName" && e.cell.columnPath === "columnName") {
-                    e.cellElement.style.fontSize = "14px";
-                    e.cellElement.style.fontWeight = "bold";
+                if(e.cell.rowPath === 'rowName' && e.cell.columnPath === 'columnName') {
+                    e.cellElement.style.fontSize = '14px';
+                    e.cellElement.style.fontWeight = 'bold';
                 }
             }
 
@@ -119,9 +119,9 @@ This function allows you to customize cells and modify their content. Common use
             },
             methods: {
                 onCellPrepared(e) {          
-                    if(e.cell.rowPath === "rowName" && e.cell.columnPath === "columnName") {
-                        e.cellElement.style.fontSize = "14px";
-                        e.cellElement.style.fontWeight = "bold";
+                    if(e.cell.rowPath === 'rowName' && e.cell.columnPath === 'columnName') {
+                        e.cellElement.style.fontSize = '14px';
+                        e.cellElement.style.fontWeight = 'bold';
                     }
                 }
             }
@@ -137,27 +137,24 @@ This function allows you to customize cells and modify their content. Common use
         import 'devextreme/dist/css/dx.light.css';
 
         import PivotGrid from 'devextreme-react/pivot-grid';
-
-        const App = () => {
+        
+        export default function App() {
             const customizeCells = useCallback((e) {          
-                if(e.cell.rowPath === "rowName" && e.cell.columnPath === "columnName") {
-                    e.cellElement.style.fontSize = "14px";
-                    e.cellElement.style.fontWeight = "bold";
+                if(e.cell.rowPath === 'rowName' && e.cell.columnPath === 'columnName') {
+                    e.cellElement.style.fontSize = '14px';
+                    e.cellElement.style.fontWeight = 'bold';
                 }
             }, []);
-            
             return (
                 <PivotGrid ...
                     onCellPrepared={customizeCells}
                 />
             );
         }
-        export default App;
 
-    ---
+    ---     
 
-
-- Add a class to a **cellElement**. The following code adds a custom class to cells in the [Grand Total](/concepts/05%20UI%20Components/PivotGrid/010%20Visual%20Elements/05%20Totals/03%20Grand%20Total%20Row%20and%20Column.md '/Documentation/Guide/UI_Components/PivotGrid/Visual_Elements/#Totals/Grand_Total_Row_and_Column') row and column. This code also adds another class to all cells in the *"row"* and *"column"* areas:
+- Add a class to a **cellElement**. The following code adds a custom class to cells in the [Grand Total](/concepts/05%20UI%20Components/PivotGrid/010%20Visual%20Elements/05%20Totals/03%20Grand%20Total%20Row%20and%20Column.md '/Documentation/Guide/UI_Components/PivotGrid/Visual_Elements/#Totals/Grand_Total_Row_and_Column') row and column. This code also adds another class to all cells in the *"row"* and *"column"* areas:        
 
     ---
     ##### jQuery
@@ -192,9 +189,9 @@ This function allows you to customize cells and modify their content. Common use
         })
         export class AppComponent {
             onCellPrepared(e) {          
-                if(e.cell.columnType === "GT" || e.cell.rowType === "GT")
-                    e.cellElement.addClass("your-custom-class");
-                if(e.area === "row" || e.area === "column")
+                if(e.cell.columnType === 'GT' || e.cell.rowType === 'GT')
+                    e.cellElement.addClass('your-custom-class');
+                if(e.area === 'row' || e.area === 'column')
                     e.cellElement.addClass("another-custom-class");
             }
 
@@ -238,10 +235,10 @@ This function allows you to customize cells and modify their content. Common use
             },
             methods: {
                 onCellPrepared(e) {          
-                    if(e.cell.columnType === "GT" || e.cell.rowType === "GT")
-                        e.cellElement.addClass("your-custom-class");
-                    if(e.area === "row" || e.area === "column")
-                        e.cellElement.addClass("another-custom-class");
+                    if(e.cell.columnType === 'GT' || e.cell.rowType === 'GT')
+                        e.cellElement.addClass('your-custom-class');
+                    if(e.area === 'row' || e.area === 'column')
+                        e.cellElement.addClass('another-custom-class');
                 }
             }
         }
@@ -257,25 +254,21 @@ This function allows you to customize cells and modify their content. Common use
 
         import PivotGrid from 'devextreme-react/pivot-grid';
 
-        const App = () => {
-            const customizeCells = useCallback((e) {          
-                if(e.cell.columnType === "GT" || e.cell.rowType === "GT")
-                    e.cellElement.addClass("your-custom-class")
-                if(e.area === "row" || e.area === "column")
-                    e.cellElement.addClass("another-custom-class");
+        export default function App() {
+            const customizeCells = useCallback((e) {
+                if(e.cell.columnType === 'GT' || e.cell.rowType === 'GT')
+                    e.cellElement.addClass('your-custom-class');
+                if(e.area === 'row' || e.area === 'column')
+                    e.cellElement.addClass('another-custom-class');
             }, []);
-            
             return (
                 <PivotGrid ...
-                    onCellPrepared={customizeCells}
+                    onCellPrepared={customizeCells}>
                 />
             );
         }
-        export default App;
 
-    ---
-
-    
+    --- 
 
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/PivotGrid/ExcelJSCellCustomization/"

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onCellPrepared.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onCellPrepared.md
@@ -263,7 +263,7 @@ This function allows you to customize cells and modify their content. Common use
             }, []);
             return (
                 <PivotGrid ...
-                    onCellPrepared={customizeCells}>
+                    onCellPrepared={customizeCells}
                 />
             );
         }


### PR DESCRIPTION
* Fix broken layout in PivotGrid.onCellPrepared

* Change quotes type

Co-authored-by: Alexander Yakovlev <alexander.yakovlev@devexpress.com>
(cherry picked from commit 35c4ae9b509a59571d92fd213a065b448599067c)