### PR TITLE
Fix T1031746 - DataGrid.state() - Typo in the code snippet (#2895)

### DIFF
--- a/api-reference/10 UI Components/GridBase/3 Methods/state().md
+++ b/api-reference/10 UI Components/GridBase/3 Methods/state().md
@@ -18,7 +18,7 @@ The following example shows how to save the UI component state in the local stor
     $(function () {
         const {widgetName} = $("#{widgetName}Container").dx{WidgetName}({ 
             // ...
-        }).dx{WidgetName};
+        }).dx{WidgetName}("instance");
         $("#save").dxButton({
             text: "Save State",
             onClick: function() {


### PR DESCRIPTION
(cherry picked from commit 56a584072189c8078506440bc682a187336ddef2)