### PR TITLE
Add Vue and React examples to themes.current(themeName) (#2510)

### DIFF
--- a/api-reference/50 Common/utils/ui/themes/current(themeName).md
+++ b/api-reference/50 Common/utils/ui/themes/current(themeName).md
@@ -11,8 +11,8 @@ The theme's name.
 ---
 The theme name passed as a parameter should be the value of the **data-theme** attribute used within the **rel="dx-theme"** links to the theme. For instance, if you have links to two of your themes...
 
-    <!--HTML--><link rel="dx-theme" data-theme="generic.mytheme-dark" href="css/mytheme-dark.css" data-active="true">
-    <link rel="dx-theme" data-theme="generic.mytheme-light" href="css/mytheme-light.css" data-active="false">
+    <!--HTML--><link rel="dx-theme" data-theme="generic.dark" href="css/mytheme-dark.css" data-active="true">
+    <link rel="dx-theme" data-theme="generic.light" href="css/mytheme-light.css" data-active="false">
 
 ... you can switch between them as shown in the code below. Note that you should specify a callback function that repaints all UI components after the theme has been loaded using the [ready(callback)](/api-reference/50%20Common/utils/ui/themes/ready(callback).md '/Documentation/ApiReference/Common/utils/ui/themes/#readycallback') method.
 
@@ -23,8 +23,8 @@ The theme name passed as a parameter should be the value of the **data-theme** a
         $("#dataGridContainer").dxDataGrid("repaint");
         // Call other UI components' repaint() method here
     });
-    DevExpress.ui.themes.current('mytheme-light');
-    // DevExpress.ui.themes.current('mytheme-dark');
+    DevExpress.ui.themes.current('generic.light');
+    // DevExpress.ui.themes.current('generic.dark');
 
 ##### Angular
 
@@ -42,20 +42,108 @@ The theme name passed as a parameter should be the value of the **data-theme** a
     })
     
     export class AppComponent {
-        @ViewChild(DxDataGridComponent, { static: false }) dataGrid: DxDataGridComponent
-        @ViewChild(DxButtonComponent, { static: false }) button: DxButtonComponent
+        @ViewChild(DxDataGridComponent, { static: false }) dataGrid: DxDataGridComponent;
+        @ViewChild(DxButtonComponent, { static: false }) button: DxButtonComponent;
         // Prior to Angular 8
-        // @ViewChild(DxDataGridComponent) dataGrid: DxDataGridComponent
-        // @ViewChild(DxButtonComponent) button: DxButtonComponent
+        // @ViewChild(DxDataGridComponent) dataGrid: DxDataGridComponent;
+        // @ViewChild(DxButtonComponent) button: DxButtonComponent;
 
         changeTheme() {
             themes.ready(() => {
                 this.dataGrid.instance.repaint();
                 this.button.instance.repaint();
             });
-            themes.current('mytheme-light');
-            // themes.current('mytheme-dark');
+            themes.current('generic.light');
+            // themes.current('generic.dark');
         }
+    }
+
+##### Vue
+
+    <!-- tab: App.vue -->
+    <template>
+        <DxDataGrid ...
+            :ref="dataGridRefKey"
+        />
+        <DxButton
+            :ref="buttonRefKey"
+            text="Change Theme"
+            @click="changeTheme"
+        />
+    </template>
+
+    <script>
+    import DxDataGrid from 'devextreme-vue/data-grid';
+    import DxButton from 'devextreme-vue/button';
+
+    const dataGridRefKey = 'my-data-grid';
+    const buttonRefKey = 'my-button';
+
+    export default {
+        components: {
+            DxDataGrid,
+            DxButton
+        },
+        data() {
+            return {
+                dataGridRefKey,
+                buttonRefKey
+            }
+        },
+        computed: {
+            dataGrid: function () {
+                return this.$refs[dataGridRefKey].instance;
+            },
+            button: function () {
+                return this.$refs[buttonRefKey].instance;
+            }
+        },
+        methods: {
+            changeTheme() {
+                themes.ready(() => {
+                    this.dataGrid.repaint();
+                    this.button.repaint();
+                });
+                themes.current('generic.light');
+                // themes.current('generic.dark');
+            }
+        }
+    }
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    import React from 'react';
+    import DataGrid from 'devextreme-react/data-grid';
+    import Button from 'devextreme-react/button';
+    import themes from 'devextreme/ui/themes';
+
+    export default function App() {
+        const dataGrid = React.useRef(null);
+        const button = React.useRef(null);
+
+        const changeTheme = React.useCallback(() => {
+            themes.ready(() => {
+                dataGrid.current.instance.repaint();
+                button.current.instance.repaint();
+            });
+            themes.current('generic.light');
+            // themes.current('generic.dark');
+        }, []);
+
+        return (
+            <React.Fragment>
+                <DataGrid ...
+                    ref={dataGrid}
+                />
+                <Button
+                    ref={button}
+                    text="Change Theme"
+                    onClick={changeTheme}
+                />
+            </React.Fragment>
+        );
     }
 
 ---


### PR DESCRIPTION
* Add Vue and React examples to themes.current(themeName)

* Fix data-theme values

(cherry picked from commit 12f70111701941041108822c5bb12d569600b470)