### PR TITLE
Fix T1031744 - Column Reordering API - Typo in the code snippet

### DIFF
--- a/concepts/05 UI Components/DataGrid/15 Columns/25 Column Reordering/10 API.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/25 Column Reordering/10 API.md
@@ -8,7 +8,7 @@ The [columns](/api-reference/10%20UI%20Components/dxDataGrid/1%20Configuration/c
         $("#dataGridContainer").dxDataGrid({
             // ...
             customizeColumns: function(columns) {
-                column[2].visibleIndex = 1;
+                columns[2].visibleIndex = 1;
             }
         });
     });
@@ -20,7 +20,7 @@ The [columns](/api-reference/10%20UI%20Components/dxDataGrid/1%20Configuration/c
     // ...
     export class AppComponent {
         customizeColumns (columns) {
-            column[2].visibleIndex = 1;
+            columns[2].visibleIndex = 1;
         }
     }
     @NgModule({
@@ -56,7 +56,7 @@ The [columns](/api-reference/10%20UI%20Components/dxDataGrid/1%20Configuration/c
         },
         methods: {
             customizeColumns(columns) {
-                column[2].visibleIndex = 1;
+                columns[2].visibleIndex = 1;
             }
         }
     }
@@ -73,7 +73,7 @@ The [columns](/api-reference/10%20UI%20Components/dxDataGrid/1%20Configuration/c
 
     class App extends React.Component {
         customizeColumns(columns) {
-            column[2].visibleIndex = 1;
+            columns[2].visibleIndex = 1;
         }
 
         render() {

--- a/concepts/05 UI Components/TreeList/10 Columns/25 Column Reordering/10 API.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/25 Column Reordering/10 API.md
@@ -8,7 +8,7 @@ The [columns](/api-reference/10%20UI%20Components/dxTreeList/1%20Configuration/c
         $("#treeListContainer").dxTreeList({
             // ...
             customizeColumns: function(columns) {
-                column[2].visibleIndex = 1;
+                columns[2].visibleIndex = 1;
             }
         });
     });
@@ -20,7 +20,7 @@ The [columns](/api-reference/10%20UI%20Components/dxTreeList/1%20Configuration/c
     // ...
     export class AppComponent {
         customizeColumns (columns) {
-            column[2].visibleIndex = 1;
+            columns[2].visibleIndex = 1;
         }
     }
     @NgModule({
@@ -55,7 +55,7 @@ The [columns](/api-reference/10%20UI%20Components/dxTreeList/1%20Configuration/c
         },
         methods: {
             customizeColumns(columns) {
-                column[2].visibleIndex = 1;
+                columns[2].visibleIndex = 1;
             }
         }
     }
@@ -69,7 +69,7 @@ The [columns](/api-reference/10%20UI%20Components/dxTreeList/1%20Configuration/c
     import TreeList from 'devextreme-react/tree-list';
 
     const customizeColumns = (columns) => {
-        column[2].visibleIndex = 1;
+        columns[2].visibleIndex = 1;
     };
 
     export default function App() {


### PR DESCRIPTION
(cherry picked from commit de41bbe723c669ef218f5055c0f1d2c2514afb72)