### PR TITLE
Gantt: fix link to npm package

### DIFF
--- a/concepts/05 UI Components/Gantt/00 Getting Started with Gantt/10 Add the Gantt Component to a Page.md
+++ b/concepts/05 UI Components/Gantt/00 Getting Started with Gantt/10 Add the Gantt Component to a Page.md
@@ -5,8 +5,8 @@ Add Gantt resources (scripts and styles) onto the page.
     The `devexpress-gantt` is a dependency package of the `DevExtreme` package. Therefore, [install the DevExtreme npm package](/concepts/Common/Distribution%20Channels/01%20npm.md '/Documentation/Guide/Common/Distribution_Channels/npm/') to include the Gantt UI component in your project. Then, add the `dx-gantt.min.css` and `dx-gantt.min.js` files to your page.
 
         <!--HTML-->
-        <link rel="stylesheet" href="node_modules/devexpress-gantt/dx-gantt.min.css">
-        <script type="text/javascript" src="node_modules/devexpress-gantt/dx-gantt.min.js"></script>
+        <link rel="stylesheet" href="node_modules/devexpress-gantt/dist/dx-gantt.min.css">
+        <script type="text/javascript" src="node_modules/devexpress-gantt/dist/dx-gantt.min.js"></script>
 
 - **CDN**
 


### PR DESCRIPTION
(cherry picked from commit f5409995342ab6fdc736a44c6b74195441010140)