### PR TITLE
Getting Started with FAB: Remove background-color from embedded examples (#2572)

### DIFF
--- a/applications/GettingStartedWith/FloatingActionButton/HandleScreenTransitions/index.css
+++ b/applications/GettingStartedWith/FloatingActionButton/HandleScreenTransitions/index.css
@@ -6,13 +6,11 @@
   height: 360px;
   width: 320px;
   border: 1px solid rgb(221, 221, 221);
-  background-color: #fff;
 }
 
 p {
   font-size: 14px;
   text-align: center;
-  color: rgb(51, 51, 51);
 }
 
 .dx-tabpanel .dx-tabs-wrapper {

--- a/applications/GettingStartedWith/FloatingActionButton/MultipleActions/index.css
+++ b/applications/GettingStartedWith/FloatingActionButton/MultipleActions/index.css
@@ -6,11 +6,9 @@
   height: 360px;
   width: 320px;
   border: 1px solid rgb(221, 221, 221);
-  background-color: #fff;
 }
 
 p {
   font-size: 14px;
   text-align: center;
-  color: rgb(51, 51, 51);
 }

--- a/applications/GettingStartedWith/FloatingActionButton/MultipleActions/index.html
+++ b/applications/GettingStartedWith/FloatingActionButton/MultipleActions/index.html
@@ -1,4 +1,4 @@
-<div id="app-container">
+<div id="app-container" class="dx-widget">
     <p>View's content</p>
     <div id="action-mail"></div>
     <div id="action-copy"></div>

--- a/applications/GettingStartedWith/FloatingActionButton/SingleAction/index.css
+++ b/applications/GettingStartedWith/FloatingActionButton/SingleAction/index.css
@@ -6,11 +6,9 @@
   height: 360px;
   width: 320px;
   border: 1px solid rgb(221, 221, 221);
-  background-color: #fff;
 }
 
 p {
   font-size: 14px;
   text-align: center;
-  color: rgb(51, 51, 51);
 }

--- a/applications/GettingStartedWith/FloatingActionButton/SingleAction/index.html
+++ b/applications/GettingStartedWith/FloatingActionButton/SingleAction/index.html
@@ -1,4 +1,4 @@
-<div id="app-container">
+<div id="app-container" class="dx-widget">
     <p>View's content</p>
     <div id="action-edit"></div>
 </div>


### PR DESCRIPTION
…

* Getting Started with FAB: Remove background-color from embedded examples

* Add class="dx-widget"

Co-authored-by: Oleg Kipchatov <35765711+OlegKipchatov@users.noreply.github.com>
(cherry picked from commit 6956dcfffdbcead1ea7a3b90f545768f23f98703)