### PR TITLE
Fix T1026739 - Objects or functions should be outside the rendering function in React (#2815)

### DIFF
--- a/concepts/50 React Components/40 Component Configuration Syntax/26 Event Handling.md
+++ b/concepts/50 React Components/40 Component Configuration Syntax/26 Event Handling.md
@@ -1,10 +1,11 @@
     <!-- tab: Function component -->
+    import { useCallback } from 'react';
     import Button from 'devextreme-react/button';
 
     export default function App() {
-        const handleButtonClick = (e) => {
+        const handleButtonClick = useCallback((e) => {
             alert("The button was clicked")
-        }
+        }, []);
 
         return (
             <Button
@@ -35,3 +36,5 @@
             alert("The button was clicked")
         }
     }
+
+[important] In function components, wrap the event handler declaration into the `useCallback` React Hook to prevent possible issues caused by unnecessary re-rendering.

--- a/concepts/50 React Components/40 Component Configuration Syntax/31 Callback Functions.md
+++ b/concepts/50 React Components/40 Component Configuration Syntax/31 Callback Functions.md
@@ -1,10 +1,11 @@
     <!-- tab: Function component -->
+    import { useCallback } from 'react';
     import VectorMap, { Layer } from 'devextreme-react/vector-map';
 
     export default function App() {
-        const customizeLayers = (elements) => {
+        const customizeLayers = useCallback((elements) => {
             // ...
-        }
+        }, []);
 
         return (
             <VectorMap>
@@ -33,6 +34,8 @@
             // ...
         }
     }
+
+[important] In function components, wrap the callback function declaration into the `useCallback` React Hook to prevent possible issues caused by unnecessary re-rendering.
 
 In class components, callback functions are executed _outside_ the React component's context. If the context is important, explicitly bind the callback function to it in the constructor.
 

--- a/concepts/50 React Components/40 Component Configuration Syntax/60 Call Methods.md
+++ b/concepts/50 React Components/40 Component Configuration Syntax/60 Call Methods.md
@@ -1,16 +1,16 @@
 To call UI component methods, you need the UI component instance. Create a <a href="https://reactjs.org/docs/refs-and-the-dom.html" target="_blank">ref</a> and attach it to the target component via the `ref` property. In the following code, this approach is used to get a `TextBox` instance:
     
     <!-- tab: Function component -->
-    import React, { useRef } from 'react';
+    import React, { useRef, useCallback } from 'react';
     import Button from 'devextreme-react/button';
     import TextBox from 'devextreme-react/text-box';
 
     export default function App() {
         const textBox = useRef(null);
-        const focusTextBox = () => {
+        const focusTextBox = useCallback(() => {
             // `current.instance` points to the UI component instance 
             textBox.current.instance.focus();
-        }
+        }, []);
 
         return (
             <div>

--- a/concepts/50 React Components/40 Component Configuration Syntax/75 DevExtreme Validation Features.md
+++ b/concepts/50 React Components/40 Component Configuration Syntax/75 DevExtreme Validation Features.md
@@ -1,7 +1,7 @@
 In the following example, two textboxes are placed in a [validation group](/api-reference/10%20UI%20Components/dxValidationGroup '/Documentation/ApiReference/UI_Components/dxValidationGroup/') that is validated on a button click. Each textbox has a set of [validation rules](/api-reference/10%20UI%20Components/dxValidator/8%20Validation%20Rules '/Documentation/ApiReference/UI_Components/dxValidator/Validation_Rules/'). The validation result is displayed under the textboxes in a [validation summary](/api-reference/10%20UI%20Components/dxValidationSummary '/Documentation/ApiReference/UI_Components/dxValidationSummary/').
 
     <!-- tab: Function component -->
-    import React, { useState } from 'react';
+    import React, { useState, useCallback } from 'react';
     import TextBox from 'devextreme-react/text-box';
     import Validator, { RequiredRule, EmailRule } from 'devextreme-react/validator';
     import ValidationGroup from 'devextreme-react/validation-group';
@@ -10,7 +10,7 @@ In the following example, two textboxes are placed in a [validation group](/api-
     export default function App() {
         const [email, setEmail] = useState(null);
         const [password, setPassword] = useState(null);
-        const validate = (params) => {
+        const validate = useCallback((params) => {
             const result = params.validationGroup.validate();
             if (result.isValid) {
                 // The values are valid
@@ -19,13 +19,13 @@ In the following example, two textboxes are placed in a [validation group](/api-
                 // ... and then reset
                 // params.validationGroup.reset();
             }
-        }
-        const handleEmailChange = (e) => {
+        }, []);
+        const handleEmailChange = useCallback((e) => {
             setEmail(e.value);
-        }
-        const handlePasswordChange = (e) => {
+        }, []);
+        const handlePasswordChange = useCallback((e) => {
             setPassword(e.value);
-        }
+        }, []);
 
         return (
             <ValidationGroup>


### PR DESCRIPTION

* Fix T1026739 - Objects or functions should be outside the rendering function in React

* Add a note

(cherry picked from commit 4707b1d80e06f257c171fb89c2db27dd808775cb)