### PR TITLE
Fix T1030086 - DataGrid - focusedRowIndex is not specific to focusedRowEnabled (#2868)

### DIFF
--- a/api-reference/10 UI Components/GridBase/1 Configuration/focusedRowIndex.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/focusedRowIndex.md
@@ -6,7 +6,7 @@ firedEvents: focusedRowChanged
 ---
 ---
 ##### shortDescription
-Specifies or indicates the focused data row's index. Use this property when [focusedRowEnabled](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/focusedRowEnabled.md '{basewidgetpath}/Configuration/#focusedRowEnabled') is **true**.
+Specifies or indicates the focused data row's index.
 
 ---
 The focused row has a [key](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/focusedRowKey.md '{basewidgetpath}/Configuration/#focusedRowKey') and index on a page. When the [pager](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/pager '{basewidgetpath}/Configuration/pager/') is used for navigation, the focused row's index persists from page to page, but corresponds to a different row with a different key on each page.

--- a/api-reference/10 UI Components/GridBase/1 Configuration/focusedRowKey.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/focusedRowKey.md
@@ -6,7 +6,7 @@ firedEvents: focusedRowChanged
 ---
 ---
 ##### shortDescription
-Specifies initially or currently focused grid row's key. Use it when [focusedRowEnabled](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/focusedRowEnabled.md '{basewidgetpath}/Configuration/#focusedRowEnabled') is **true**.
+Specifies initially or currently focused grid row's key.
 
 ---
 The focused row has a key and [index](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/focusedRowIndex.md '{basewidgetpath}/Configuration/#focusedRowIndex') on a page. When the [pager](/api-reference/10%20UI%20Components/GridBase/1%20Configuration/pager '{basewidgetpath}/Configuration/pager/') is used for navigation, the focused row's index persists from page to page but corresponds to a different row with a different key on each page.


### PR DESCRIPTION
(cherry picked from commit d8c0d7f4ff8bdfdda4b40b24e5b864a02fad70fd)