### PR TITLE
Fix T1029977 - TagBox - onSelectionChanged is raised only after "OK" …

### DIFF
--- a/api-reference/10 UI Components/dxLookup/1 Configuration/onSelectionChanged.md
+++ b/api-reference/10 UI Components/dxLookup/1 Configuration/onSelectionChanged.md
@@ -1,0 +1,3 @@
+<!-- %fullDescription% -->
+
+<!-- import * from 'api-reference\10 UI Components\dxTagBox\1 Configuration\onSelectionChanged.md' -->

--- a/api-reference/10 UI Components/dxTagBox/1 Configuration/onSelectionChanged.md
+++ b/api-reference/10 UI Components/dxTagBox/1 Configuration/onSelectionChanged.md
@@ -26,3 +26,5 @@ Model data. Available only if Knockout is used.
 The data of the items whose selection has been canceled.
 
 ---
+
+[note] When [applyValueMode]({basewidgetpath}/Configuration/#applyValueMode) is *"useButtons"*, the **onSelectionChanged** handler is executed only when users click the OK button.


### PR DESCRIPTION
…… (#2889)

* Fix T1029977 - TagBox - onSelectionChanged is raised only after "OK" button is clicked when applyValueMode is 'buttons'

* Update api-reference/10 UI Components/dxTagBox/1 Configuration/onSelectionChanged.md

Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>

* Add info about lookup

Co-authored-by: Alexander Yakovlev <alexander.yakovlev@devexpress.com>
Co-authored-by: RomanTsukanov <RomanTsukanov@users.noreply.github.com>
(cherry picked from commit 0c47a5b21efcc1e7d8796f3f9188fffb652db17f)