### PR TITLE
Fix T1020523 - VectorMap - The 'grouping' topic mentions 3 types but describes only 2

### DIFF
--- a/api-reference/10 UI Components/dxVectorMap/1 Configuration/legends/source/grouping.md
+++ b/api-reference/10 UI Components/dxVectorMap/1 Configuration/legends/source/grouping.md
@@ -8,7 +8,7 @@ notUsedInTheme:
 Specifies the type of the legend grouping.
 
 ---
-The VectorMap's legend supports three grouping types.
+The VectorMap's legend supports two grouping types.
 
 - **color**        
 Can be used if you have grouped map markers or areas in several differently-colored groups. For more information, refer to the layers's [colorGroupingField](/api-reference/10%20UI%20Components/dxVectorMap/1%20Configuration/layers/colorGroupingField.md '/Documentation/ApiReference/UI_Components/dxVectorMap/Configuration/layers/#colorGroupingField') and [colorGroups](/api-reference/10%20UI%20Components/dxVectorMap/1%20Configuration/layers/colorGroups.md '/Documentation/ApiReference/UI_Components/dxVectorMap/Configuration/layers/#colorGroups') property descriptions.


### PR DESCRIPTION
… (#2698)

(cherry picked from commit f649096ca33fa8db590ae0b201f58ebcfc08d1a6)