### PR TITLE
Fix T1023119 - Chart - Ellipsis does not work for labels when they are rotated (#2732)

### DIFF
--- a/api-reference/10 UI Components/dxChart/1 Configuration/commonAxisSettings/label/textOverflow.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/commonAxisSettings/label/textOverflow.md
@@ -9,3 +9,4 @@ default: 'none'
 Specifies what to do with axis labels that overflow the allocated space after applying [wordWrap](/api-reference/10%20UI%20Components/dxChart/1%20Configuration/commonAxisSettings/label/wordWrap.md '/Documentation/ApiReference/UI_Components/dxChart/Configuration/commonAxisSettings/label/#wordWrap'): hide, truncate them and display an ellipsis, or do nothing.
 
 ---
+The **textOverflow** property does not apply if the [displayMode](/Documentation/ApiReference/UI_Components/dxChart/Configuration/commonAxisSettings/label/#displayMode) or [overlappingBehavior](/Documentation/ApiReference/UI_Components/dxChart/Configuration/commonAxisSettings/label/#overlappingBehavior) property is used to rotate axis labels.


### PR DESCRIPTION
* Fix T1023119 - Chart - Ellipsis does not work for labels when they are rotated

* Update the note

(cherry picked from commit 64687cc7e3975b8334b7e4838294a9bba38b0a15)