### PR TITLE
Scheduler scrollTo: add details for the 2nd parameter

### DIFF
--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/currentView.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/currentView.md
@@ -7,14 +7,14 @@ firedEvents: optionChanged
 ---
 ---
 ##### shortDescription
-Specifies the currently displayed view. Accepts the view's [name](/api-reference/10%20UI%20Components/dxScheduler/1%20Configuration/views/name.md '/Documentation/ApiReference/UI_Components/dxScheduler/Configuration/views/#name') or [type](/api-reference/10%20UI%20Components/dxScheduler/1%20Configuration/views/type.md '/Documentation/ApiReference/UI_Components/dxScheduler/Configuration/views/#type').
+Specifies the displayed view. Accepts [name](/api-reference/10%20UI%20Components/dxScheduler/1%20Configuration/views/name.md '/Documentation/ApiReference/UI_Components/dxScheduler/Configuration/views/#name') or [type](/api-reference/10%20UI%20Components/dxScheduler/1%20Configuration/views/type.md '/Documentation/ApiReference/UI_Components/dxScheduler/Configuration/views/#type') of a view available in the [views](/Documentation/ApiReference/UI_Components/dxScheduler/Configuration/views/) array.
 
 ---
 #include common-demobutton with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/Scheduler/BasicViews/"
 }
 
-When more than one view matches the **currentView** value, the Scheduler displays the first matching view from the [views](/api-reference/10%20UI%20Components/dxScheduler/1%20Configuration/views '/Documentation/ApiReference/UI_Components/dxScheduler/Configuration/views/') array.
+When more than one view matches the **currentView** value, the Scheduler displays the first matching view.
 
 To subscribe to changes of the current view, use the [onOptionChanged](/api-reference/10%20UI%20Components/DOMComponent/1%20Configuration/onOptionChanged.md '/Documentation/ApiReference/UI_Components/dxScheduler/Configuration/#onOptionChanged') handler.
 

--- a/api-reference/10 UI Components/dxScheduler/3 Methods/scrollTo(date_group_allDay).md
+++ b/api-reference/10 UI Components/dxScheduler/3 Methods/scrollTo(date_group_allDay).md
@@ -9,7 +9,7 @@ Scrolls the current view to a specified position. Available for all views except
 A date and time to scroll to.
 
 ##### param(group): Object | undefined
-If appointments are [grouped by resources](/Documentation/Guide/UI_Components/Scheduler/Resources/Group_Appointments_by_Resources/), specifies the appointment group id (optional).
+If appointments are [grouped by resources](https://js.devexpress.com/Demos/WidgetsGallery/Demo/Scheduler/GroupOrientation/), specifies a group ID (optional).
 
 ##### param(allDay): Boolean | undefined
 If **true**, scrolls the view to the all-day panel of the specified group. Applies only if the all-day panel is [visible](/api-reference/10%20UI%20Components/dxScheduler/1%20Configuration/showAllDayPanel.md '/Documentation/ApiReference/UI_Components/dxScheduler/Configuration/#showAllDayPanel').

--- a/api-reference/10 UI Components/dxScheduler/3 Methods/scrollTo(date_group_allDay).md
+++ b/api-reference/10 UI Components/dxScheduler/3 Methods/scrollTo(date_group_allDay).md
@@ -9,7 +9,7 @@ Scrolls the current view to a specified position. Available for all views except
 A date and time to scroll to.
 
 ##### param(group): Object | undefined
-An appointment group (optional).
+If appointments are [grouped by resources](/Documentation/Guide/UI_Components/Scheduler/Resources/Group_Appointments_by_Resources/), specifies the appointment group id (optional).
 
 ##### param(allDay): Boolean | undefined
 If **true**, scrolls the view to the all-day panel of the specified group. Applies only if the all-day panel is [visible](/api-reference/10%20UI%20Components/dxScheduler/1%20Configuration/showAllDayPanel.md '/Documentation/ApiReference/UI_Components/dxScheduler/Configuration/#showAllDayPanel').

--- a/api-reference/10 UI Components/dxScheduler/3 Methods/scrollTo(date_group_allDay).md
+++ b/api-reference/10 UI Components/dxScheduler/3 Methods/scrollTo(date_group_allDay).md
@@ -6,7 +6,7 @@ id: dxScheduler.scrollTo(date, group, allDay)
 Scrolls the current view to a specified position. Available for all views except *"agenda"*. You should specify the [height](/api-reference/10%20UI%20Components/DOMComponent/1%20Configuration/height.md '/Documentation/ApiReference/UI_Components/dxScheduler/Configuration/#height') property to use this method.
 
 ##### param(date): Date
-A date and time to scroll to.
+A date and time to which to scroll.
 
 ##### param(group): Object | undefined
 If appointments are [grouped by resources](https://js.devexpress.com/Demos/WidgetsGallery/Demo/Scheduler/GroupOrientation/), specifies a group ID (optional).


### PR DESCRIPTION
A novice user may not be aware what a group is. Thus this change.
[Trello](https://trello.com/c/H0WEHLlj/1802-t1020344-fix-the-scrollto-method-argument-description)
CPs: https://github.com/DevExpress/devextreme-documentation/pull/2768, https://github.com/DevExpress/devextreme-documentation/pull/2769