### PR TITLE
Optimize Angular code listings

### DIFF
--- a/api-reference/10 UI Components/BaseChart/1 Configuration/animation/animation.md
+++ b/api-reference/10 UI Components/BaseChart/1 Configuration/animation/animation.md
@@ -35,18 +35,6 @@ The UI component animates its elements at the beginning of its lifetime and when
         </dxo-animation>
     </dx-{widget-name}>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/BaseChart/1 Configuration/animation/animation.md
+++ b/api-reference/10 UI Components/BaseChart/1 Configuration/animation/animation.md
@@ -48,24 +48,7 @@ The UI component animates its elements at the beginning of its lifetime and when
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/BaseGauge/1 Configuration/animation/animation.md
+++ b/api-reference/10 UI Components/BaseGauge/1 Configuration/animation/animation.md
@@ -33,18 +33,6 @@ To make your gauge "live", enable animation for it by setting the **enabled** pr
         </dxo-animation>
     </dx-{widget-name}>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/BaseGauge/1 Configuration/animation/animation.md
+++ b/api-reference/10 UI Components/BaseGauge/1 Configuration/animation/animation.md
@@ -46,24 +46,7 @@ To make your gauge "live", enable animation for it by setting the **enabled** pr
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/BaseLegend/title/font/font.md
+++ b/api-reference/10 UI Components/BaseLegend/title/font/font.md
@@ -40,18 +40,6 @@ The following code sample illustrates how to set this property:
         </dxo-legend>
     </dx-{widget-name}>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/BaseLegend/title/font/font.md
+++ b/api-reference/10 UI Components/BaseLegend/title/font/font.md
@@ -53,24 +53,7 @@ The following code sample illustrates how to set this property:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/BaseLegend/title/subtitle/font/font.md
+++ b/api-reference/10 UI Components/BaseLegend/title/subtitle/font/font.md
@@ -46,18 +46,6 @@ The following code sample illustrates how to set this property:
         </dxo-legend>
     </dx-{widget-name}>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/BaseLegend/title/subtitle/font/font.md
+++ b/api-reference/10 UI Components/BaseLegend/title/subtitle/font/font.md
@@ -59,24 +59,7 @@ The following code sample illustrates how to set this property:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/BaseWidget/1 Configuration/margin/margin.md
+++ b/api-reference/10 UI Components/BaseWidget/1 Configuration/margin/margin.md
@@ -37,18 +37,6 @@ Generates space around the UI component.
         </dxo-margin>
     </dx-{widget-name}>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/BaseWidget/1 Configuration/margin/margin.md
+++ b/api-reference/10 UI Components/BaseWidget/1 Configuration/margin/margin.md
@@ -50,24 +50,7 @@ Generates space around the UI component.
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/BaseWidget/1 Configuration/size/size.md
+++ b/api-reference/10 UI Components/BaseWidget/1 Configuration/size/size.md
@@ -34,18 +34,6 @@ The UI component occupies its container's entire area by default. Use the **size
         </dxo-size>
     </dx-{widget-name}>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/BaseWidget/1 Configuration/size/size.md
+++ b/api-reference/10 UI Components/BaseWidget/1 Configuration/size/size.md
@@ -47,24 +47,7 @@ The UI component occupies its container's entire area by default. Use the **size
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/BaseWidget/1 Configuration/title/font/font.md
+++ b/api-reference/10 UI Components/BaseWidget/1 Configuration/title/font/font.md
@@ -36,18 +36,6 @@ The following code sample illustrates how to set this property:
         </dxo-title>
     </dx-{widget-name}>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/BaseWidget/1 Configuration/title/font/font.md
+++ b/api-reference/10 UI Components/BaseWidget/1 Configuration/title/font/font.md
@@ -49,24 +49,7 @@ The following code sample illustrates how to set this property:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/Component/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/Component/1 Configuration/onOptionChanged.md
@@ -53,12 +53,7 @@ The following example shows how to subscribe to component property changes:
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core'; 
 
-    @Component({ 
-        selector: 'app-root', 
-        templateUrl: './app.component.html', 
-        styleUrls: ['./app.component.css'] 
-    }) 
-
+    #include angular-component-decorator
     export class AppComponent { 
         // ...
         handlePropertyChange(e) {

--- a/api-reference/10 UI Components/Component/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/Component/1 Configuration/onOptionChanged.md
@@ -69,24 +69,7 @@ The following example shows how to subscribe to component property changes:
     } 
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser'; 
-    import { NgModule } from '@angular/core'; 
-    import { AppComponent } from './app.component'; 
-    import { Dx{WidgetName}Module } from 'devextreme-angular'; 
-  
-    @NgModule({ 
-        declarations: [ 
-            AppComponent 
-        ], 
-        imports: [ 
-            BrowserModule, 
-            Dx{WidgetName}Module 
-        ], 
-        providers: [ ], 
-        bootstrap: [AppComponent] 
-    }) 
-
-    export class AppModule { }  
+    #include angular-app-module-ts
 
 ##### Vue 
   

--- a/api-reference/10 UI Components/GridBase/1 Configuration/editing/form.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/editing/form.md
@@ -77,18 +77,6 @@ Default form editors depend on the [columns' configuration](/api-reference/10%20
         <dxi-column dataField="Skype"></dxi-column>
     </dx-{widget-name}>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/editing/form.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/editing/form.md
@@ -90,24 +90,7 @@ Default form editors depend on the [columns' configuration](/api-reference/10%20
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### ASP.NET MVC Controls
 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/editing/texts/texts.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/editing/texts/texts.md
@@ -36,18 +36,6 @@ The following code shows the **editing**.**texts** declaration syntax:
         </dxo-editing>
     </dx-{widget-name}>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/editing/texts/texts.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/editing/texts/texts.md
@@ -49,24 +49,7 @@ The following code shows the **editing**.**texts** declaration syntax:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/filterRow/operationDescriptions/operationDescriptions.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/filterRow/operationDescriptions/operationDescriptions.md
@@ -36,24 +36,7 @@ The following code sample illustrates how to set this property:
     </dx-{widget-name}>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/onInitNewRow.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/onInitNewRow.md
@@ -119,24 +119,7 @@ In the following code, the **onInitNewRow** function is used to provide default 
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/onInitNewRow.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/onInitNewRow.md
@@ -88,11 +88,7 @@ In the following code, the **onInitNewRow** function is used to provide default 
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employees = [{
             ID: 1,

--- a/api-reference/10 UI Components/GridBase/1 Configuration/onKeyDown.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/onKeyDown.md
@@ -69,24 +69,7 @@ The following code shows how to handle a key combination:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/onKeyDown.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/onKeyDown.md
@@ -55,11 +55,7 @@ The following code shows how to handle a key combination:
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         onKeyDown(e) {
             if (e.event.ctrlKey && e.event.key === "Q") {

--- a/api-reference/10 UI Components/GridBase/1 Configuration/onRowValidating.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/onRowValidating.md
@@ -85,11 +85,7 @@ The following code illustrates how to validate an email address on the server an
     import { Component } from '@angular/core';
     import { HttpClient, HttpParams } from '@angular/common/http';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         constructor(@Inject(HttpClient) http: HttpClient) {
             this.checkEmail = this.checkEmail.bind(this);

--- a/api-reference/10 UI Components/GridBase/3 Methods/refresh().md
+++ b/api-reference/10 UI Components/GridBase/3 Methods/refresh().md
@@ -38,11 +38,7 @@ The following code shows how to call this method:
     <!-- tab: app.component.ts -->
     import { Component, ViewChild } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         @ViewChild('{widgetName}Var', { static: false }) {widgetName}: Dx{WidgetName}Component;
         // Prior to Angular 8

--- a/api-reference/10 UI Components/UI Events/dxhold.md
+++ b/api-reference/10 UI Components/UI Events/dxhold.md
@@ -65,11 +65,7 @@ If you need to subscribe to **dxhold** for two elements that are in the parent-c
     import { on } from 'devextreme/events';
     import 'devextreme/events/hold';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent implements AfterViewInit {
         ngAfterViewInit() {
             const dxholdHandler = (event) => {

--- a/api-reference/10 UI Components/dxButtonGroup/1 Configuration/buttonTemplate.md
+++ b/api-reference/10 UI Components/dxButtonGroup/1 Configuration/buttonTemplate.md
@@ -45,24 +45,7 @@ A template name or container.
     </dx-button-group>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxButtonGroupModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxButtonGroupModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxChart/1 Configuration/annotations/annotations.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/annotations/annotations.md
@@ -73,24 +73,7 @@ To create annotations, assign an array of objects to the **annotations[]** prope
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxChartModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxChartModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxChart/1 Configuration/annotations/annotations.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/annotations/annotations.md
@@ -61,17 +61,6 @@ To create annotations, assign an array of objects to the **annotations[]** prope
         </svg>
     </dx-chart>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/aggregateByCategory.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/aggregateByCategory.md
@@ -58,11 +58,7 @@ The following code shows an example of a data source that can be aggregated by c
     import { Component } from '@angular/core';
     import { DataPoint, Service } from './app.service';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         chartData: DataPoint[];
         constructor(service: Service) {

--- a/api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/categories.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/categories.md
@@ -57,11 +57,8 @@ Arguments of the `string` type on discrete axes maintain the order of objects in
 
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+
+    #include angular-component-decorator
     export class AppComponent {
         dataSource = [
             { continent: 'Asia', area: 43820000 },

--- a/api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/categories.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/categories.md
@@ -85,24 +85,7 @@ Arguments of the `string` type on discrete axes maintain the order of objects in
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/minVisualRangeLength/minVisualRangeLength.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/minVisualRangeLength/minVisualRangeLength.md
@@ -34,18 +34,6 @@ If the visual range is set on a numeric axis, assign a number to this property. 
         </dxo-argument-axis>
     </dx-chart>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/minVisualRangeLength/minVisualRangeLength.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/argumentAxis/minVisualRangeLength/minVisualRangeLength.md
@@ -47,24 +47,7 @@ If the visual range is set on a numeric axis, assign a number to this property. 
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxChartModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxChartModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 
 ##### Vue

--- a/api-reference/10 UI Components/dxChart/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
@@ -47,24 +47,7 @@ The following code shows the **commonAnnotationSettings** declaration syntax:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxChartModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxChartModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxChart/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
@@ -34,18 +34,6 @@ The following code shows the **commonAnnotationSettings** declaration syntax:
         </dx-common-annotation-settings>
     </dx-chart>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxChart/1 Configuration/customizeAnnotation.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/customizeAnnotation.md
@@ -58,16 +58,7 @@ The following code shows how to use the **customizeAnnotation** function to appl
     }
 
     <!-- tab: app.module.ts -->
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-    // ...
-    @NgModule({
-        imports: [
-            // ...
-            Dx{WidgetName}Module
-        ],
-        // ...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxChart/1 Configuration/dataPrepareSettings/dataPrepareSettings.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/dataPrepareSettings/dataPrepareSettings.md
@@ -31,18 +31,6 @@ The following code shows the **dataPrepareSettings** declaration syntax:
         </dxo-data-prepare-settings>
     </dx-chart>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxChart/1 Configuration/dataPrepareSettings/dataPrepareSettings.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/dataPrepareSettings/dataPrepareSettings.md
@@ -44,24 +44,7 @@ The following code shows the **dataPrepareSettings** declaration syntax:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxChartModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxChartModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxChart/1 Configuration/valueAxis/categories.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/valueAxis/categories.md
@@ -87,24 +87,7 @@ Values of the `string` type on discrete axes maintain the order of objects in th
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxChart/1 Configuration/valueAxis/categories.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/valueAxis/categories.md
@@ -59,11 +59,8 @@ Values of the `string` type on discrete axes maintain the order of objects in th
 
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+
+    #include angular-component-decorator
     export class AppComponent {
         dataSource = [
             { continent: 'Asia', area: 43820000 },

--- a/api-reference/10 UI Components/dxChart/1 Configuration/valueAxis/minVisualRangeLength/minVisualRangeLength.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/valueAxis/minVisualRangeLength/minVisualRangeLength.md
@@ -34,18 +34,6 @@ If the visual range is set on a numeric axis, assign a number to this property. 
         </dxi-value-axis>
     </dx-chart>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxChart/1 Configuration/valueAxis/minVisualRangeLength/minVisualRangeLength.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/valueAxis/minVisualRangeLength/minVisualRangeLength.md
@@ -47,24 +47,7 @@ If the visual range is set on a numeric axis, assign a number to this property. 
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxChartModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxChartModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 
 ##### Vue

--- a/api-reference/10 UI Components/dxChart/5 Series Types/CommonSeries/label/label.md
+++ b/api-reference/10 UI Components/dxChart/5 Series Types/CommonSeries/label/label.md
@@ -59,24 +59,7 @@ Declared in [commonSeriesSettings](/api-reference/10%20UI%20Components/dxChart/1
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxChartModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxChartModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxChart/5 Series Types/CommonSeries/label/label.md
+++ b/api-reference/10 UI Components/dxChart/5 Series Types/CommonSeries/label/label.md
@@ -46,18 +46,6 @@ Declared in [commonSeriesSettings](/api-reference/10%20UI%20Components/dxChart/1
         </dxo-common-series-settings>
     </dx-chart>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/export/export.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/export/export.md
@@ -101,25 +101,7 @@ The following instructions show how to enable and configure client-side export:
 
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { DxDataGridModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxDataGridModule
-            ],
-            providers: [ ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
-
+        #include angular-app-module-ts
 
     ##### Vue
 
@@ -254,24 +236,7 @@ The following instructions show how to enable and configure client-side export:
         }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-        import { DxDataGridModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxDataGridModule
-            ],
-            providers: [ ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
-
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/export/export.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/export/export.md
@@ -90,11 +90,7 @@ The following instructions show how to enable and configure client-side export:
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
         
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             // ...
         }
@@ -208,11 +204,7 @@ The following instructions show how to enable and configure client-side export:
         import { Workbook } from 'exceljs';
         import saveAs from 'file-saver';
         
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             onExporting(e) {
                 const workbook = new Workbook();    

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onContextMenuPreparing.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onContextMenuPreparing.md
@@ -101,24 +101,7 @@ In the following code, the **onContextMenuPreparing** function adds a custom ite
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onContextMenuPreparing.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onContextMenuPreparing.md
@@ -78,11 +78,7 @@ In the following code, the **onContextMenuPreparing** function adds a custom ite
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         addMenuItems(e) { 
             if (e.target == 'header') {

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onEditorPreparing.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onEditorPreparing.md
@@ -127,24 +127,7 @@ Use this function to:
         }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                Dx{WidgetName}Module
-            ],
-            providers: [],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onEditorPreparing.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onEditorPreparing.md
@@ -104,11 +104,7 @@ Use this function to:
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             overrideOnValueChanged(e) {
                 if (e.dataField === 'requiredDataField' && e.parentType === 'dataRow') {

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onExporting.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onExporting.md
@@ -84,11 +84,7 @@ You can use this function to adjust column properties before export. In the foll
     import { Workbook } from 'exceljs';
     import saveAs from 'file-saver';
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         onExporting(e) {
             e.component.beginUpdate();

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onExporting.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onExporting.md
@@ -113,23 +113,7 @@ You can use this function to adjust column properties before export. In the foll
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxDataGridModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxDataGridModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 
 ##### Vue

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onRowClick.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onRowClick.md
@@ -91,11 +91,7 @@ In the following code, the **onRowClick** function calls the [editRow](/api-refe
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
    
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // ...
         startEdit(e) {

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onRowClick.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onRowClick.md
@@ -106,23 +106,7 @@ In the following code, the **onRowClick** function calls the [editRow](/api-refe
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/calculateCustomSummary.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/calculateCustomSummary.md
@@ -120,24 +120,7 @@ A summary value calculation is conducted in three stages: *start* - the **totalV
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser'; 
-    import { NgModule } from '@angular/core'; 
-    import { AppComponent } from './app.component'; 
-    import { DxDataGridModule } from 'devextreme-angular'; 
-    
-    @NgModule({ 
-        declarations: [ 
-            AppComponent 
-        ], 
-        imports: [ 
-            BrowserModule, 
-            DxDataGridModule 
-        ], 
-        providers: [ ], 
-        bootstrap: [AppComponent] 
-    }) 
-    
-    export class AppModule { } 
+    #include angular-app-module-ts
 
 ##### Vue
 
@@ -340,24 +323,7 @@ You can use the **value** field to retrieve the column value. If you do not spec
     </dx-data-grid>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser'; 
-    import { NgModule } from '@angular/core'; 
-    import { AppComponent } from './app.component'; 
-    import { DxDataGridModule } from 'devextreme-angular'; 
-    
-    @NgModule({ 
-        declarations: [ 
-            AppComponent 
-        ], 
-        imports: [ 
-            BrowserModule, 
-            DxDataGridModule 
-        ], 
-        providers: [ ], 
-        bootstrap: [AppComponent] 
-    }) 
-    
-    export class AppModule { } 
+    #include angular-app-module-ts
     
 ##### Vue
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/calculateCustomSummary.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/calculateCustomSummary.md
@@ -89,11 +89,7 @@ A summary value calculation is conducted in three stages: *start* - the **totalV
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         calculateSummary(options) {
             // Calculating "customSummary1"

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/groupItems/displayFormat.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/groupItems/displayFormat.md
@@ -50,24 +50,7 @@ You can use the following position markers in this text:
     </dx-data-grid>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxDataGridModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxDataGridModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 #####Vue
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/totalItems/displayFormat.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/totalItems/displayFormat.md
@@ -50,24 +50,7 @@ You can use the following position markers in this text:
     </dx-data-grid>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxDataGridModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxDataGridModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 #####Vue
 

--- a/api-reference/10 UI Components/dxDataGrid/3 Methods/addRow().md
+++ b/api-reference/10 UI Components/dxDataGrid/3 Methods/addRow().md
@@ -36,11 +36,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             constructor() {
                 this.dataSource = new DataSource({
@@ -147,11 +143,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             constructor() {
                 this.dataSource = new DataSource({

--- a/api-reference/10 UI Components/dxDataGrid/3 Methods/addRow().md
+++ b/api-reference/10 UI Components/dxDataGrid/3 Methods/addRow().md
@@ -56,23 +56,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { DxDataGridModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxDataGridModule
-            ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 
@@ -183,23 +167,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { DxDataGridModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxDataGridModule
-            ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/api-reference/10 UI Components/dxDataGrid/3 Methods/getSelectedRowsData().md
+++ b/api-reference/10 UI Components/dxDataGrid/3 Methods/getSelectedRowsData().md
@@ -58,24 +58,7 @@ When selection is [deferred](/api-reference/10%20UI%20Components/dxDataGrid/1%20
     ></dx-data-grid>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxDataGridModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxDataGridModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxDataGrid/3 Methods/getSelectedRowsData().md
+++ b/api-reference/10 UI Components/dxDataGrid/3 Methods/getSelectedRowsData().md
@@ -30,11 +30,7 @@ When selection is [deferred](/api-reference/10%20UI%20Components/dxDataGrid/1%20
     import { Component, ViewChild } from '@angular/core';
     import { DxDataGridComponent } from 'devextreme-angular';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         @ViewChild('dataGridRef', { static: false }) dataGrid: DxDataGridComponent;
         // Prior to Angular 8

--- a/api-reference/10 UI Components/dxDateBox/1 Configuration/disabledDates.md
+++ b/api-reference/10 UI Components/dxDateBox/1 Configuration/disabledDates.md
@@ -50,11 +50,7 @@ This property accepts an array of dates:
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         disabledDates: Date[] = [ 
             new Date("07/1/2017"),  
@@ -161,11 +157,7 @@ Alternatively, pass a function to **disabledDates**. This function should define
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         disableDates(args) {
             const dayOfWeek = args.date.getDay();

--- a/api-reference/10 UI Components/dxDateBox/1 Configuration/disabledDates.md
+++ b/api-reference/10 UI Components/dxDateBox/1 Configuration/disabledDates.md
@@ -64,24 +64,7 @@ This property accepts an array of dates:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 
@@ -195,24 +178,7 @@ Alternatively, pass a function to **disabledDates**. This function should define
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxDiagram/1 Configuration/customShapes/customShapes.md
+++ b/api-reference/10 UI Components/dxDiagram/1 Configuration/customShapes/customShapes.md
@@ -89,11 +89,7 @@ Use the [toolbox](/api-reference/10%20UI%20Components/dxDiagram/1%20Configuratio
 
     import { DxDiagramModule, DxDiagramComponent } from 'devextreme-angular';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         @ViewChild(DxDiagramComponent, { static: false }, { static: false }) diagram: DxDiagramComponent;
         // Prior to Angular 8

--- a/api-reference/10 UI Components/dxDropDownBox/1 Configuration/displayValueFormatter.md
+++ b/api-reference/10 UI Components/dxDropDownBox/1 Configuration/displayValueFormatter.md
@@ -42,11 +42,7 @@ The following code demonstrates how to change separators from commas to semicolo
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // ...
         displayValueFormatter(value) {

--- a/api-reference/10 UI Components/dxDropDownBox/1 Configuration/displayValueFormatter.md
+++ b/api-reference/10 UI Components/dxDropDownBox/1 Configuration/displayValueFormatter.md
@@ -55,25 +55,7 @@ The following code demonstrates how to change separators from commas to semicolo
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-
-    import { AppComponent } from './app.component';
-
-    import { DxDropDownBoxModule } from 'devextreme-angular';
-
-    @NgModule({
-    declarations: [
-        AppComponent
-    ],
-    imports: [
-        BrowserModule,
-        DxDropDownBoxModule
-    ],
-    providers: [],
-    bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/allowedFileExtensions.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/allowedFileExtensions.md
@@ -38,22 +38,7 @@ The FileManager UI component cannot upload a file and displays an error message 
     </dx-file-manager>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/currentPath.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/currentPath.md
@@ -33,22 +33,7 @@ Specifies the path that is used when the FileManager is initialized.
     </dx-file-manager>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/currentPathKeys.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/currentPathKeys.md
@@ -32,22 +32,7 @@ Each path part has each own key. For example, path "folder1/folder2" has two par
     </dx-file-manager>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/customizeDetailColumns.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/customizeDetailColumns.md
@@ -39,11 +39,7 @@ The columns after customization.
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // Uncomment the following lines if the function should be executed in the component's context
         // constructor() {

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/customizeDetailColumns.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/customizeDetailColumns.md
@@ -59,24 +59,7 @@ The columns after customization.
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/fileSystemProvider.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/fileSystemProvider.md
@@ -98,22 +98,7 @@ The following example illustrates how to configure an [Object](/api-reference/10
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/fileSystemProvider.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/fileSystemProvider.md
@@ -67,12 +67,7 @@ The following example illustrates how to configure an [Object](/api-reference/10
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';    
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileSystem = [{
             name: "Documents",

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/focusedItemKey.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/focusedItemKey.md
@@ -30,22 +30,7 @@ Specifies a key of the initially or currently focused item.
     </dx-file-manager>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/itemView/details/details.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/itemView/details/details.md
@@ -43,22 +43,7 @@ Configures the "Details" file system representation mode.
     </dx-file-manager>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/itemView/itemView.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/itemView/itemView.md
@@ -46,22 +46,7 @@ Configures the file and folder view.
     </dx-file-manager>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onContextMenuItemClick.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onContextMenuItemClick.md
@@ -90,19 +90,7 @@ Specifies whether the context menu is invoked in the navigation panel or in the 
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            DxFileManagerModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onContextMenuItemClick.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onContextMenuItemClick.md
@@ -75,12 +75,7 @@ Specifies whether the context menu is invoked in the navigation panel or in the 
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         onItemClick(e){
             if(e.itemData.options.extension) {

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onCurrentDirectoryChanged.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onCurrentDirectoryChanged.md
@@ -63,19 +63,7 @@ The model data. Available only if you use Knockout.
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            DxFileManagerModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onCurrentDirectoryChanged.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onCurrentDirectoryChanged.md
@@ -50,12 +50,7 @@ The model data. Available only if you use Knockout.
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         onDirectoryChanged(e){
             // your code

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onErrorOccurred.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onErrorOccurred.md
@@ -72,12 +72,7 @@ Model data. Available only if you use Knockout.
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         onOccurred(e){
             // your code

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onErrorOccurred.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onErrorOccurred.md
@@ -85,19 +85,7 @@ Model data. Available only if you use Knockout.
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            DxFileManagerModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onFocusedItemChanged.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onFocusedItemChanged.md
@@ -53,12 +53,7 @@ The model data. Available only if you use Knockout.
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         onFocusedItemChangedEv(e){
             // your code

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onFocusedItemChanged.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onFocusedItemChanged.md
@@ -66,19 +66,7 @@ The model data. Available only if you use Knockout.
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            DxFileManagerModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onSelectedFileOpened.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onSelectedFileOpened.md
@@ -47,11 +47,7 @@ Model data. Available only if you use Knockout.
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         fileManager_onSelectedFileOpened(e) {
             // Your code goes here

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onSelectedFileOpened.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onSelectedFileOpened.md
@@ -59,24 +59,7 @@ Model data. Available only if you use Knockout.
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onSelectionChanged.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onSelectionChanged.md
@@ -56,11 +56,7 @@ The currently selected file system items.
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         fileManager_onSelectionChanged(e) {
             // Your code goes here

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onSelectionChanged.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onSelectionChanged.md
@@ -68,24 +68,7 @@ The currently selected file system items.
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onToolbarItemClick.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onToolbarItemClick.md
@@ -70,24 +70,7 @@ Model data. Available only if you use Knockout.
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onToolbarItemClick.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onToolbarItemClick.md
@@ -58,11 +58,7 @@ Model data. Available only if you use Knockout.
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         fileManager_onToolbarItemClick(e) {
             // Your code goes here

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/rootFolderName.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/rootFolderName.md
@@ -31,22 +31,7 @@ Specifies the root folder name.
     </dx-file-manager>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/selectedItemKeys.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/selectedItemKeys.md
@@ -30,22 +30,7 @@ Contains an array of initially or currently selected files and directories' keys
     </dx-file-manager>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/selectionMode.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/selectionMode.md
@@ -34,22 +34,7 @@ Specifies whether a user can select a single or multiple files and folders in th
     </dx-file-manager>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/toolbar/toolbar.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/toolbar/toolbar.md
@@ -271,7 +271,6 @@ The [widget](/api-reference/_hidden/dxFileManagerToolbarItem/widget.md '/Documen
         styleUrls: ['./app.component.css'],
         providers: [Service]
     })
-
     export class AppComponent {
         constructor(service: Service) {
             this.fileMenuOptions = {

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/toolbar/toolbar.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/toolbar/toolbar.md
@@ -85,22 +85,7 @@ To add a predefined item to the toolbar, specify its [name](/api-reference/_hidd
     </dx-file-manager>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 
@@ -324,20 +309,7 @@ The [widget](/api-reference/_hidden/dxFileManagerToolbarItem/widget.md '/Documen
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/upload/upload.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/upload/upload.md
@@ -31,22 +31,7 @@ Configures upload settings.
     </dx-file-manager>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/3 Methods/refresh().md
+++ b/api-reference/10 UI Components/dxFileManager/3 Methods/refresh().md
@@ -31,11 +31,7 @@ The following example illustrates how to use this method:
     import { Component, ViewChild } from '@angular/core';
     import { DxFileManagerModule } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxFileManagerComponent, { static: false }) fileManager: DxFileManagerComponent;

--- a/api-reference/10 UI Components/dxFileManager/3 Methods/refresh().md
+++ b/api-reference/10 UI Components/dxFileManager/3 Methods/refresh().md
@@ -55,24 +55,7 @@ The following example illustrates how to use this method:
     </dx-file-manager>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }  
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/abortFileUpload.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/abortFileUpload.md
@@ -70,22 +70,7 @@ A Promise that is resolved after the file upload in aborted. It is a <a href="ht
     // other functions
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/abortFileUpload.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/abortFileUpload.md
@@ -48,12 +48,7 @@ A Promise that is resolved after the file upload in aborted. It is a <a href="ht
     import { Component } from '@angular/core';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider'; 
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileSystemProvider: CustomFileSystemProvider;
         constructor(http: HttpClient) {

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/copyItem.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/copyItem.md
@@ -44,12 +44,7 @@ A Promise that is resolved after the file system item is copied. It is a <a href
     import { Component } from '@angular/core';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider'; 
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileSystemProvider: CustomFileSystemProvider;
         constructor(http: HttpClient) {

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/copyItem.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/copyItem.md
@@ -66,22 +66,7 @@ A Promise that is resolved after the file system item is copied. It is a <a href
     // other functions
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/createDirectory.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/createDirectory.md
@@ -66,22 +66,7 @@ A Promise that is resolved after a new directory is created. It is a <a href="ht
     // other functions
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/createDirectory.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/createDirectory.md
@@ -44,12 +44,7 @@ A Promise that is resolved after a new directory is created. It is a <a href="ht
     import { Component } from '@angular/core';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider'; 
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileSystemProvider: CustomFileSystemProvider;
         constructor(http: HttpClient) {

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/deleteItem.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/deleteItem.md
@@ -41,12 +41,7 @@ A Promise that is resolved after a file system item is deleted. It is a <a href=
     import { Component } from '@angular/core';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider'; 
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileSystemProvider: CustomFileSystemProvider;
         constructor(http: HttpClient) {

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/deleteItem.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/deleteItem.md
@@ -63,22 +63,7 @@ A Promise that is resolved after a file system item is deleted. It is a <a href=
     // other functions
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/downloadItems.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/downloadItems.md
@@ -38,12 +38,7 @@ The file system items.
     import { Component } from '@angular/core';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider'; 
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileSystemProvider: CustomFileSystemProvider;
         constructor(http: HttpClient) {

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/downloadItems.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/downloadItems.md
@@ -60,22 +60,7 @@ The file system items.
     // other functions
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/getItems.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/getItems.md
@@ -65,22 +65,7 @@ The **getItems** function returns data items and then passes them to the [dataIt
     // other functions
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/getItems.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/getItems.md
@@ -43,12 +43,7 @@ The **getItems** function returns data items and then passes them to the [dataIt
     import { Component } from '@angular/core';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider'; 
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileSystemProvider: CustomFileSystemProvider;
         constructor(http: HttpClient) {

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/getItemsContent.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/getItemsContent.md
@@ -63,22 +63,7 @@ A Promise that is resolved after the content of the file system items is obtaine
     // other functions
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/getItemsContent.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/getItemsContent.md
@@ -41,12 +41,7 @@ A Promise that is resolved after the content of the file system items is obtaine
     import { Component } from '@angular/core';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider'; 
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileSystemProvider: CustomFileSystemProvider;
         constructor(http: HttpClient) {

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/hasSubDirectoriesExpr.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/hasSubDirectoriesExpr.md
@@ -33,12 +33,7 @@ A function or the name of a data source field that provides information on wheth
     import { Component } from '@angular/core';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider'; 
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileSystemProvider: CustomFileSystemProvider;
         constructor(http: HttpClient) {

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/hasSubDirectoriesExpr.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/hasSubDirectoriesExpr.md
@@ -50,22 +50,7 @@ A function or the name of a data source field that provides information on wheth
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/moveItem.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/moveItem.md
@@ -66,22 +66,7 @@ A Promise that is resolved after the file system item is moved. It is a <a href=
     // other functions
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/moveItem.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/moveItem.md
@@ -44,12 +44,7 @@ A Promise that is resolved after the file system item is moved. It is a <a href=
     import { Component } from '@angular/core';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider'; 
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileSystemProvider: CustomFileSystemProvider;
         constructor(http: HttpClient) {

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/renameItem.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/renameItem.md
@@ -66,22 +66,7 @@ A Promise that is resolved after the file system item is renamed. It is a <a hre
     // other functions
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/renameItem.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/renameItem.md
@@ -44,12 +44,7 @@ A Promise that is resolved after the file system item is renamed. It is a <a hre
     import { Component } from '@angular/core';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider'; 
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileSystemProvider: CustomFileSystemProvider;
         constructor(http: HttpClient) {

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/uploadFileChunk.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/uploadFileChunk.md
@@ -69,22 +69,7 @@ A Promise that is resolved after the file system item is uploaded. It is a <a hr
     // other functions
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/uploadFileChunk.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/uploadFileChunk.md
@@ -47,12 +47,7 @@ A Promise that is resolved after the file system item is uploaded. It is a <a hr
     import { Component } from '@angular/core';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider'; 
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileSystemProvider: CustomFileSystemProvider;
         constructor(http: HttpClient) {

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/Custom.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/Custom.md
@@ -49,12 +49,7 @@ The following code shows how to create a custom file system provider and bind th
     import { Component } from '@angular/core';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider'; 
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileSystemProvider: CustomFileSystemProvider;
         constructor(http: HttpClient) {

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/Custom.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/Custom.md
@@ -74,22 +74,7 @@ The following code shows how to create a custom file system provider and bind th
     // other functions
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Object/Object.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Object/Object.md
@@ -60,11 +60,7 @@ The following code shows how to bind the FileManager to the **Object** file syst
     import { Component } from '@angular/core';
     import ObjectFileSystemProvider from 'devextreme/file_management/object_provider'; 
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     
     export class AppComponent {
         fileItems = [{

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Object/Object.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Object/Object.md
@@ -91,22 +91,7 @@ The following code shows how to bind the FileManager to the **Object** file syst
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Remote/Remote.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Remote/Remote.md
@@ -69,20 +69,7 @@ The following code shows how to bind the FileManager to the **Remote** file syst
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule} from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Remote/Remote.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Remote/Remote.md
@@ -52,12 +52,7 @@ The following code shows how to bind the FileManager to the **Remote** file syst
     import { Component } from '@angular/core';
     import RemoteFileSystemProvider from 'devextreme/file_management/remote_provider';
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: 'app/app.component.html',
-        styleUrls: ['app/app.component.css']
-    })  
-    
+    #include angular-component-decorator
     export class AppComponent {
         remoteFileProvider: RemoteFileSystemProvider;
     

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/abortUpload.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/abortUpload.md
@@ -56,24 +56,7 @@ A Promise that is resolved after the upload in aborted. It is a <a href="https:/
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFileUploaderModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileUploaderModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/abortUpload.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/abortUpload.md
@@ -39,11 +39,7 @@ A Promise that is resolved after the upload in aborted. It is a <a href="https:/
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // Uncomment the following lines if the function should be executed in the component's context
         // constructor() {

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/onBeforeSend.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/onBeforeSend.md
@@ -69,19 +69,7 @@ An object that provides information about the file upload session.
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileUploaderModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            DxFileUploaderModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/onBeforeSend.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/onBeforeSend.md
@@ -56,12 +56,7 @@ An object that provides information about the file upload session.
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         onBeforeSend(e){
             e.request.withCredentials = true;

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/onFilesUploaded.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/onFilesUploaded.md
@@ -60,19 +60,7 @@ Model data. Available only if Knockout is used.
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileUploaderModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            DxFileUploaderModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/onFilesUploaded.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/onFilesUploaded.md
@@ -47,12 +47,7 @@ Model data. Available only if Knockout is used.
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         onBeforeSend(e){
             // ...

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/onUploadError.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/onUploadError.md
@@ -66,12 +66,7 @@ The following code shows how you can handle a network error.
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         onUploadError(e){
             var xhttp = e.request;

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/onUploadError.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/onUploadError.md
@@ -82,19 +82,7 @@ The following code shows how you can handle a network error.
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileUploaderModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            DxFileUploaderModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadChunk.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadChunk.md
@@ -39,11 +39,7 @@ A Promise that is resolved after the chunk is uploaded. It is a <a href="https:/
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // Uncomment the following lines if the function should be executed in the component's context
         // constructor() {

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadChunk.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadChunk.md
@@ -56,24 +56,7 @@ A Promise that is resolved after the chunk is uploaded. It is a <a href="https:/
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFileUploaderModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileUploaderModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadCustomData.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadCustomData.md
@@ -34,22 +34,7 @@ Specifies custom data for the upload request.
     </dx-file-uploader>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileUploaderModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileUploaderModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadFile.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadFile.md
@@ -65,24 +65,7 @@ A Promise that is resolved after the file is uploaded. It is a <a href="https://
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFileUploaderModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileUploaderModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadFile.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadFile.md
@@ -44,11 +44,7 @@ A Promise that is resolved after the file is uploaded. It is a <a href="https://
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // Uncomment the following lines if the function should be executed in the component's context
         // constructor() {

--- a/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/filterOperationDescriptions/filterOperationDescriptions.md
+++ b/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/filterOperationDescriptions/filterOperationDescriptions.md
@@ -32,24 +32,7 @@ The following code sample illustrates how to set this property:
     </dx-{widget-name}>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/groupOperationDescriptions/groupOperationDescriptions.md
+++ b/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/groupOperationDescriptions/groupOperationDescriptions.md
@@ -33,24 +33,7 @@ The following code sample illustrates how to set this property:
     </dx-{widget-name}>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxForm/5 Item Types/GroupItem/colCountByScreen/colCountByScreen.md
+++ b/api-reference/10 UI Components/dxForm/5 Item Types/GroupItem/colCountByScreen/colCountByScreen.md
@@ -43,23 +43,7 @@ Specifies the relation between the [screen size qualifier](/api-reference/10%20U
     </dx-form>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxForm/5 Item Types/SimpleItem/editorOptions.md
+++ b/api-reference/10 UI Components/dxForm/5 Item Types/SimpleItem/editorOptions.md
@@ -26,24 +26,7 @@ Configures the form item's editor.
     </dx-form>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxForm/5 Item Types/SimpleItem/template.md
+++ b/api-reference/10 UI Components/dxForm/5 Item Types/SimpleItem/template.md
@@ -90,24 +90,7 @@ The code below configures the [DateBox](/api-reference/10%20UI%20Components/dxDa
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxForm/5 Item Types/SimpleItem/template.md
+++ b/api-reference/10 UI Components/dxForm/5 Item Types/SimpleItem/template.md
@@ -75,11 +75,7 @@ The code below configures the [DateBox](/api-reference/10%20UI%20Components/dxDa
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         customer = {
             Email: "",

--- a/api-reference/10 UI Components/dxForm/5 Item Types/TabbedItem/tabs/colCountByScreen/colCountByScreen.md
+++ b/api-reference/10 UI Components/dxForm/5 Item Types/TabbedItem/tabs/colCountByScreen/colCountByScreen.md
@@ -47,23 +47,7 @@ Specifies the relation between the [screen size qualifier](/api-reference/10%20U
     </dx-form>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/allowSelection.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/allowSelection.md
@@ -46,20 +46,7 @@ Specifies whether users can select tasks in the Gantt.
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/allowSelection.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/allowSelection.md
@@ -32,19 +32,6 @@ Specifies whether users can select tasks in the Gantt.
         <!-- ... -->
     </dx-gantt>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        // ...      
-    }    
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/columns.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/columns.md
@@ -62,20 +62,7 @@ The **columns** property accepts an array of columns. To configure a column, use
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser'; 
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/columns.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/columns.md
@@ -48,19 +48,6 @@ The **columns** property accepts an array of columns. To configure a column, use
         <dxi-column dataField="end" caption="End Date"></dxi-column>
     </dx-gantt>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        // ...      
-    }    
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/dependencies/dependencies.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/dependencies/dependencies.md
@@ -106,12 +106,7 @@ Use the [dataSource](/api-reference/10%20UI%20Components/dxGantt/1%20Configurati
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         dependencies: Dependency[];
         // ...

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/editing/editing.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/editing/editing.md
@@ -69,20 +69,7 @@ The UI component allows users to add, modify and delete tasks, resources and dep
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/editing/editing.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/editing/editing.md
@@ -55,19 +55,6 @@ The UI component allows users to add, modify and delete tasks, resources and dep
         <!-- ... -->
     </dx-gantt>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        // ...      
-    }    
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/firstDayOfWeek.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/firstDayOfWeek.md
@@ -45,19 +45,6 @@ The culture settings specify the property's default value.
         <!-- ... -->
     </dx-gantt>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        // ...      
-    }    
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/firstDayOfWeek.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/firstDayOfWeek.md
@@ -59,20 +59,7 @@ The culture settings specify the property's default value.
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/resourceAssignments/resourceAssignments.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/resourceAssignments/resourceAssignments.md
@@ -61,11 +61,7 @@ Use the [dataSource](/api-reference/10%20UI%20Components/dxGantt/1%20Configurati
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         resourceAssignments: ResourceAssignment[];

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/resources/resources.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/resources/resources.md
@@ -64,12 +64,7 @@ Use the [dataSource](/api-reference/10%20UI%20Components/dxGantt/1%20Configurati
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         resources: Resource[];
         // ...

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/scaleType.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/scaleType.md
@@ -46,20 +46,7 @@ The **scaleType** property specifies the zoom level for tasks when the Gantt UI 
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/scaleType.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/scaleType.md
@@ -32,19 +32,6 @@ The **scaleType** property specifies the zoom level for tasks when the Gantt UI 
         <!-- ... -->
     </dx-gantt>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        // ...      
-    }    
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/selectedRowKey.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/selectedRowKey.md
@@ -46,20 +46,7 @@ Allows you to select a row or determine which row is selected.
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/selectedRowKey.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/selectedRowKey.md
@@ -32,19 +32,6 @@ Allows you to select a row or determine which row is selected.
         <!-- ... -->
     </dx-gantt>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        // ...      
-    }    
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/showResources.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/showResources.md
@@ -46,20 +46,7 @@ Specifies whether to display [task resources](/api-reference/10%20UI%20Component
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/showResources.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/showResources.md
@@ -32,19 +32,6 @@ Specifies whether to display [task resources](/api-reference/10%20UI%20Component
         <!-- ... -->
     </dx-gantt>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        // ...      
-    }    
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/showRowLines.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/showRowLines.md
@@ -41,20 +41,7 @@ Specifies whether to show/hide horizontal faint lines that separate tasks.
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/showRowLines.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/showRowLines.md
@@ -27,19 +27,6 @@ Specifies whether to show/hide horizontal faint lines that separate tasks.
         <!-- ... -->
     </dx-gantt>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        // ...      
-    }    
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/stripLines.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/stripLines.md
@@ -61,19 +61,6 @@ Strip lines allows you to highlight certain time or time intervals in the chart.
         </dxi-strip-line>
     </dx-gantt>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        // ...      
-    }    
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/stripLines.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/stripLines.md
@@ -75,20 +75,7 @@ Strip lines allows you to highlight certain time or time intervals in the chart.
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/taskListWidth.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/taskListWidth.md
@@ -49,20 +49,7 @@ Specifies the width of the task list in pixels.
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/taskListWidth.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/taskListWidth.md
@@ -35,19 +35,6 @@ Specifies the width of the task list in pixels.
         <!-- ... -->
     </dx-gantt>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        // ...      
-    }    
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/taskTitlePosition.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/taskTitlePosition.md
@@ -47,20 +47,7 @@ Titles can be displayed *"inside"* or *"outside"* the the task. Set the position
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/taskTitlePosition.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/taskTitlePosition.md
@@ -33,19 +33,6 @@ Titles can be displayed *"inside"* or *"outside"* the the task. Set the position
         <!-- ... -->
     </dx-gantt>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        // ...      
-    }    
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/taskTooltipContentTemplate.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/taskTooltipContentTemplate.md
@@ -50,12 +50,7 @@ Note that the **container** parameter contains the content of the default toolti
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         // ...
     } 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/taskTooltipContentTemplate.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/taskTooltipContentTemplate.md
@@ -61,21 +61,7 @@ Note that the **container** parameter contains the content of the default toolti
     } 
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/tasks/tasks.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/tasks/tasks.md
@@ -73,12 +73,7 @@ Use the [dataSource](/api-reference/10%20UI%20Components/dxGantt/1%20Configurati
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         tasks: Task[];
         // ...

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/validation/enablePredecessorGap.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/validation/enablePredecessorGap.md
@@ -60,20 +60,7 @@ The **enablePredecessorGap** option allows users to increase/decrease the gap be
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/validation/enablePredecessorGap.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/validation/enablePredecessorGap.md
@@ -46,19 +46,6 @@ The **enablePredecessorGap** option allows users to increase/decrease the gap be
         <!-- ... -->
     </dx-gantt>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        // ...      
-    }    
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/validation/validation.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/validation/validation.md
@@ -47,20 +47,7 @@ Configures validation properties.
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/validation/validation.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/validation/validation.md
@@ -33,19 +33,6 @@ Configures validation properties.
         <!-- ... -->
     </dx-gantt>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        // ...      
-    }    
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/assignResourceToTask(resourceKey_taskKey).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/assignResourceToTask(resourceKey_taskKey).md
@@ -27,11 +27,7 @@ The task key.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/assignResourceToTask(resourceKey_taskKey).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/assignResourceToTask(resourceKey_taskKey).md
@@ -49,24 +49,7 @@ The task key.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/deleteDependency(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/deleteDependency(key).md
@@ -24,11 +24,7 @@ The dependency key.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/deleteDependency(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/deleteDependency(key).md
@@ -46,24 +46,7 @@ The dependency key.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/deleteResource(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/deleteResource(key).md
@@ -46,24 +46,7 @@ The resource key.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/deleteResource(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/deleteResource(key).md
@@ -24,11 +24,7 @@ The resource key.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/deleteTask(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/deleteTask(key).md
@@ -46,24 +46,7 @@ The task key.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/deleteTask(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/deleteTask(key).md
@@ -24,11 +24,7 @@ The task key.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getDependencyData(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getDependencyData(key).md
@@ -27,11 +27,7 @@ The dependency key.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getDependencyData(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getDependencyData(key).md
@@ -49,24 +49,7 @@ The dependency key.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getResourceAssignmentData(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getResourceAssignmentData(key).md
@@ -49,24 +49,7 @@ The resource assignment key.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getResourceAssignmentData(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getResourceAssignmentData(key).md
@@ -27,11 +27,7 @@ The resource assignment key.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getResourceData(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getResourceData(key).md
@@ -49,24 +49,7 @@ The resource key.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getResourceData(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getResourceData(key).md
@@ -27,11 +27,7 @@ The resource key.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getTaskData(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getTaskData(key).md
@@ -27,11 +27,7 @@ The task key.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getTaskData(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getTaskData(key).md
@@ -49,24 +49,7 @@ The task key.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getTaskResources(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getTaskResources(key).md
@@ -28,11 +28,7 @@ The task's key.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getTaskResources(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getTaskResources(key).md
@@ -50,24 +50,7 @@ The task's key.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleDependencyKeys().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleDependencyKeys().md
@@ -47,24 +47,7 @@ The keys.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleDependencyKeys().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleDependencyKeys().md
@@ -25,11 +25,7 @@ The keys.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleResourceAssignmentKeys().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleResourceAssignmentKeys().md
@@ -47,24 +47,7 @@ The keys.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleResourceAssignmentKeys().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleResourceAssignmentKeys().md
@@ -25,11 +25,7 @@ The keys.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleResourceKeys().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleResourceKeys().md
@@ -47,24 +47,7 @@ The keys.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleResourceKeys().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleResourceKeys().md
@@ -25,11 +25,7 @@ The keys.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleTaskKeys().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleTaskKeys().md
@@ -47,24 +47,7 @@ The keys.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleTaskKeys().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleTaskKeys().md
@@ -25,11 +25,7 @@ The keys.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/insertDependency(data).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/insertDependency(data).md
@@ -24,11 +24,7 @@ The dependency data.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/insertDependency(data).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/insertDependency(data).md
@@ -46,24 +46,7 @@ The dependency data.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/insertResource(data_taskKeys).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/insertResource(data_taskKeys).md
@@ -62,24 +62,7 @@ An array of task keys.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/insertResource(data_taskKeys).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/insertResource(data_taskKeys).md
@@ -34,11 +34,7 @@ An array of task keys.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/insertTask(data).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/insertTask(data).md
@@ -60,24 +60,7 @@ The **insertTask** method does not update the following data fields in the data 
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/insertTask(data).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/insertTask(data).md
@@ -35,11 +35,7 @@ The **insertTask** method does not update the following data fields in the data 
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/unassignResourceFromTask(resourceKey_taskKey).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/unassignResourceFromTask(resourceKey_taskKey).md
@@ -27,11 +27,7 @@ The task key.
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxGantt/3 Methods/unassignResourceFromTask(resourceKey_taskKey).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/unassignResourceFromTask(resourceKey_taskKey).md
@@ -49,24 +49,7 @@ The task key.
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/updateTask(key_data).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/updateTask(key_data).md
@@ -51,24 +51,7 @@ Note that the **updateTask** method does not allow you to change a task's parent
     </dx-gantt>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/updateTask(key_data).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/updateTask(key_data).md
@@ -29,11 +29,7 @@ Note that the **updateTask** method does not allow you to change a task's parent
     import { Component, ViewChild } from '@angular/core';
     import { DxGanttComponent } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })    
+    #include angular-component-decorator    
     
     export class AppComponent {
         @ViewChild(DxGanttComponent, { static: false }) gantt: DxGanttComponent;

--- a/api-reference/10 UI Components/dxHtmlEditor/1 Configuration/customizeModules.md
+++ b/api-reference/10 UI Components/dxHtmlEditor/1 Configuration/customizeModules.md
@@ -38,11 +38,7 @@ The DevExtreme Quill modules and the API you can use to customize them are descr
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         customizeQuillModules(config) {
             config.history = {

--- a/api-reference/10 UI Components/dxHtmlEditor/1 Configuration/customizeModules.md
+++ b/api-reference/10 UI Components/dxHtmlEditor/1 Configuration/customizeModules.md
@@ -53,23 +53,7 @@ The DevExtreme Quill modules and the API you can use to customize them are descr
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxHtmlEditorModule } from 'devextreme-angular';
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxHtmlEditorModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxHtmlEditor/3 Methods/get(componentPath).md
+++ b/api-reference/10 UI Components/dxHtmlEditor/3 Methods/get(componentPath).md
@@ -72,24 +72,7 @@ In the following code, the `bold` format is associated with the `<b>` tag instea
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxHtmlEditorModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxHtmlEditorModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxHtmlEditor/3 Methods/get(componentPath).md
+++ b/api-reference/10 UI Components/dxHtmlEditor/3 Methods/get(componentPath).md
@@ -51,11 +51,7 @@ In the following code, the `bold` format is associated with the `<b>` tag instea
     import { Component, ViewChild, AfterViewInit } from '@angular/core';
     import { DxHtmlEditorComponent } from 'devextreme-angular';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         @ViewChild(DxHtmlEditorComponent, { static: false }) htmlEditor: DxHtmlEditorComponent;
         // Prior to Angular 8

--- a/api-reference/10 UI Components/dxMap/1 Configuration/apiKey/apiKey.md
+++ b/api-reference/10 UI Components/dxMap/1 Configuration/apiKey/apiKey.md
@@ -40,11 +40,7 @@ If you have more than one map provider in your application, specify the keys in 
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent { }
 
     <!-- tab: app.module.ts -->

--- a/api-reference/10 UI Components/dxMap/1 Configuration/apiKey/apiKey.md
+++ b/api-reference/10 UI Components/dxMap/1 Configuration/apiKey/apiKey.md
@@ -48,24 +48,7 @@ If you have more than one map provider in your application, specify the keys in 
     export class AppComponent { }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxMapModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxMapModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxMap/1 Configuration/key/key.md
+++ b/api-reference/10 UI Components/dxMap/1 Configuration/key/key.md
@@ -46,24 +46,7 @@ A key used to authenticate the application within the required map provider.
     export class AppComponent { }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxMapModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxMapModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxMap/1 Configuration/key/key.md
+++ b/api-reference/10 UI Components/dxMap/1 Configuration/key/key.md
@@ -38,11 +38,7 @@ A key used to authenticate the application within the required map provider.
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent { }
 
     <!-- tab: app.module.ts -->

--- a/api-reference/10 UI Components/dxPieChart/1 Configuration/annotations/annotations.md
+++ b/api-reference/10 UI Components/dxPieChart/1 Configuration/annotations/annotations.md
@@ -73,24 +73,7 @@ To create annotations, assign an array of objects to the **annotations[]** prope
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxPieChartModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxPieChartModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxPieChart/1 Configuration/annotations/annotations.md
+++ b/api-reference/10 UI Components/dxPieChart/1 Configuration/annotations/annotations.md
@@ -61,17 +61,6 @@ To create annotations, assign an array of objects to the **annotations[]** prope
         </svg>
     </dx-pie-chart>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxPieChart/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
+++ b/api-reference/10 UI Components/dxPieChart/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
@@ -47,24 +47,7 @@ The following code shows the **commonAnnotationSettings** declaration syntax:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxPieChartModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxPieChartModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxPieChart/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
+++ b/api-reference/10 UI Components/dxPieChart/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
@@ -34,18 +34,6 @@ The following code shows the **commonAnnotationSettings** declaration syntax:
         </dx-common-annotation-settings>
     </dx-pie-chart>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/dataSource.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/dataSource.md
@@ -77,24 +77,7 @@ Use one of the following extensions to enable the server to process data accordi
         </dx-pivot-grid>
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { DxPivotGridModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxPivotGridModule
-            ],
-            providers: [],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/dataSource.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/dataSource.md
@@ -53,11 +53,7 @@ Use one of the following extensions to enable the server to process data accordi
         import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
         import { createStore } from 'devextreme-aspnet-data-nojquery';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             store: CustomStore;
             constructor() {

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/export/export.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/export/export.md
@@ -95,25 +95,7 @@ The following instructions show how to enable and configure client-side export:
 
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { DxPivotGridModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxPivotGridModule
-            ],
-            providers: [ ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
-
+        #include angular-app-module-ts
 
     ##### Vue
 
@@ -239,24 +221,7 @@ The following instructions show how to enable and configure client-side export:
         }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-        import { DxPivotGridModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxPivotGridModule
-            ],
-            providers: [ ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
-
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/export/export.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/export/export.md
@@ -81,19 +81,6 @@ The following instructions show how to enable and configure client-side export:
             <dxo-export [enabled]="true"></dxo-export>
         </dx-pivot-grid>
 
-        <!-- tab: app.component.ts -->
-        import { Component } from '@angular/core';
-        
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
-        export class AppComponent {
-            // ...
-        }
-
-
         <!-- tab: app.module.ts -->
         #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/export/export.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/export/export.md
@@ -180,11 +180,7 @@ The following instructions show how to enable and configure client-side export:
         import { Workbook } from 'exceljs';
         import saveAs from 'file-saver';
         
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             onExporting(e) {
                 const workbook = new Workbook();    

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onCellPrepared.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onCellPrepared.md
@@ -66,11 +66,7 @@ This function allows you to customize cells and modify their content. Common use
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
     
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             onCellPrepared(e) {          
                 if(e.cell.rowPath === 'rowName' && e.cell.columnPath === 'columnName') {
@@ -166,11 +162,7 @@ This function allows you to customize cells and modify their content. Common use
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
     
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             onCellPrepared(e) {          
                 if(e.cell.columnType === 'GT' || e.cell.rowType === 'GT')

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onCellPrepared.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onCellPrepared.md
@@ -80,23 +80,7 @@ This function allows you to customize cells and modify their content. Common use
             }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { DxPivotGridModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxPivotGridModule
-            ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 
@@ -196,23 +180,7 @@ This function allows you to customize cells and modify their content. Common use
             }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { DxPivotGridModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxPivotGridModule
-            ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/api-reference/10 UI Components/dxPolarChart/1 Configuration/annotations/annotations.md
+++ b/api-reference/10 UI Components/dxPolarChart/1 Configuration/annotations/annotations.md
@@ -62,17 +62,6 @@ To create annotations, assign an array of objects to the **annotations[]** prope
         </svg>
     </dx-polar-chart>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxPolarChart/1 Configuration/annotations/annotations.md
+++ b/api-reference/10 UI Components/dxPolarChart/1 Configuration/annotations/annotations.md
@@ -74,24 +74,7 @@ To create annotations, assign an array of objects to the **annotations[]** prope
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxPolarChartModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxPolarChartModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxPolarChart/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
+++ b/api-reference/10 UI Components/dxPolarChart/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
@@ -47,24 +47,7 @@ The following code shows the **commonAnnotationSettings** declaration syntax:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxPolarChartModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxPolarChartModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxPolarChart/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
+++ b/api-reference/10 UI Components/dxPolarChart/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
@@ -34,18 +34,6 @@ The following code shows the **commonAnnotationSettings** declaration syntax:
         </dx-common-annotation-settings>
     </dx-polar-chart>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxPolarChart/1 Configuration/customizeAnnotation.md
+++ b/api-reference/10 UI Components/dxPolarChart/1 Configuration/customizeAnnotation.md
@@ -58,16 +58,7 @@ The following code shows how to use the **customizeAnnotation** function to appl
     }
 
     <!-- tab: app.module.ts -->
-    import { DxPolarChartModule } from 'devextreme-angular';
-    // ...
-    @NgModule({
-        imports: [
-            // ...
-            DxPolarChartModule
-        ],
-        // ...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxPolarChart/1 Configuration/valueAxis/minVisualRangeLength/minVisualRangeLength.md
+++ b/api-reference/10 UI Components/dxPolarChart/1 Configuration/valueAxis/minVisualRangeLength/minVisualRangeLength.md
@@ -47,24 +47,7 @@ Assign a number to this property if the visual range is set on a numeric axis. I
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxPolarChartModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxPolarChartModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 
 ##### Vue

--- a/api-reference/10 UI Components/dxPolarChart/1 Configuration/valueAxis/minVisualRangeLength/minVisualRangeLength.md
+++ b/api-reference/10 UI Components/dxPolarChart/1 Configuration/valueAxis/minVisualRangeLength/minVisualRangeLength.md
@@ -34,18 +34,6 @@ Assign a number to this property if the visual range is set on a numeric axis. I
         </dxi-value-axis>
     </dx-polar-chart>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxPopup/1 Configuration/toolbarItems/options.md
+++ b/api-reference/10 UI Components/dxPopup/1 Configuration/toolbarItems/options.md
@@ -26,24 +26,7 @@ Configures the DevExtreme UI component used as a toolbar item.
     </dx-{widget-name}>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxPopup/1 Configuration/toolbarItems/toolbarItems.md
+++ b/api-reference/10 UI Components/dxPopup/1 Configuration/toolbarItems/toolbarItems.md
@@ -69,24 +69,7 @@ In the following code, two items are defined on the toolbar: one is plain text, 
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### ASP.NET MVC Controls
 

--- a/api-reference/10 UI Components/dxPopup/1 Configuration/toolbarItems/toolbarItems.md
+++ b/api-reference/10 UI Components/dxPopup/1 Configuration/toolbarItems/toolbarItems.md
@@ -59,11 +59,7 @@ In the following code, two items are defined on the toolbar: one is plain text, 
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         refresh () { /* ... */ }
     }

--- a/api-reference/10 UI Components/dxRangeSelector/1 Configuration/scale/aggregateByCategory.md
+++ b/api-reference/10 UI Components/dxRangeSelector/1 Configuration/scale/aggregateByCategory.md
@@ -63,11 +63,7 @@ The following code shows an example of a data source that can be aggregated by c
     import { Component } from '@angular/core';
     import { DataPoint, Service } from './app.service';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         chartData: DataPoint[];
         constructor(service: Service) {

--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/appointmentCollectorTemplate.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/appointmentCollectorTemplate.md
@@ -51,24 +51,7 @@ A template name or container.
     </dx-scheduler>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxSchedulerModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxSchedulerModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/resources/dataSource.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/resources/dataSource.md
@@ -59,11 +59,7 @@ Use one of the following extensions to enable the server to process data accordi
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             store: CustomStore;
             constructor() {

--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/resources/dataSource.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/resources/dataSource.md
@@ -87,24 +87,7 @@ Use one of the following extensions to enable the server to process data accordi
         </dx-{widget-name}>
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                Dx{WidgetName}Module
-            ],
-            providers: [],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/views/appointmentCollectorTemplate.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/views/appointmentCollectorTemplate.md
@@ -58,24 +58,7 @@ A template name or container.
     </dx-scheduler>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxSchedulerModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxSchedulerModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxScheduler/3 Methods/deleteAppointment(appointment).md
+++ b/api-reference/10 UI Components/dxScheduler/3 Methods/deleteAppointment(appointment).md
@@ -58,11 +58,7 @@ If you delete a recurring appointment from the data source, all its occurrences 
     import { Component, ViewChild } from "@angular/core";
     import { Appointment, Service } from './app.service';
     import { DxSchedulerComponent } from "devextreme-angular";
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent  {
         @ViewChild(DxSchedulerComponent, { static: false }) scheduler: DxSchedulerComponent;
         // Prior to Angular 8

--- a/api-reference/10 UI Components/dxTagBox/1 Configuration/tagTemplate.md
+++ b/api-reference/10 UI Components/dxTagBox/1 Configuration/tagTemplate.md
@@ -49,24 +49,7 @@ This template replaces the default tag template. If you need to recreate the def
     </dx-tag-box>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxTagBoxModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxTagBoxModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxTextEditor/1 Configuration/maskRules.md
+++ b/api-reference/10 UI Components/dxTextEditor/1 Configuration/maskRules.md
@@ -70,11 +70,7 @@ The following code snippet demonstrates the use of the function to set a dynamic
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         rules = {
             H: char => char >= 0 && char <= 2,

--- a/api-reference/10 UI Components/dxTextEditor/1 Configuration/maskRules.md
+++ b/api-reference/10 UI Components/dxTextEditor/1 Configuration/maskRules.md
@@ -90,24 +90,7 @@ The following code snippet demonstrates the use of the function to set a dynamic
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
- 
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
- 
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxTextEditor/1 Configuration/readOnly.md
+++ b/api-reference/10 UI Components/dxTextEditor/1 Configuration/readOnly.md
@@ -53,24 +53,7 @@ When this property is set to **true**, the following applies:
         }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                Dx{WidgetName}Module
-            ],
-            providers: [ ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 
@@ -197,24 +180,7 @@ When this property is set to **true**, the following applies:
         }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                Dx{WidgetName}Module
-            ],
-            providers: [ ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/api-reference/10 UI Components/dxTextEditor/1 Configuration/readOnly.md
+++ b/api-reference/10 UI Components/dxTextEditor/1 Configuration/readOnly.md
@@ -38,11 +38,7 @@ When this property is set to **true**, the following applies:
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             myCustomButtonConfig = {
                 onClick: (e) => {
@@ -165,11 +161,7 @@ When this property is set to **true**, the following applies:
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             changeButtonState(e) {
                 if(e.name == 'readOnly') {

--- a/api-reference/10 UI Components/dxTextEditor/3 Methods/getButton(name).md
+++ b/api-reference/10 UI Components/dxTextEditor/3 Methods/getButton(name).md
@@ -27,11 +27,7 @@ Use the returned button instance to call the [Button UI component's methods](/ap
     import { Component, ViewChild } from '@angular/core';
     import { Dx{WidgetName}Component } from 'devextreme-angular';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         @ViewChild('{widgetName}Ref', { static: false }) {widgetName}: Dx{WidgetName}Component;
         // Prior to Angular 8

--- a/api-reference/10 UI Components/dxTreeList/1 Configuration/onContextMenuPreparing.md
+++ b/api-reference/10 UI Components/dxTreeList/1 Configuration/onContextMenuPreparing.md
@@ -101,24 +101,7 @@ In the following code, the **onContextMenuPreparing** function adds a custom ite
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxTreeList/1 Configuration/onContextMenuPreparing.md
+++ b/api-reference/10 UI Components/dxTreeList/1 Configuration/onContextMenuPreparing.md
@@ -78,11 +78,7 @@ In the following code, the **onContextMenuPreparing** function adds a custom ite
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         addMenuItems(e) { 
             if (e.target == 'header') {

--- a/api-reference/10 UI Components/dxTreeList/3 Methods/addRow().md
+++ b/api-reference/10 UI Components/dxTreeList/3 Methods/addRow().md
@@ -52,23 +52,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { DxTreeListModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxTreeListModule
-            ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 
@@ -181,23 +165,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { DxTreeListModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxTreeListModule
-            ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/api-reference/10 UI Components/dxTreeList/3 Methods/addRow().md
+++ b/api-reference/10 UI Components/dxTreeList/3 Methods/addRow().md
@@ -32,11 +32,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             constructor() {
                 this.dataSource = new DataSource({
@@ -145,11 +141,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             constructor() {
                 this.dataSource = new DataSource({

--- a/api-reference/10 UI Components/dxTreeList/3 Methods/getSelectedRowsData().md
+++ b/api-reference/10 UI Components/dxTreeList/3 Methods/getSelectedRowsData().md
@@ -47,24 +47,7 @@ The objects are not processed by the [DataSource](/api-reference/30%20Data%20Lay
     ></dx-tree-list>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxTreeListModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxTreeListModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxTreeList/3 Methods/getSelectedRowsData().md
+++ b/api-reference/10 UI Components/dxTreeList/3 Methods/getSelectedRowsData().md
@@ -24,11 +24,7 @@ The objects are not processed by the [DataSource](/api-reference/30%20Data%20Lay
     import { Component, ViewChild } from '@angular/core';
     import { DxTreeListComponent } from 'devextreme-angular';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         @ViewChild('treeListRef', { static: false }) treeList: DxTreeListComponent;
         // Prior to Angular 8

--- a/api-reference/10 UI Components/dxTreeList/3 Methods/getSelectedRowsData(mode).md
+++ b/api-reference/10 UI Components/dxTreeList/3 Methods/getSelectedRowsData(mode).md
@@ -71,24 +71,7 @@ Returns only leaves' data objects.
     ></dx-tree-list>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxTreeListModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxTreeListModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxTreeList/3 Methods/getSelectedRowsData(mode).md
+++ b/api-reference/10 UI Components/dxTreeList/3 Methods/getSelectedRowsData(mode).md
@@ -48,11 +48,7 @@ Returns only leaves' data objects.
     import { Component, ViewChild } from '@angular/core';
     import { DxTreeListComponent } from 'devextreme-angular';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         @ViewChild('treeListRef', { static: false }) treeList: DxTreeListComponent;
         // Prior to Angular 8

--- a/api-reference/10 UI Components/dxTreeMap/1 Configuration/dataSource.md
+++ b/api-reference/10 UI Components/dxTreeMap/1 Configuration/dataSource.md
@@ -128,24 +128,7 @@ Use one of the following extensions to enable the server to process data accordi
         </dx-tree-map>
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { DxTreeMapModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxTreeMapModule
-            ],
-            providers: [],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/api-reference/10 UI Components/dxTreeMap/1 Configuration/dataSource.md
+++ b/api-reference/10 UI Components/dxTreeMap/1 Configuration/dataSource.md
@@ -106,11 +106,7 @@ Use one of the following extensions to enable the server to process data accordi
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             store: CustomStore;
             constructor() {

--- a/api-reference/10 UI Components/dxTreeView/3 Methods/getSelectedNodes().md
+++ b/api-reference/10 UI Components/dxTreeView/3 Methods/getSelectedNodes().md
@@ -44,24 +44,7 @@ Selected nodes.
     </dx-tree-view>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxTreeViewModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxTreeViewModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxTreeView/3 Methods/getSelectedNodes().md
+++ b/api-reference/10 UI Components/dxTreeView/3 Methods/getSelectedNodes().md
@@ -21,11 +21,7 @@ Selected nodes.
     import { Component, ViewChild } from '@angular/core';
     import { DxTreeViewComponent } from 'devextreme-angular';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         @ViewChild('treeViewRef', { static: false }) treeView: DxTreeViewComponent;
         // Prior to Angular 8

--- a/api-reference/10 UI Components/dxValidationGroup/9 Validation Result/complete.md
+++ b/api-reference/10 UI Components/dxValidationGroup/9 Validation Result/complete.md
@@ -80,11 +80,7 @@ In the following example, a button validates a group of editors with async rules
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         validationGroupName = "myValidationGroup";
 

--- a/api-reference/10 UI Components/dxValidator/8 Validation Rules/AsyncRule/validationCallback.md
+++ b/api-reference/10 UI Components/dxValidator/8 Validation Rules/AsyncRule/validationCallback.md
@@ -77,11 +77,7 @@ The following code shows a generic **validationCallback** implementation for a s
     import { Component } from '@angular/core';
     import { HttpClient } from '@angular/common/http';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         constructor(private httpClient: HttpClient) {
             this.validateAsync = this.validateAsync.bind(this);

--- a/api-reference/10 UI Components/dxValidator/9 Validation Result/complete.md
+++ b/api-reference/10 UI Components/dxValidator/9 Validation Result/complete.md
@@ -60,11 +60,7 @@ In the following example, a button validates an editor with an async rule. The *
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         validationGroupName = "myValidationGroup";
 

--- a/api-reference/10 UI Components/dxVectorMap/1 Configuration/annotations/annotations.md
+++ b/api-reference/10 UI Components/dxVectorMap/1 Configuration/annotations/annotations.md
@@ -73,24 +73,7 @@ To create annotations, assign an array of objects to the **annotations[]** prope
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxVectorMapModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxVectorMapModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxVectorMap/1 Configuration/annotations/annotations.md
+++ b/api-reference/10 UI Components/dxVectorMap/1 Configuration/annotations/annotations.md
@@ -61,17 +61,6 @@ To create annotations, assign an array of objects to the **annotations[]** prope
         </svg>
     </dx-vector-map>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxVectorMap/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
+++ b/api-reference/10 UI Components/dxVectorMap/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
@@ -47,24 +47,7 @@ The following code shows the **commonAnnotationSettings** declaration syntax:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxVectorMapModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxVectorMapModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/10 UI Components/dxVectorMap/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
+++ b/api-reference/10 UI Components/dxVectorMap/1 Configuration/commonAnnotationSettings/commonAnnotationSettings.md
@@ -34,18 +34,6 @@ The following code shows the **commonAnnotationSettings** declaration syntax:
         </dx-common-annotation-settings>
     </dx-vector-map>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/10 UI Components/dxVectorMap/1 Configuration/layers/palette.md
+++ b/api-reference/10 UI Components/dxVectorMap/1 Configuration/layers/palette.md
@@ -52,11 +52,7 @@ Use the [paletteIndex](/api-reference/10%20UI%20Components/dxVectorMap/1%20Confi
     import { Component } from '@angular/core';
     import * as mapsData from 'devextreme/dist/js/vectormap-data/world.js';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         constructor() {
             this.colorizeMap = this.colorizeMap.bind(this);

--- a/api-reference/10 UI Components/dxVectorMap/1 Configuration/layers/palette.md
+++ b/api-reference/10 UI Components/dxVectorMap/1 Configuration/layers/palette.md
@@ -74,24 +74,7 @@ Use the [paletteIndex](/api-reference/10%20UI%20Components/dxVectorMap/1%20Confi
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxVectorMapModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxVectorMapModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/fields/format.md
+++ b/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/fields/format.md
@@ -207,11 +207,7 @@ The following code declares a custom group for the `ShippingDate` data field. Th
     import { Component } from '@angular/core';
     import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         pivotGridDataSource: PivotGridDataSource;
         constructor() {
@@ -420,11 +416,7 @@ Cannot be converted, the cell value is exported without formatting. To export th
         import { Component } from '@angular/core';
         import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             pivotGridDataSource: PivotGridDataSource;
             constructor() {

--- a/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/fields/format.md
+++ b/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/fields/format.md
@@ -203,7 +203,7 @@ The following code declares a custom group for the `ShippingDate` data field. Th
 
 ##### Angular
 
-        <!-- tab: app.component.ts -->
+    <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
     import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 

--- a/api-reference/50 Common/Object Structures/ExcelExportDataGridProps/customizeCell.md
+++ b/api-reference/50 Common/Object Structures/ExcelExportDataGridProps/customizeCell.md
@@ -86,11 +86,7 @@ The following code illustrates how to customize <a href="https://github.com/exce
     import { Workbook } from 'exceljs';
     import saveAs from 'file-saver';
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         onExporting(e) {
             const workbook = new Workbook();

--- a/api-reference/50 Common/Object Structures/ExcelExportPivotGridProps/customizeCell.md
+++ b/api-reference/50 Common/Object Structures/ExcelExportPivotGridProps/customizeCell.md
@@ -77,11 +77,7 @@ In the following code, the **customizeCell** function customizes <a href="https:
     import { Workbook } from 'exceljs';
     import saveAs from 'file-saver';
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         onExporting(e) {
             const workbook = new Workbook();

--- a/api-reference/50 Common/Object Structures/PdfExportDataGridProps/customizeCell.md
+++ b/api-reference/50 Common/Object Structures/PdfExportDataGridProps/customizeCell.md
@@ -67,11 +67,7 @@ An object that describes a cell in a PDF file. Refer to the following <a href="h
     import { jsPDF } from 'jspdf';
     import 'jspdf-autotable';
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         @ViewChild(DxDataGridComponent, { static: false }) dataGrid: DxDataGridComponent;
 

--- a/api-reference/50 Common/Object Structures/positionConfig/of.md
+++ b/api-reference/50 Common/Object Structures/positionConfig/of.md
@@ -114,11 +114,7 @@ This property accepts the following value types:
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
     
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             getWindow() {
                 return window;
@@ -211,11 +207,7 @@ This property accepts the following value types:
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
     
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             eventHandler($event, item) {
                 this.target = $event;

--- a/api-reference/50 Common/utils/excelExporter/exportDataGrid(options).md
+++ b/api-reference/50 Common/utils/excelExporter/exportDataGrid(options).md
@@ -65,11 +65,7 @@ You can call this method at any point in your application. In the example below,
     import { Workbook } from 'exceljs';
     import saveAs from 'file-saver';
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         onExporting(e) {
             const workbook = new Workbook();    

--- a/api-reference/50 Common/utils/excelExporter/exportPivotGrid(options).md
+++ b/api-reference/50 Common/utils/excelExporter/exportPivotGrid(options).md
@@ -64,11 +64,7 @@ You can call this method at any point in your application. In the example below,
     import { Workbook } from 'exceljs';
     import saveAs from 'file-saver';
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         onExporting(e) {
             const workbook = new Workbook();    

--- a/api-reference/50 Common/utils/pdfExporter/exportDataGrid(options).md
+++ b/api-reference/50 Common/utils/pdfExporter/exportDataGrid(options).md
@@ -72,11 +72,7 @@ You can call this method at any point in your application. In this example, we c
     import { jsPDF } from 'jspdf';
     import 'jspdf-autotable';
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         @ViewChild(DxDataGridComponent, { static: false }) dataGrid: DxDataGridComponent;
 

--- a/api-reference/50 Common/utils/ui/dialog/confirm(messageHtml_title).md
+++ b/api-reference/50 Common/utils/ui/dialog/confirm(messageHtml_title).md
@@ -34,11 +34,7 @@ The dialog's title.
     import { Component, AfterViewInit } from '@angular/core';
     import { confirm } from 'devextreme/ui/dialog';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent implements AfterViewInit{
         ngAfterViewInit() { 
             let result = confirm("<i>Are you sure?</i>", "Confirm changes");

--- a/api-reference/50 Common/utils/ui/dialog/custom(options).md
+++ b/api-reference/50 Common/utils/ui/dialog/custom(options).md
@@ -68,11 +68,7 @@ In the following code, the clicked button is identified by its text. The **messa
     import { Component, AfterViewInit } from '@angular/core';
     import { custom } from 'devextreme/ui/dialog';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent implements AfterViewInit {
         ngAfterViewInit() { 
             let myDialog = custom({

--- a/api-reference/50 Common/utils/ui/notify(message_type_displayTime).md
+++ b/api-reference/50 Common/utils/ui/notify(message_type_displayTime).md
@@ -31,11 +31,7 @@ The time interval in milliseconds for which the message is displayed.
     import { Component, AfterViewInit } from '@angular/core';
     import notify from 'devextreme/ui/notify';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent implements AfterViewInit {
         ngAfterViewInit() { 
             notify("Warning message", "warning", 500);

--- a/api-reference/50 Common/utils/ui/notify(options_type_displayTime).md
+++ b/api-reference/50 Common/utils/ui/notify(options_type_displayTime).md
@@ -31,11 +31,7 @@ The time interval in milliseconds for which the message is displayed.
     import { Component, AfterViewInit } from '@angular/core';
     import notify from 'devextreme/ui/notify';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent implements AfterViewInit {
         ngAfterViewInit() { 
             notify({ message: "Error message", width: 300, shading: true }, "error", 500);

--- a/api-reference/50 Common/utils/ui/repaintFloatingActionButton().md
+++ b/api-reference/50 Common/utils/ui/repaintFloatingActionButton().md
@@ -31,11 +31,7 @@ Call this method to repaint the Floating Action Button after you change the **gl
     import config from 'devextreme/core/config';
     import repaintFloatingActionButton from 'devextreme/ui/speed_dial_action/repaint_floating_action_button';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         changeFabConfig() {
             config({

--- a/api-reference/50 Common/utils/ui/themes/current(themeName).md
+++ b/api-reference/50 Common/utils/ui/themes/current(themeName).md
@@ -40,7 +40,6 @@ The theme name passed as a parameter should be the value of the **data-theme** a
             <dx-button text="Change Theme" (onClick)="changeTheme()"></dx-button>
         `
     })
-    
     export class AppComponent {
         @ViewChild(DxDataGridComponent, { static: false }) dataGrid: DxDataGridComponent;
         @ViewChild(DxButtonComponent, { static: false }) button: DxButtonComponent;

--- a/api-reference/_hidden/GridBaseColumn/calculateCellValue.md
+++ b/api-reference/_hidden/GridBaseColumn/calculateCellValue.md
@@ -59,11 +59,7 @@ In the following code, the **calculateCellValue** function is used to create an 
     import { Component } from '@angular/core';
     import { Product, Service } from './app.service';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         products: Product[];
         constructor(service: Service) {
@@ -289,11 +285,7 @@ To invoke the default behavior, call the **defaultCalculateCellValue** function 
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         calculateCellValue(rowData) {
             // ...

--- a/api-reference/_hidden/GridBaseColumn/calculateSortValue.md
+++ b/api-reference/_hidden/GridBaseColumn/calculateSortValue.md
@@ -39,24 +39,7 @@ This property accepts the name of the [data source field](/api-reference/10%20UI
     </dx-{widget-name}>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser'; 
-    import { NgModule } from '@angular/core'; 
-    import { AppComponent } from './app.component'; 
-    import { DxDataGridModule } from 'devextreme-angular'; 
-    
-    @NgModule({ 
-        declarations: [ 
-            AppComponent 
-        ], 
-        imports: [ 
-            BrowserModule, 
-            DxDataGridModule 
-        ], 
-        providers: [ ], 
-        bootstrap: [AppComponent] 
-    }) 
-    
-    export class AppModule { }
+    #include angular-app-module-ts
     
 
 ##### Vue
@@ -143,24 +126,7 @@ This property accepts the name of the [data source field](/api-reference/10%20UI
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser'; 
-    import { NgModule } from '@angular/core'; 
-    import { AppComponent } from './app.component'; 
-    import { DxDataGridModule } from 'devextreme-angular'; 
-    
-    @NgModule({ 
-        declarations: [ 
-            AppComponent 
-        ], 
-        imports: [ 
-            BrowserModule, 
-            DxDataGridModule 
-        ], 
-        providers: [ ], 
-        bootstrap: [AppComponent] 
-    }) 
-    
-    export class AppModule { }
+    #include angular-app-module-ts
     
 ##### Vue
 

--- a/api-reference/_hidden/GridBaseColumn/cssClass.md
+++ b/api-reference/_hidden/GridBaseColumn/cssClass.md
@@ -50,11 +50,7 @@ In the following code, this property is assigned a `cell-highlighted` CSS class 
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employees = [{
             ID: 1,

--- a/api-reference/_hidden/GridBaseColumn/cssClass.md
+++ b/api-reference/_hidden/GridBaseColumn/cssClass.md
@@ -64,24 +64,7 @@ In the following code, this property is assigned a `cell-highlighted` CSS class 
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
     
     <!-- tab: app.component.css -->
     ::ng-deep .dx-data-row .cell-highlighted {

--- a/api-reference/_hidden/GridBaseColumn/customizeText.md
+++ b/api-reference/_hidden/GridBaseColumn/customizeText.md
@@ -57,11 +57,7 @@ The text the cell should display.
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         customizeText(cellInfo) {
             return cellInfo.value + " &deg;C";

--- a/api-reference/_hidden/GridBaseColumn/customizeText.md
+++ b/api-reference/_hidden/GridBaseColumn/customizeText.md
@@ -69,25 +69,7 @@ The text the cell should display.
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [
-        ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 #####Vue
 

--- a/api-reference/_hidden/GridBaseColumn/editorOptions.md
+++ b/api-reference/_hidden/GridBaseColumn/editorOptions.md
@@ -52,24 +52,7 @@ Because of this dependency, **editorOptions** cannot be typed and are not implem
     </dx-{widget-name}>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/_hidden/GridBaseColumn/filterValues.md
+++ b/api-reference/_hidden/GridBaseColumn/filterValues.md
@@ -44,24 +44,7 @@ If the **headerFilter**.[groupInterval](/api-reference/_hidden/GridBaseColumn/he
     </dx-{widget-name}>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/_hidden/GridBaseColumn/format.md
+++ b/api-reference/_hidden/GridBaseColumn/format.md
@@ -42,24 +42,7 @@ In the following code, the *"fixedPoint"* [format type](/api-reference/50%20Comm
     </dx-{widget-name}>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/_hidden/GridBaseColumn/headerFilter/groupInterval.md
+++ b/api-reference/_hidden/GridBaseColumn/headerFilter/groupInterval.md
@@ -54,11 +54,7 @@ For date columns, set this property to one of the accepted string values above. 
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         calculateFilterExpression(value, operation, target) {
             const column = this as any;

--- a/api-reference/_hidden/GridBaseColumn/headerFilter/groupInterval.md
+++ b/api-reference/_hidden/GridBaseColumn/headerFilter/groupInterval.md
@@ -71,24 +71,7 @@ For date columns, set this property to one of the accepted string values above. 
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/_hidden/GridBaseColumn/lookup/allowClearing.md
+++ b/api-reference/_hidden/GridBaseColumn/lookup/allowClearing.md
@@ -32,11 +32,7 @@ To specify this property based on a condition, set the [showClearButton](/api-re
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         onEditorPreparing(e) {
             if (/* a condition to set the property's value */) {

--- a/api-reference/_hidden/GridBaseColumn/lookup/allowClearing.md
+++ b/api-reference/_hidden/GridBaseColumn/lookup/allowClearing.md
@@ -46,23 +46,7 @@ To specify this property based on a condition, set the [showClearButton](/api-re
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
     <!-- tab: app.component.html -->
     <dx-{widget-name} ...

--- a/api-reference/_hidden/GridBaseColumn/lookup/displayExpr.md
+++ b/api-reference/_hidden/GridBaseColumn/lookup/displayExpr.md
@@ -56,11 +56,7 @@ Values in a lookup column are sorted by the **valueExpr** field. Implement the c
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         calculateSortValue (data) {
             const column = this as any;

--- a/api-reference/_hidden/GridBaseColumn/lookup/displayExpr.md
+++ b/api-reference/_hidden/GridBaseColumn/lookup/displayExpr.md
@@ -70,24 +70,7 @@ Values in a lookup column are sorted by the **valueExpr** field. Implement the c
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/_hidden/GridBaseColumn/setCellValue.md
+++ b/api-reference/_hidden/GridBaseColumn/setCellValue.md
@@ -60,11 +60,7 @@ This function allows you to process user input before it is saved to the data so
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         setCellValue (newData, value, currentRowData) {
             newData.Count = value;
@@ -206,11 +202,7 @@ If you need to perform asynchronous operations in the **setCellValue** function,
     import { HttpClient, HttpParams } from '@angular/common/http';
     import 'rxjs/add/operator/toPromise';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         constructor(private httpClient: HttpClient) {
             this.setCellValue = this.setCellValue.bind(this);

--- a/api-reference/_hidden/GridBaseColumn/setCellValue.md
+++ b/api-reference/_hidden/GridBaseColumn/setCellValue.md
@@ -73,24 +73,7 @@ This function allows you to process user input before it is saved to the data so
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 #####Vue
 

--- a/api-reference/_hidden/dxDataGridColumn/calculateGroupValue.md
+++ b/api-reference/_hidden/dxDataGridColumn/calculateGroupValue.md
@@ -41,24 +41,7 @@ This property accepts the name of the data source field that provides values use
     </dx-data-grid>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser'; 
-    import { NgModule } from '@angular/core'; 
-    import { AppComponent } from './app.component'; 
-    import { DxDataGridModule } from 'devextreme-angular'; 
-    
-    @NgModule({ 
-        declarations: [ 
-            AppComponent 
-        ], 
-        imports: [ 
-            BrowserModule, 
-            DxDataGridModule 
-        ], 
-        providers: [ ], 
-        bootstrap: [AppComponent] 
-    }) 
-    
-    export class AppModule { }
+    #include angular-app-module-ts
     
 
 ##### Vue
@@ -183,24 +166,7 @@ This property accepts the name of the data source field that provides values use
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser'; 
-    import { NgModule } from '@angular/core'; 
-    import { AppComponent } from './app.component'; 
-    import { DxDataGridModule } from 'devextreme-angular'; 
-    
-    @NgModule({ 
-        declarations: [ 
-            AppComponent 
-        ], 
-        imports: [ 
-            BrowserModule, 
-            DxDataGridModule 
-        ], 
-        providers: [ ], 
-        bootstrap: [AppComponent] 
-    }) 
-    
-    export class AppModule { }
+    #include angular-app-module-ts
     
 
 ##### Vue

--- a/api-reference/_hidden/dxDataGridColumn/format.md
+++ b/api-reference/_hidden/dxDataGridColumn/format.md
@@ -53,11 +53,7 @@ Cannot be converted, the cell value is exported without formatting. To export th
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             customizeText(options) {
                 return options.valueText;

--- a/api-reference/_hidden/dxDataGridColumn/format.md
+++ b/api-reference/_hidden/dxDataGridColumn/format.md
@@ -65,24 +65,7 @@ Cannot be converted, the cell value is exported without formatting. To export th
         }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { DxDataGridModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxDataGridModule
-            ],
-            providers: [],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/api-reference/_hidden/dxDataGridColumnButton/template.md
+++ b/api-reference/_hidden/dxDataGridColumnButton/template.md
@@ -100,24 +100,7 @@ When you use a custom button template, the [onClick](/api-reference/_hidden/dxDa
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/_hidden/dxDataGridColumnButton/template.md
+++ b/api-reference/_hidden/dxDataGridColumnButton/template.md
@@ -88,11 +88,7 @@ When you use a custom button template, the [onClick](/api-reference/_hidden/dxDa
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         logMyCommandClick() {
             console.log('My command was clicked');

--- a/api-reference/_hidden/dxFileManagerContextMenu/items/items.md
+++ b/api-reference/_hidden/dxFileManagerContextMenu/items/items.md
@@ -68,12 +68,7 @@ To add a predefined item to the context menu, add its [name](/api-reference/_hid
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         // ...      
     }
@@ -232,12 +227,7 @@ To add a custom context menu item, specify its [text](/api-reference/_hidden/dxM
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         onItemClick(e){
             if(e.itemData.options.extension) {

--- a/api-reference/_hidden/dxFileManagerContextMenu/items/items.md
+++ b/api-reference/_hidden/dxFileManagerContextMenu/items/items.md
@@ -79,19 +79,7 @@ To add a predefined item to the context menu, add its [name](/api-reference/_hid
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            DxFileManagerModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 
@@ -259,19 +247,7 @@ To add a custom context menu item, specify its [text](/api-reference/_hidden/dxM
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            DxFileManagerModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/_hidden/dxFileManagerContextMenuItem/items.md
+++ b/api-reference/_hidden/dxFileManagerContextMenuItem/items.md
@@ -66,19 +66,7 @@ The FileManager UI component allows you to add default and create custom context
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            DxFileManagerModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/_hidden/dxFileManagerContextMenuItem/items.md
+++ b/api-reference/_hidden/dxFileManagerContextMenuItem/items.md
@@ -52,19 +52,6 @@ The FileManager UI component allows you to add default and create custom context
         <!-- ... -->
     </dx-file-manager>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        //...
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/api-reference/_hidden/dxFileManagerToolbarItem/options.md
+++ b/api-reference/_hidden/dxFileManagerToolbarItem/options.md
@@ -27,24 +27,7 @@ Default toolbar items support the following options:
     </dx-file-manager>    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFileManagerModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/_hidden/dxFilterBuilderField/editorOptions.md
+++ b/api-reference/_hidden/dxFilterBuilderField/editorOptions.md
@@ -22,24 +22,7 @@ Because **editorOptions** depend on the **dataType**, they cannot be typed and a
     </dx-filter-builder>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFilterBuilderModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFilterBuilderModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/_hidden/dxFilterBuilderField/lookup/allowClearing.md
+++ b/api-reference/_hidden/dxFilterBuilderField/lookup/allowClearing.md
@@ -32,11 +32,7 @@ If you need to specify this property based on a condition, set the [showClearBut
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         onEditorPreparing(e) {
             if (/* a condition to set the property's value */) {

--- a/api-reference/_hidden/dxFilterBuilderField/lookup/allowClearing.md
+++ b/api-reference/_hidden/dxFilterBuilderField/lookup/allowClearing.md
@@ -46,23 +46,7 @@ If you need to specify this property based on a condition, set the [showClearBut
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
     <!-- tab: app.component.html -->
     <dx-{widget-name} ...

--- a/api-reference/_hidden/dxGanttToolbar/items.md
+++ b/api-reference/_hidden/dxGanttToolbar/items.md
@@ -85,20 +85,7 @@ The Gantt UI component allows you to add default and create custom toolbar items
     }    
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxGanttModule } from 'devextreme-angular';
-
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxGanttModule
-        ],        
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/api-reference/_hidden/dxGanttToolbar/items.md
+++ b/api-reference/_hidden/dxGanttToolbar/items.md
@@ -70,7 +70,6 @@ The Gantt UI component allows you to add default and create custom toolbar items
         styleUrls: ['./app.component.css'],
         providers: [Service]
     })
-
     export class AppComponent {
         constructor(service: Service) {
             this.customButtonOptions = {

--- a/api-reference/_hidden/dxHtmlEditorMention/dataSource.md
+++ b/api-reference/_hidden/dxHtmlEditorMention/dataSource.md
@@ -53,11 +53,7 @@ Use one of the following extensions to enable the server to process data accordi
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             store: CustomStore;
             constructor() {

--- a/api-reference/_hidden/dxHtmlEditorMention/dataSource.md
+++ b/api-reference/_hidden/dxHtmlEditorMention/dataSource.md
@@ -75,24 +75,7 @@ Use one of the following extensions to enable the server to process data accordi
         </dx-{widget-name}>
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                Dx{WidgetName}Module
-            ],
-            providers: [],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/api-reference/_hidden/dxHtmlEditorVariables/dataSource.md
+++ b/api-reference/_hidden/dxHtmlEditorVariables/dataSource.md
@@ -53,11 +53,7 @@ Use one of the following extensions to enable the server to process data accordi
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             store: CustomStore;
             constructor() {

--- a/api-reference/_hidden/dxHtmlEditorVariables/dataSource.md
+++ b/api-reference/_hidden/dxHtmlEditorVariables/dataSource.md
@@ -75,24 +75,7 @@ Use one of the following extensions to enable the server to process data accordi
         </dx-{widget-name}>
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                Dx{WidgetName}Module
-            ],
-            providers: [],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/api-reference/_hidden/dxToolbarItem/options.md
+++ b/api-reference/_hidden/dxToolbarItem/options.md
@@ -21,24 +21,7 @@ Configures the DevExtreme UI component used as a toolbar item.
     </dx-toolbar>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxToolbarModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxToolbarModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/Button/00 Getting Started with Button/02 Create a Button.md
+++ b/concepts/05 UI Components/Button/00 Getting Started with Button/02 Create a Button.md
@@ -47,23 +47,7 @@
     export class AppComponent { }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { DxButtonModule } from 'devextreme-angular';
-    import { AppComponent } from './app.component';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxButtonModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/Button/00 Getting Started with Button/02 Create a Button.md
+++ b/concepts/05 UI Components/Button/00 Getting Started with Button/02 Create a Button.md
@@ -39,11 +39,7 @@
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent { }
 
     <!-- tab: app.module.ts -->

--- a/concepts/05 UI Components/Button/00 Getting Started with Button/04 Handle the Click Event.md
+++ b/concepts/05 UI Components/Button/00 Getting Started with Button/04 Handle the Click Event.md
@@ -24,11 +24,7 @@ To respond to user clicks, write an [onClick](/api-reference/10%20UI%20Component
     import { Component } from '@angular/core';
     import notify from 'devextreme/ui/notify';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         showMessage = () => {
             notify("The button was clicked");

--- a/concepts/05 UI Components/ButtonGroup/00 Getting Started with ButtonGroup/1 Create the ButtonGroup.md
+++ b/concepts/05 UI Components/ButtonGroup/00 Getting Started with ButtonGroup/1 Create the ButtonGroup.md
@@ -46,24 +46,7 @@ You can use the following library- or framework-specific code to create the Butt
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxButtonGroupModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxButtonGroupModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/ButtonGroup/00 Getting Started with ButtonGroup/1 Create the ButtonGroup.md
+++ b/concepts/05 UI Components/ButtonGroup/00 Getting Started with ButtonGroup/1 Create the ButtonGroup.md
@@ -36,11 +36,7 @@ You can use the following library- or framework-specific code to create the Butt
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
 
     }

--- a/concepts/05 UI Components/ButtonGroup/00 Getting Started with ButtonGroup/3 Add Buttons to the ButtonGroup.md
+++ b/concepts/05 UI Components/ButtonGroup/00 Getting Started with ButtonGroup/3 Add Buttons to the ButtonGroup.md
@@ -38,11 +38,7 @@ Assign the array to the [items](/api-reference/10%20UI%20Components/dxButtonGrou
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         fontStyles: Array<{ icon: string, style: string }> = [{
             icon: "bold",

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/02 Create a DataGrid.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/02 Create a DataGrid.md
@@ -46,11 +46,7 @@
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
 
     }

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/02 Create a DataGrid.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/02 Create a DataGrid.md
@@ -56,24 +56,7 @@
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxDataGridModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxDataGridModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
     <!-- tab: app.component.css -->
     #dataGrid {

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/05 Bind the DataGrid to Data.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/05 Bind the DataGrid to Data.md
@@ -184,11 +184,7 @@ The DataGrid component can load and update data from different data source types
     import { Component } from '@angular/core';
     import { Employee, EmployeesService } from './employees.service';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employees: Employee[] = [];
 

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/50 Select Records.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/50 Select Records.md
@@ -62,11 +62,7 @@ You can obtain the selected record's data in the [onSelectionChanged](/api-refer
     import { Component } from '@angular/core';
     import { Employee, EmployeesService } from './employees.service';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // ...
         selectedEmployee: Employee;

--- a/concepts/05 UI Components/DataGrid/15 Columns/35 Hide a Column Using the API.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/35 Hide a Column Using the API.md
@@ -18,11 +18,7 @@ A column is considered hidden when its [visible](/api-reference/_hidden/GridBase
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         isEmailVisible: boolean = true;
         hideEmails() {

--- a/concepts/05 UI Components/DataGrid/15 Columns/35 Hide a Column Using the API.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/35 Hide a Column Using the API.md
@@ -31,24 +31,7 @@ A column is considered hidden when its [visible](/api-reference/_hidden/GridBase
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxDataGridModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxDataGridModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/DataGrid/20 Editing/20 API/40 Get Current Cell Values.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/20 API/40 Get Current Cell Values.md
@@ -30,11 +30,7 @@ The **cellValue(rowIndex, dataField)** method requires a row index. Use the [get
     import { Component, ViewChild } from "@angular/core";
     import { DxDataGridComponent } from "devextreme-angular";
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         @ViewChild(DxDataGridComponent, { static: false }, { static: false }) dataGrid: DxDataGridComponent
         // Prior to Angular 8
@@ -194,11 +190,7 @@ To access a cell value after the user has edited it, but before it is saved to t
     import { Component } from "@angular/core";
     import { DxDataGridComponent } from "devextreme-angular";
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         setCellValue (newData, value, currentRowData) {
             // currentRowData contains the row data before the edit

--- a/concepts/05 UI Components/DataGrid/20 Editing/20 API/40 Get Current Cell Values.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/20 API/40 Get Current Cell Values.md
@@ -57,23 +57,7 @@ The **cellValue(rowIndex, dataField)** method requires a row index. Use the [get
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxDataGridModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxDataGridModule
-        ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 
@@ -223,23 +207,7 @@ To access a cell value after the user has edited it, but before it is saved to t
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxDataGridModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxDataGridModule
-        ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/DataGrid/99 How To/Bind a Lookup Column to a Custom Data Source.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Bind a Lookup Column to a Custom Data Source.md
@@ -43,7 +43,7 @@ In the following code snippet, `Author Name` is a [lookup column](/concepts/05%2
     import CustomStore from "devextreme/data/custom_store";
     import "rxjs/add/operator/toPromise";
 
-    @Component({ ... })
+    #include angular-component-decorator
     export class AppComponent {
         lookupDataSource = {};
         constructor(@Inject(HttpClient) httpClient: HttpClient) {

--- a/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/10 Specify a Custom Data Source.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/10 Specify a Custom Data Source.md
@@ -47,11 +47,7 @@ The following code shows how to specify a custom data source:
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         headerFilterData: any;
         constructor() {

--- a/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/10 Specify a Custom Data Source.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/10 Specify a Custom Data Source.md
@@ -69,24 +69,7 @@ The following code shows how to specify a custom data source:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/20 Map Data Source Fields.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/20 Map Data Source Fields.md
@@ -53,11 +53,7 @@ In the following code, the `categoryName` and `categoryId` fields are mapped to 
     import { Component } from '@angular/core';
     import ArrayStore from 'devextreme/data/array_store';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         headerFilterData;
         constructor() {

--- a/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/20 Map Data Source Fields.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/20 Map Data Source Fields.md
@@ -84,24 +84,7 @@ In the following code, the `categoryName` and `categoryId` fields are mapped to 
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/30 Change the Generated Data Source.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/30 Change the Generated Data Source.md
@@ -68,24 +68,7 @@ In the following code, the **postProcess** function adds a custom item to the ge
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/30 Change the Generated Data Source.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/30 Change the Generated Data Source.md
@@ -46,11 +46,7 @@ In the following code, the **postProcess** function adds a custom item to the ge
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         customizeHeaderFilterData(options) {
             options.dataSource.postProcess = (results) => {

--- a/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/40 Customize Item Appearance.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/40 Customize Item Appearance.md
@@ -81,24 +81,7 @@ You can use [templates](/api-reference/50%20Common/Object%20Structures/template 
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/40 Customize Item Appearance.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/40 Customize Item Appearance.md
@@ -52,11 +52,7 @@ You can use [templates](/api-reference/50%20Common/Object%20Structures/template 
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         headerFilterData: any;
         constructor() {

--- a/concepts/05 UI Components/DataGrid/99 How To/Dynamically Change Editor Properties in the Editing State.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Dynamically Change Editor Properties in the Editing State.md
@@ -58,24 +58,7 @@ Use this handler's **editorOptions** parameter to change editor properties. The 
         }
         
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { DxDataGridModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxDataGridModule
-            ],
-            providers: [ ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/concepts/05 UI Components/DataGrid/99 How To/Dynamically Change Editor Properties in the Editing State.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Dynamically Change Editor Properties in the Editing State.md
@@ -43,11 +43,7 @@ Use this handler's **editorOptions** parameter to change editor properties. The 
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             // ...
             onEditorPreparing(e) {
@@ -198,11 +194,7 @@ Specify **setCellValue** for those columns whose editors should affect other edi
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             // ...
             setCellValue(newData, value) {

--- a/concepts/05 UI Components/DataGrid/99 How To/Dynamically Change Form Item Properties in the Editing State.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Dynamically Change Form Item Properties in the Editing State.md
@@ -76,24 +76,7 @@ This handler is used to save the key of the row that enters the editing state, a
         }
         
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { DxDataGridModule } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxDataGridModule
-            ],
-            providers: [ ],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/concepts/05 UI Components/DataGrid/99 How To/Dynamically Change Form Item Properties in the Editing State.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Dynamically Change Form Item Properties in the Editing State.md
@@ -62,11 +62,7 @@ This handler is used to save the key of the row that enters the editing state, a
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             rowKey: any = -1;
             // ...
@@ -260,11 +256,7 @@ This function allows you to change form item properties dynamically. Within this
         <!-- tab: app.component.ts -->
         import { Component, ViewChild } from '@angular/core';
         import { DxDataGridComponent } from 'devextreme-angular';
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {            
             @ViewChild(DxDataGridComponent, { static: false }) dataGrid: DxDataGridComponent;            
             // Prior to Angular 8
@@ -415,11 +407,7 @@ Specify **setCellValue** for those columns whose editors affect other form items
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             // ...
             setCellValue(newData, value) {

--- a/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/05 Create the DateBox.md
+++ b/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/05 Create the DateBox.md
@@ -36,11 +36,7 @@ Use the following code to create a basic DateBox:
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         
     }

--- a/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/05 Create the DateBox.md
+++ b/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/05 Create the DateBox.md
@@ -46,24 +46,7 @@ Use the following code to create a basic DateBox:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxDateBoxModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxDateBoxModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/13 Set the Accepted Date Range.md
+++ b/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/13 Set the Accepted Date Range.md
@@ -24,11 +24,7 @@ To define the range from which users can select dates, specify the [min](/api-re
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         minDate: Date = new Date(1900, 0, 1);
         now: Date = new Date();

--- a/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/15 Set the Value.md
+++ b/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/15 Set the Value.md
@@ -22,11 +22,7 @@ To set the UI component's value, specify the [value](/api-reference/10%20UI%20Co
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // ...
         now: Date = new Date();

--- a/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/20 Handle the Value Change Event.md
+++ b/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/20 Handle the Value Change Event.md
@@ -24,11 +24,7 @@ To handle value changes, implement the [onValueChanged](/api-reference/10%20UI%2
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // ...
         onValueChanged(e) {

--- a/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/25 Disable Specific Dates.md
+++ b/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/25 Disable Specific Dates.md
@@ -55,11 +55,7 @@ To prevent users from setting specific dates, use the [disabledDates](/api-refer
     import { Component } from '@angular/core';
     import { AppService } from './app.service';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // ...
         holidays: Date[];

--- a/concepts/05 UI Components/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
+++ b/concepts/05 UI Components/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
@@ -70,24 +70,7 @@ In addition, you can specify the [minSize](/api-reference/10%20UI%20Components/d
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from "@angular/platform-browser";
-    import { NgModule } from "@angular/core";
-    import { AppComponent } from "./app.component";
-
-    import { DxDrawerModule } from "devextreme-angular";
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxDrawerModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
     <!-- tab: app.component.css -->
     ::ng-deep .dx-overlay-content {

--- a/concepts/05 UI Components/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
+++ b/concepts/05 UI Components/Drawer/Getting Started with Navigation Drawer/00 Create the Drawer.md
@@ -56,19 +56,6 @@ In addition, you can specify the [minSize](/api-reference/10%20UI%20Components/d
         <div>View content</div>
     </dx-drawer>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from "@angular/core";
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/concepts/05 UI Components/Drawer/Getting Started with Navigation Drawer/10 Open and Close the Drawer.md
+++ b/concepts/05 UI Components/Drawer/Getting Started with Navigation Drawer/10 Open and Close the Drawer.md
@@ -62,12 +62,7 @@ In the following code, a toolbar button outside the Drawer opens and closes it:
     <!-- tab: app.component.ts -->
     import { Component } from "@angular/core";
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         isDrawerOpen: Boolean = false;
         buttonOptions: any = {

--- a/concepts/05 UI Components/Drawer/Getting Started with Navigation Drawer/15 Implement Navigation.md
+++ b/concepts/05 UI Components/Drawer/Getting Started with Navigation Drawer/15 Implement Navigation.md
@@ -111,11 +111,7 @@ Each list item should navigate to a different view. To implement this, follow th
     <!-- tab: app.component.ts -->
     import { Component } from "@angular/core";
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         navigation: any[] = [
             { id: 1, text: "Inbox", icon: "message", path: "inbox" },

--- a/concepts/05 UI Components/DropDownButton/00 Getting Started with DropDownButton/10 Create a DropDownButton.md
+++ b/concepts/05 UI Components/DropDownButton/00 Getting Started with DropDownButton/10 Create a DropDownButton.md
@@ -46,24 +46,7 @@ You can use the following code to create a DropDownButton:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxDropDownButtonModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxDropDownButtonModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/DropDownButton/00 Getting Started with DropDownButton/10 Create a DropDownButton.md
+++ b/concepts/05 UI Components/DropDownButton/00 Getting Started with DropDownButton/10 Create a DropDownButton.md
@@ -36,11 +36,7 @@ You can use the following code to create a DropDownButton:
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         
     }

--- a/concepts/05 UI Components/FileManager/00 Getting Started with File Manager/10 Create a File Manager.md
+++ b/concepts/05 UI Components/FileManager/00 Getting Started with File Manager/10 Create a File Manager.md
@@ -21,22 +21,7 @@ The following code creates the FileManager UI component and adds it to your page
     </dx-file-manager>  
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/FileManager/00 Getting Started with File Manager/20 Bind the File Manager Component to a File System.md
+++ b/concepts/05 UI Components/FileManager/00 Getting Started with File Manager/20 Bind the File Manager Component to a File System.md
@@ -67,12 +67,7 @@ In the example below, the FileManager UI component displays hierarchical data st
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';    
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileItems = [{
             name: "Documents",

--- a/concepts/05 UI Components/FileManager/00 Getting Started with File Manager/20 Bind the File Manager Component to a File System.md
+++ b/concepts/05 UI Components/FileManager/00 Getting Started with File Manager/20 Bind the File Manager Component to a File System.md
@@ -98,22 +98,7 @@ In the example below, the FileManager UI component displays hierarchical data st
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/FileManager/10 Bind to File Systems/10 Object File System.md
+++ b/concepts/05 UI Components/FileManager/10 Bind to File Systems/10 Object File System.md
@@ -101,22 +101,7 @@ In the example below, the FileManager UI component displays hierarchical data st
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 
@@ -339,22 +324,7 @@ If the data source's field names differ from the standard field names mentioned 
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/FileManager/10 Bind to File Systems/10 Object File System.md
+++ b/concepts/05 UI Components/FileManager/10 Bind to File Systems/10 Object File System.md
@@ -70,12 +70,7 @@ In the example below, the FileManager UI component displays hierarchical data st
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';    
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileItems = [{
             name: "Documents",
@@ -287,12 +282,7 @@ If the data source's field names differ from the standard field names mentioned 
     import { Component } from '@angular/core';
     import ObjectFileSystemProvider from 'devextreme/file_management/object_provider';   
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         fileItems: object[];
         objectFileProvider: ObjectFileSystemProvider;

--- a/concepts/05 UI Components/FileManager/10 Bind to File Systems/20 Remote File System.md
+++ b/concepts/05 UI Components/FileManager/10 Bind to File Systems/20 Remote File System.md
@@ -36,12 +36,7 @@ The data object, which is sent back from the server, contains attributes that st
     import { Component } from '@angular/core';
     import RemoteFileSystemProvider from 'devextreme/file_management/remote_provider';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: 'app/app.component.html',
-        styleUrls: ['app/app.component.css']
-    })  
-
+    #include angular-component-decorator
     export class AppComponent {
         remoteFileProvider: RemoteFileSystemProvider;
 

--- a/concepts/05 UI Components/FileManager/10 Bind to File Systems/20 Remote File System.md
+++ b/concepts/05 UI Components/FileManager/10 Bind to File Systems/20 Remote File System.md
@@ -53,20 +53,7 @@ The data object, which is sent back from the server, contains attributes that st
     }
     
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule} from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/FileManager/10 Bind to File Systems/30 Custom File System.md
+++ b/concepts/05 UI Components/FileManager/10 Bind to File Systems/30 Custom File System.md
@@ -41,12 +41,7 @@ Assign the [Custom](/api-reference/10%20UI%20Components/dxFileManager/5%20File%2
     import { Component } from '@angular/core';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: 'app/app.component.html',
-        styleUrls: ['app/app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         customFileProvider: CustomFileSystemProvider;
 

--- a/concepts/05 UI Components/FileManager/10 Bind to File Systems/30 Custom File System.md
+++ b/concepts/05 UI Components/FileManager/10 Bind to File Systems/30 Custom File System.md
@@ -72,20 +72,7 @@ Assign the [Custom](/api-reference/10%20UI%20Components/dxFileManager/5%20File%2
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule} from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        declarations: [AppComponent],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/FileManager/30 Validation/10 Permissions.md
+++ b/concepts/05 UI Components/FileManager/30 Validation/10 Permissions.md
@@ -45,11 +45,7 @@ The UI component also has the [allowedFileExtensions](/api-reference/10%20UI%20C
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         allowedFileExtensions: string[];
         

--- a/concepts/05 UI Components/FileManager/30 Validation/10 Permissions.md
+++ b/concepts/05 UI Components/FileManager/30 Validation/10 Permissions.md
@@ -60,22 +60,7 @@ The UI component also has the [allowedFileExtensions](/api-reference/10%20UI%20C
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/FileManager/30 Validation/20 Upload Settings.md
+++ b/concepts/05 UI Components/FileManager/30 Validation/20 Upload Settings.md
@@ -42,11 +42,7 @@ The UI component allows you to configure upload settings:
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         //...
     }

--- a/concepts/05 UI Components/FileManager/30 Validation/20 Upload Settings.md
+++ b/concepts/05 UI Components/FileManager/30 Validation/20 Upload Settings.md
@@ -52,22 +52,7 @@ The UI component allows you to configure upload settings:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileManagerModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileManagerModule
-        ],
-        //...
-    })
-    export class AppModule { }    
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/05 Upload Mode.md
+++ b/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/05 Upload Mode.md
@@ -50,22 +50,7 @@ The following examples show how to configure the FileUploader for each upload mo
         }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-        import { DxFileUploaderModule } from 'devextreme-angular';
-        
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxFileUploaderModule
-            ],
-            //...
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 
@@ -188,22 +173,7 @@ The following examples show how to configure the FileUploader for each upload mo
         }
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-        import { DxFileUploaderModule } from 'devextreme-angular';
-        
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                DxFileUploaderModule
-            ],
-            //...
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/05 Upload Mode.md
+++ b/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/05 Upload Mode.md
@@ -36,19 +36,6 @@ The following examples show how to configure the FileUploader for each upload mo
             uploadUrl="https://mydomain.com/MyUploadService">
         </dx-file-uploader>  
 
-        <!-- tab: app.component.ts -->
-        import { Component } from '@angular/core';    
-
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
-
-        export class AppComponent {
-            //...
-        }
-
         <!-- tab: app.module.ts -->
         #include angular-app-module-ts
 
@@ -162,11 +149,7 @@ The following examples show how to configure the FileUploader for each upload mo
         <!-- tab: app.component.ts -->
         import { Component } from '@angular/core';    
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
 
         export class AppComponent {
             //...

--- a/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/07 Chunk Upload.md
+++ b/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/07 Chunk Upload.md
@@ -26,20 +26,7 @@ Chunk upload allows large files to be divided into parts called "chunks" and sen
         uploadMode="useButtons" <!-- or "instantly" -->
         uploadUrl="https://mydomain.com/MyUploadService"
         [chunkSize]="400000"> <!-- 400 KB -->>
-    </dx-file-uploader>  
-
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';    
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
-    export class AppComponent {
-        //...
-    }
+    </dx-file-uploader>
 
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts

--- a/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/07 Chunk Upload.md
+++ b/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/07 Chunk Upload.md
@@ -42,22 +42,7 @@ Chunk upload allows large files to be divided into parts called "chunks" and sen
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-    import { DxFileUploaderModule } from 'devextreme-angular';
-    
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFileUploaderModule
-        ],
-        //...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/10 Additional Parameters in a Request.md
+++ b/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/10 Additional Parameters in a Request.md
@@ -57,12 +57,7 @@ If the [uploadMode](/api-reference/10%20UI%20Components/dxFileUploader/1%20Confi
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';    
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         employee = { id: 1, name: "John Heart", position: "CEO", office: 614 };
         uploadUrl = "https://mydomain.com/MyUploadService";
@@ -315,12 +310,7 @@ When the **uploadMode** is *"useForm"*, define the parameters within hidden inpu
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';    
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-
+    #include angular-component-decorator
     export class AppComponent {
         employee = { id: 1, name: "John Heart", position: "CEO", office: 614 };
         employeeId: any;

--- a/concepts/05 UI Components/FileUploader/99 How To/10 Specify a Header for the Request.md
+++ b/concepts/05 UI Components/FileUploader/99 How To/10 Specify a Header for the Request.md
@@ -38,22 +38,7 @@ Use the [uploadHeaders](/api-reference/10%20UI%20Components/dxFileUploader/1%20C
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFileUploaderModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [AppComponent],
-        imports: [
-            BrowserModule,
-            DxFileUploaderModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/FileUploader/99 How To/10 Specify a Header for the Request.md
+++ b/concepts/05 UI Components/FileUploader/99 How To/10 Specify a Header for the Request.md
@@ -26,11 +26,7 @@ Use the [uploadHeaders](/api-reference/10%20UI%20Components/dxFileUploader/1%20C
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         constructor() {
             

--- a/concepts/05 UI Components/FileUploader/99 How To/20 Specify a file's GUID.md
+++ b/concepts/05 UI Components/FileUploader/99 How To/20 Specify a file's GUID.md
@@ -54,11 +54,7 @@ Use the [valueChanged](/api-reference/10%20UI%20Components/dxFileUploader/4%20Ev
     import { BrowserModule } from "@angular/platform-browser";
     import { DxFileUploaderModule } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         value: any[] = [];
         uploadUrl: string = "https://js.devexpress.com/Demos/NetCore/FileUploader/Upload";

--- a/concepts/05 UI Components/FileUploader/99 How To/30 Get a file's Guid after uploading in chunks.md
+++ b/concepts/05 UI Components/FileUploader/99 How To/30 Get a file's Guid after uploading in chunks.md
@@ -54,11 +54,7 @@ Follow the steps below to get a file's GUID in 'chunk' [upload mode](/api-refere
     import { BrowserModule } from "@angular/platform-browser";
     import { DxFileUploaderModule } from "devextreme-angular";
     
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         onUploaded(e){
             console.log(e.request.getResponseHeader("File-Guid"));

--- a/concepts/05 UI Components/Floating Action Button/00 Getting Started with Floating Action Button/30 Handle Screen Transitions.md
+++ b/concepts/05 UI Components/Floating Action Button/00 Getting Started with Floating Action Button/30 Handle Screen Transitions.md
@@ -108,11 +108,7 @@ The following code shows the TabPanel configuration and an empty `switchSDA` fun
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         switchSDAs(e) {
             // To be implemented

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/10 Create a Form.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/10 Create a Form.md
@@ -45,11 +45,7 @@
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
 
     }

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/10 Create a Form.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/10 Create a Form.md
@@ -55,24 +55,7 @@
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
     <!-- tab: app.component.css -->
     #form {

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/20 Populate the Form Fields.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/20 Populate the Form Fields.md
@@ -40,24 +40,7 @@ The Form chooses default editors based on value types: [TextBox](/api-reference/
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/20 Populate the Form Fields.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/20 Populate the Form Fields.md
@@ -26,11 +26,7 @@ The Form chooses default editors based on value types: [TextBox](/api-reference/
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employee = {
             name: 'John Heart',

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/30 Configure Simple Items.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/30 Configure Simple Items.md
@@ -54,24 +54,7 @@ Use the [items[]](/Documentation/ApiReference/UI_Components/dxForm/Configuration
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/30 Configure Simple Items.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/30 Configure Simple Items.md
@@ -36,11 +36,7 @@ Use the [items[]](/Documentation/ApiReference/UI_Components/dxForm/Configuration
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employee = {
             name: 'John Heart',

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/10 In Columns.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/10 In Columns.md
@@ -42,11 +42,7 @@ An item can span multiple columns. The example below sets the [colSpan](/api-ref
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employee = {
             name: 'John Heart',

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/10 In Columns.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/10 In Columns.md
@@ -58,24 +58,7 @@ An item can span multiple columns. The example below sets the [colSpan](/api-ref
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/20 In Groups.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/20 In Groups.md
@@ -74,24 +74,7 @@ The following code creates two groups, each occupies a separate column. The resu
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/20 In Groups.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/20 In Groups.md
@@ -56,11 +56,7 @@ The following code creates two groups, each occupies a separate column. The resu
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employee = {
             name: 'John Heart',

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/30 In Tabs.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/30 In Tabs.md
@@ -85,11 +85,7 @@ The code also shows how to configure the tab panel's [height](/api-reference/10%
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employee = {
             name: 'John Heart',

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/30 In Tabs.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/30 In Tabs.md
@@ -104,24 +104,7 @@ The code also shows how to configure the tab panel's [height](/api-reference/10%
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/40 Add an Empty Space.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/40 Add an Empty Space.md
@@ -43,11 +43,7 @@ In the following example, the empty item [spans](/api-reference/10%20UI%20Compon
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employee = {
             // ...

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/40 Add an Empty Space.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/40 Add an Empty Space.md
@@ -55,24 +55,7 @@ In the following example, the empty item [spans](/api-reference/10%20UI%20Compon
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/50 Configure Item Labels.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/50 Configure Item Labels.md
@@ -66,24 +66,7 @@ The following code shows how to configure the **labelLocation** property to plac
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/50 Configure Item Labels.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/50 Configure Item Labels.md
@@ -54,11 +54,7 @@ The following code shows how to configure the **labelLocation** property to plac
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employee = {
             // ...

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/60 Modify the Form at Runtime.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/60 Modify the Form at Runtime.md
@@ -42,11 +42,7 @@ You can change any properties of the form, its items or editors at runtime. To u
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employee = {
             // ...

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/70 Validate the Form Data.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/70 Validate the Form Data.md
@@ -64,24 +64,7 @@ The following example sets the **isRequired** property for the `Name` item. It a
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/70 Validate the Form Data.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/70 Validate the Form Data.md
@@ -52,11 +52,7 @@ The following example sets the **isRequired** property for the `Name` item. It a
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employee = {
             // ...

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/80 Submit the Form.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/80 Submit the Form.md
@@ -112,24 +112,7 @@ The code below shows how to add a submit button, but does not show how to implem
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFormModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFormModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/80 Submit the Form.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/80 Submit the Form.md
@@ -87,11 +87,7 @@ The code below shows how to add a submit button, but does not show how to implem
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employee = {
             // ...

--- a/concepts/05 UI Components/Funnel/03 Data Binding/05 Simple Array/05 Array Only.md
+++ b/concepts/05 UI Components/Funnel/03 Data Binding/05 Simple Array/05 Array Only.md
@@ -48,24 +48,7 @@ To bind the Funnel to an array, pass this array to the [dataSource](/api-referen
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFunnelModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFunnelModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/Funnel/03 Data Binding/05 Simple Array/05 Array Only.md
+++ b/concepts/05 UI Components/Funnel/03 Data Binding/05 Simple Array/05 Array Only.md
@@ -32,11 +32,7 @@ To bind the Funnel to an array, pass this array to the [dataSource](/api-referen
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         fruits = [
             { fruit: 'Apples', count: 10 },

--- a/concepts/05 UI Components/Funnel/03 Data Binding/05 Simple Array/10 ArrayStore.md
+++ b/concepts/05 UI Components/Funnel/03 Data Binding/05 Simple Array/10 ArrayStore.md
@@ -35,11 +35,7 @@ If you want to extend the functionality of a JavaScript array, place it into an 
     import { Component } from '@angular/core';
     import DataSource from 'devextreme/data/data_source';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         fruits = [
             { fruit: 'Apples', count: 10 },
@@ -194,11 +190,7 @@ As you may notice, in the previous code, the **ArrayStore** is not declared expl
     import { Component } from '@angular/core';
     import DataSource from 'devextreme/data/data_source';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         fruits = [
             { apples: 10 },

--- a/concepts/05 UI Components/Funnel/03 Data Binding/05 Simple Array/10 ArrayStore.md
+++ b/concepts/05 UI Components/Funnel/03 Data Binding/05 Simple Array/10 ArrayStore.md
@@ -68,24 +68,7 @@ If you want to extend the functionality of a JavaScript array, place it into an 
     </dx-funnel>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFunnelModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFunnelModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 
@@ -248,24 +231,7 @@ As you may notice, in the previous code, the **ArrayStore** is not declared expl
     </dx-funnel>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxFunnelModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxFunnelModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/List/00 Getting Started with List/02 Create a List.md
+++ b/concepts/05 UI Components/List/00 Getting Started with List/02 Create a List.md
@@ -44,11 +44,7 @@
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
 
     }

--- a/concepts/05 UI Components/List/00 Getting Started with List/03 Bind the List to Data.md
+++ b/concepts/05 UI Components/List/00 Getting Started with List/03 Bind the List to Data.md
@@ -110,11 +110,7 @@ The **List** can load data from different data source types. To use a local arra
     import { Component } from '@angular/core';
     import { Product, ProductsService } from './products.service';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         products: Product[] = [];
 

--- a/concepts/05 UI Components/List/00 Getting Started with List/05 Group Items.md
+++ b/concepts/05 UI Components/List/00 Getting Started with List/05 Group Items.md
@@ -29,11 +29,7 @@ You can also display a hierarchy in a list bound to a flat array. In this case, 
     import DataSource from "devextreme/data/data_source";
     import { Product, ProductsService } from './products.service';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         dataSource: DataSource;
         products: Product[] = [];

--- a/concepts/05 UI Components/List/25 Selection/05 API.md
+++ b/concepts/05 UI Components/List/25 Selection/05 API.md
@@ -25,11 +25,7 @@ Add or remove an item's key from the [selectedItemKeys](/api-reference/10%20UI%2
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         selectedKeys: Array<number> = [6, 2, 5];
         selectItem(key) {

--- a/concepts/05 UI Components/PivotGrid/035 Use CustomStore/20 Remote Operations.md
+++ b/concepts/05 UI Components/PivotGrid/035 Use CustomStore/20 Remote Operations.md
@@ -68,11 +68,7 @@ The example below shows how to implement the **load** function. Note that in thi
     import { Component } from '@angular/core';
     import { HttpClient } from '@angular/common/http';
 
-    @Component({
-      styleUrls: ["./app.component.css"],
-      selector: "demo-app",
-      templateUrl: "./app.component.html"
-    })
+    #include angular-component-decorator
     export class AppComponent {
         dataSource: any;
 

--- a/concepts/05 UI Components/Popup/00 Getting Started with Popup/02 Create a Popup.md
+++ b/concepts/05 UI Components/Popup/00 Getting Started with Popup/02 Create a Popup.md
@@ -47,11 +47,7 @@
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
 
     }

--- a/concepts/05 UI Components/Popup/00 Getting Started with Popup/04 Show and Hide the Popup.md
+++ b/concepts/05 UI Components/Popup/00 Getting Started with Popup/04 Show and Hide the Popup.md
@@ -44,11 +44,7 @@ Users can hide the Popup when they click outside its boundaries. To enable this 
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         isPopupVisible: boolean;
 

--- a/concepts/05 UI Components/Scheduler/00 Getting Started with Scheduler/02 Create a Scheduler.md
+++ b/concepts/05 UI Components/Scheduler/00 Getting Started with Scheduler/02 Create a Scheduler.md
@@ -40,18 +40,6 @@
         <!-- Configuration goes here -->
     </dx-scheduler> 
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core'; 
-
-    @Component({ 
-        selector: 'app-root', 
-        templateUrl: './app.component.html', 
-        styleUrls: ['./app.component.css'] 
-    }) 
-    export class AppComponent { 
-
-    } 
-
     <!-- tab: app.module.ts -->
     import { BrowserModule } from '@angular/platform-browser'; 
     import { NgModule } from '@angular/core'; 

--- a/concepts/05 UI Components/Scheduler/00 Getting Started with Scheduler/07 Set the Current Date.md
+++ b/concepts/05 UI Components/Scheduler/00 Getting Started with Scheduler/07 Set the Current Date.md
@@ -21,11 +21,7 @@ To specify the current date, use the [currentDate](/api-reference/10%20UI%20Comp
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core'; 
 
-    @Component({ 
-        selector: 'app-root', 
-        templateUrl: './app.component.html', 
-        styleUrls: ['./app.component.css'] 
-    }) 
+    #include angular-component-decorator
     export class AppComponent { 
         currentDate: Date = new Date(2021, 4, 25);
     } 

--- a/concepts/05 UI Components/Scheduler/055 Date Navigator.md
+++ b/concepts/05 UI Components/Scheduler/055 Date Navigator.md
@@ -27,11 +27,7 @@ You can specify the range of available dates in the [min](/api-reference/10%20UI
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         minDate: Date = new Date(2018, 2, 3);
         maxDate: Date = new Date(2018, 4, 3);

--- a/concepts/05 UI Components/Switch/00 Overview.md
+++ b/concepts/05 UI Components/Switch/00 Overview.md
@@ -25,11 +25,7 @@ The following code adds the Switch to your page.
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent { }
 
     <!-- tab: app.module.ts -->

--- a/concepts/05 UI Components/Switch/10 Handle the Value Change Event.md
+++ b/concepts/05 UI Components/Switch/10 Handle the Value Change Event.md
@@ -25,11 +25,7 @@ To process a new Switch value, you need to handle the value change event. If the
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         switchValue: boolean = true;
 

--- a/concepts/05 UI Components/TabPanel/01 Getting Started with TabPanel/10 Create the TabPanel.md
+++ b/concepts/05 UI Components/TabPanel/01 Getting Started with TabPanel/10 Create the TabPanel.md
@@ -46,11 +46,7 @@
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
 
     }

--- a/concepts/05 UI Components/TabPanel/01 Getting Started with TabPanel/30 Specify View Content.md
+++ b/concepts/05 UI Components/TabPanel/01 Getting Started with TabPanel/30 Specify View Content.md
@@ -101,11 +101,7 @@ This tutorial demonstrates the use of the **items[]**.**template** property. Thi
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employeeData = {
             name: 'John Heart',

--- a/concepts/05 UI Components/TabPanel/01 Getting Started with TabPanel/40 Navigate Between Tabs.md
+++ b/concepts/05 UI Components/TabPanel/01 Getting Started with TabPanel/40 Navigate Between Tabs.md
@@ -64,11 +64,7 @@ Specifies the index of the currently selected tab. Use this property to switch b
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // ...
 

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/02 Create a TreeList.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/02 Create a TreeList.md
@@ -46,11 +46,7 @@
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
 
     }

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/02 Create a TreeList.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/02 Create a TreeList.md
@@ -56,24 +56,7 @@
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxTreeListModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxTreeListModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
     <!-- tab: app.component.css -->
     #treeList {

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/05 Bind the TreeList to Data.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/05 Bind the TreeList to Data.md
@@ -429,11 +429,7 @@ The TreeList component can load and update data from different data source types
     import { Component } from '@angular/core';
     import { Employee, EmployeesService } from './employees.service';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employees: Employee[] = [];
 

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/50 Select Records.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/50 Select Records.md
@@ -62,11 +62,7 @@ You can obtain the selected record's data in the [onSelectionChanged](/Documenta
     import { Component } from '@angular/core';
     import { Employee, EmployeesService } from './employees.service';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // ...
         selectedEmployee: Employee;

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/60 Enable Row Drag & Drop.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/60 Enable Row Drag & Drop.md
@@ -67,11 +67,7 @@ Users can drag and drop nodes to reorder them or change their hierarchy. To conf
     <!-- tab: app.component.ts -->
     // ...
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // ...
         selectedEmployee: Employee;

--- a/concepts/05 UI Components/TreeList/10 Columns/35 Hide a Column Using the API.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/35 Hide a Column Using the API.md
@@ -18,11 +18,7 @@ A column is considered hidden when its [visible](/api-reference/_hidden/GridBase
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         isEmailVisible: boolean = true;
         hideEmails() {

--- a/concepts/05 UI Components/TreeList/10 Columns/35 Hide a Column Using the API.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/35 Hide a Column Using the API.md
@@ -31,24 +31,7 @@ A column is considered hidden when its [visible](/api-reference/_hidden/GridBase
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { DxTreeListModule } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            DxTreeListModule
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/concepts/05 UI Components/TreeView/00 Getting Started with TreeView/05 Bind the TreeView to Data.md
+++ b/concepts/05 UI Components/TreeView/00 Getting Started with TreeView/05 Bind the TreeView to Data.md
@@ -131,11 +131,7 @@ The TreeView supports plain and hierarchical data structures. To use plain data,
     import { Component } from '@angular/core';
     import { Product, ProductsService } from './products.service';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         products: Product[];
 

--- a/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/10 Validate an Editor Value.md
+++ b/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/10 Validate an Editor Value.md
@@ -39,11 +39,7 @@ Associate a DevExtreme editor with the [Validator](/api-reference/10%20UI%20Comp
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         login: string;
     }

--- a/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/20 Validate Several Editor Values/1 Group the Editors.md
+++ b/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/20 Validate Several Editor Values/1 Group the Editors.md
@@ -43,11 +43,7 @@ Editors belonging to a single **Validation Group** can be validated together. Al
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         login: string;
         password: string;

--- a/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/20 Validate Several Editor Values/2 Validate the Group.md
+++ b/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/20 Validate Several Editor Values/2 Validate the Group.md
@@ -58,11 +58,7 @@ Call a group's [validate()](/api-reference/10%20UI%20Components/dxValidator/3%20
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         login: string;
         password: string;
@@ -347,11 +343,7 @@ Alternatively, you can use the [DevExpress.validationEngine.validateGroup](/api-
     import { Component } from '@angular/core';
     import { DxValidationGroupComponent } from 'devextreme-angular/ui/validation-group';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         @ViewChild('targetGroup', {static: false}) validationGroup: DxValidationGroupComponent
 

--- a/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/30 Disable Validation Dynamically.md
+++ b/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/30 Disable Validation Dynamically.md
@@ -77,11 +77,7 @@ The following example illustrates this case. A page contains two [TextBoxes](/ap
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         constructor() {
             this.customCallback = this.customCallback.bind(this);

--- a/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/60 Validate a Custom Value.md
+++ b/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/60 Validate a Custom Value.md
@@ -88,11 +88,7 @@ You can use the DevExtreme validation engine to validate a custom value, for exa
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         callbacks = [];
         phone: string;

--- a/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/06 Using Rollup/05 Import DevExtreme Modules.md
+++ b/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/06 Using Rollup/05 Import DevExtreme Modules.md
@@ -26,11 +26,7 @@ Now you can use the DevExtreme UI component in your application:
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         helloWorld() {
             alert('Hello world!');

--- a/concepts/60 Themes and Styles/20 SVG-Based Components Customization/10 Palettes/10 Apply a Palette.md
+++ b/concepts/60 Themes and Styles/20 SVG-Based Components Customization/10 Palettes/10 Apply a Palette.md
@@ -290,11 +290,7 @@ In the TreeMap, the palette is part of the [colorizer](/api-reference/10%20UI%20
     import { Component } from '@angular/core';
     import * as mapsData from 'devextreme/dist/js/vectormap-data/world.js';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         constructor(service: Service) {
             this.colorizeMap = this.colorizeMap.bind(this);

--- a/concepts/70 Data Binding/00 Specify a Data Source/10 Local Array.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/10 Local Array.md
@@ -42,11 +42,7 @@ To bind a UI component to a local array, pass this array to the UI component's [
     import { Component } from '@angular/core';
     import { Employee, Service } from './app.service';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employees: Employee[];
         constructor(service: Service) {
@@ -268,11 +264,7 @@ The following example declares an **ArrayStore**, wraps it in a **DataSource**, 
     import ArrayStore from 'devextreme/data/array_store';
     import DataSource from 'devextreme/data/data_source';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         employeesDataSource: DataSource;
         constructor(service: Service) {

--- a/concepts/70 Data Binding/00 Specify a Data Source/20 Read-Only Data in JSON Format.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/20 Read-Only Data in JSON Format.md
@@ -22,11 +22,7 @@ To bind a UI component to JSON data, pass the data URL to the UI component's [da
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         jsonUrl: String = 'https://jsonplaceholder.typicode.com/posts'
     }
@@ -142,11 +138,7 @@ The following code shows a **CustomStore** configuration in which the **load** f
 
     import CustomStore from 'devextreme/data/custom_store';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         jsonDataSource: CustomStore;
         

--- a/concepts/70 Data Binding/00 Specify a Data Source/30 Web API, PHP, MongoDB.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/30 Web API, PHP, MongoDB.md
@@ -45,11 +45,7 @@ To access the server from the client, configure the [CustomStore](/api-reference
     import { Component } from '@angular/core';
     import { createStore } from 'devextreme-aspnet-data-nojquery';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         remoteDataSource: any;
 

--- a/concepts/70 Data Binding/00 Specify a Data Source/40 OData.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/40 OData.md
@@ -27,11 +27,7 @@ To access an OData service, implement the [ODataStore](/api-reference/30%20Data%
     import { Component } from '@angular/core';
     import ODataStore from 'devextreme/data/odata/store';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         productsStore: ODataStore;
 
@@ -172,11 +168,7 @@ The following example declares an **ODataStore**, wraps it in a **DataSource**, 
     import ODataStore from 'devextreme/data/odata/store';
     import DataSource from 'devextreme/data/data_source';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         productsDataSource: DataSource;
 

--- a/concepts/70 Data Binding/00 Specify a Data Source/50 OLAP Cube.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/50 OLAP Cube.md
@@ -33,11 +33,7 @@ Wrap the **XmlaStore** into a **PivotGridDataSource**. This component enables yo
     import XmlaStore from 'devextreme/ui/pivot_grid/xmla_store';
     import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         adventureWorksDataSource: PivotGridDataSource;
 

--- a/concepts/70 Data Binding/00 Specify a Data Source/60 Custom Data Sources/2 Load Data/2 Client-Side Data Processing.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/60 Custom Data Sources/2 Load Data/2 Client-Side Data Processing.md
@@ -30,11 +30,7 @@ To process data on the client, load all data from the server in the [load](/api-
 
     import CustomStore from 'devextreme/data/custom_store';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         customDataSource: CustomStore;
 

--- a/concepts/70 Data Binding/00 Specify a Data Source/60 Custom Data Sources/2 Load Data/5 Server-Side Data Processing.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/60 Custom Data Sources/2 Load Data/5 Server-Side Data Processing.md
@@ -80,11 +80,7 @@ The following example shows a **CustomStore** that sends data processing setting
 
     import CustomStore from 'devextreme/data/custom_store';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         customDataSource: CustomStore;
         constructor(private http: HttpClient) {

--- a/concepts/70 Data Binding/00 Specify a Data Source/60 Custom Data Sources/6 Edit Data.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/60 Custom Data Sources/6 Edit Data.md
@@ -61,11 +61,7 @@ To implement data editing in the **CustomStore**, add the [insert](/api-referenc
 
     import CustomStore from 'devextreme/data/custom_store';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         customDataSource: CustomStore;
         constructor(private http: HttpClient) {

--- a/concepts/70 Data Binding/03 Update Data/05 DevExtreme DataSource/02 Data Shaping.md
+++ b/concepts/70 Data Binding/03 Update Data/05 DevExtreme DataSource/02 Data Shaping.md
@@ -29,11 +29,7 @@ The following code obtains a **DataSource** instance using both approaches and c
         import { Component } from '@angular/core';
         import DataSource from 'devextreme/data/data_source';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             dataSource: DataSource;
             constructor() {
@@ -55,11 +51,7 @@ The following code obtains a **DataSource** instance using both approaches and c
         import { Component } from '@angular/core';
         import { DxDataGridComponent } from 'devextreme-angular';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             @ViewChild(DxDataGridComponent, { static: false }) dataGrid: DxDataGridComponent;
             // Prior to Angular 8

--- a/concepts/70 Data Binding/03 Update Data/05 DevExtreme DataSource/10 Data Modification.md
+++ b/concepts/70 Data Binding/03 Update Data/05 DevExtreme DataSource/10 Data Modification.md
@@ -38,11 +38,7 @@ Stores provide three data modification methods: [insert(values)](/api-reference/
     import { Component } from '@angular/core';
     import DataSource from 'devextreme/data/data_source';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         dataSource: DataSource;
         constructor() {

--- a/concepts/70 Data Binding/03 Update Data/20 Local Array/Local Array.md
+++ b/concepts/70 Data Binding/03 Update Data/20 Local Array/Local Array.md
@@ -29,11 +29,7 @@ Ensure that one- or two-way binding is used to bind the **dataSource** property 
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         fruits = [
             { fruit: 'Apples', count: 10 },

--- a/concepts/Common/Localization/01 Dictionaries/05 Add Strings to a Dictionary.md
+++ b/concepts/Common/Localization/01 Dictionaries/05 Add Strings to a Dictionary.md
@@ -29,11 +29,7 @@ In the following example, the [loadMessages(messages)](/api-reference/50%20Commo
     import { Component } from '@angular/core';
     import { formatMessage, loadMessages, locale } from 'devextreme/localization';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         constructor() {
             loadMessages({

--- a/concepts/Common/Localization/01 Dictionaries/07 Override Strings in a Dictionary.md
+++ b/concepts/Common/Localization/01 Dictionaries/07 Override Strings in a Dictionary.md
@@ -21,11 +21,7 @@ In the following code, we override two strings from the <a href="https://github.
     import { Component } from '@angular/core';
     import { loadMessages } from 'devextreme/localization';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         constructor() {
             loadMessages({

--- a/concepts/Common/Localization/05 Localize Dates, Numbers, and Currencies/05 Using Intl.md
+++ b/concepts/Common/Localization/05 Localize Dates, Numbers, and Currencies/05 Using Intl.md
@@ -29,11 +29,7 @@
     import ruMessages from "devextreme/localization/messages/ru.json";  
     import { locale, loadMessages } from "devextreme/localization";
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         constructor() {
             loadMessages(deMessages);
@@ -138,11 +134,7 @@ Strings, numbers, dates, and currencies are now automatically localized and form
     import { Component } from '@angular/core';
     import config from 'devextreme/core/config';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         constructor() {
             // Specifying a currency globally

--- a/concepts/Common/Localization/05 Localize Dates, Numbers, and Currencies/10 Using Globalize.md
+++ b/concepts/Common/Localization/05 Localize Dates, Numbers, and Currencies/10 Using Globalize.md
@@ -187,11 +187,7 @@ In addition, you can now format values using structures accepted by <a href="htt
     // ...
     // import dictionaries and localization modules here
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // ...
     }

--- a/concepts/Common/Localization/20 Right-to-Left Support.md
+++ b/concepts/Common/Localization/20 Right-to-Left Support.md
@@ -20,18 +20,6 @@ RTL layout can be specified for an individual UI component using its **rtlEnable
         [rtlEnabled]="true">
     </dx-slider>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';    
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-        // ...
-    }
-
     <!-- tab: app.module.ts -->
     import { BrowserModule } from '@angular/platform-browser';
     import { NgModule } from '@angular/core';

--- a/concepts/Common/Localization/20 Right-to-Left Support.md
+++ b/concepts/Common/Localization/20 Right-to-Left Support.md
@@ -102,11 +102,7 @@ To apply RTL to your entire application, set the same property globally using th
     import { Component } from '@angular/core';
     import config from 'devextreme/core/config';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         constructor() {
             config({ rtlEnabled: true });      

--- a/concepts/Common/Security Considerations/20 HTML Encoding/10 Encode User Input.md
+++ b/concepts/Common/Security Considerations/20 HTML Encoding/10 Encode User Input.md
@@ -51,11 +51,7 @@ Text editors, such as [TextBox](/Documentation/ApiReference/UI_Components/dxText
     import { Component, ViewChild } from '@angular/core';
     import { DxHtmlEditorComponent } from 'devextreme-angular';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
 
         editorValue = '';

--- a/concepts/Common/Security Considerations/20 HTML Encoding/30 Potentially Vulnerable API/noDataText.md
+++ b/concepts/Common/Security Considerations/20 HTML Encoding/30 Potentially Vulnerable API/noDataText.md
@@ -31,11 +31,7 @@ The following example illustrates how an unsafe **noDataText** value can affect 
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         noDataTextEncoded: string;
         constructor() {

--- a/includes/angular-app-module-ts.md
+++ b/includes/angular-app-module-ts.md
@@ -1,0 +1,18 @@
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+import { AppComponent } from './app.component';
+
+import { Dx{WidgetName}Module } from 'devextreme-angular';
+
+@NgModule({
+    declarations: [
+        AppComponent
+    ],
+    imports: [
+        BrowserModule,
+        Dx{WidgetName}Module
+    ],
+    providers: [ ],
+    bootstrap: [AppComponent]
+})
+export class AppModule { }

--- a/includes/angular-component-decorator.md
+++ b/includes/angular-component-decorator.md
@@ -1,0 +1,5 @@
+@Component({
+    selector: 'app-root',
+    templateUrl: './app.component.html',
+    styleUrls: ['./app.component.css']
+})

--- a/includes/common-dataSource-description.md
+++ b/includes/common-dataSource-description.md
@@ -70,24 +70,7 @@ Use one of the following extensions to enable the server to process data accordi
         </dx-{widget-name}>
 
         <!-- tab: app.module.ts -->
-        import { BrowserModule } from '@angular/platform-browser';
-        import { NgModule } from '@angular/core';
-        import { AppComponent } from './app.component';
-
-        import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-        @NgModule({
-            declarations: [
-                AppComponent
-            ],
-            imports: [
-                BrowserModule,
-                Dx{WidgetName}Module
-            ],
-            providers: [],
-            bootstrap: [AppComponent]
-        })
-        export class AppModule { }
+        #include angular-app-module-ts
 
     ##### Vue
 

--- a/includes/common-dataSource-description.md
+++ b/includes/common-dataSource-description.md
@@ -45,11 +45,7 @@ Use one of the following extensions to enable the server to process data accordi
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';
 
-        @Component({
-            selector: 'app-root',
-            templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css']
-        })
+        #include angular-component-decorator
         export class AppComponent {
             store: CustomStore;
             constructor() {

--- a/includes/custom-templates.md
+++ b/includes/custom-templates.md
@@ -49,11 +49,7 @@ The following code shows how to declare a template and use these parameters. Thi
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         listData = [
             { itemProperty: "someValue" },

--- a/includes/data-binding-examples-arraystore-map.md
+++ b/includes/data-binding-examples-arraystore-map.md
@@ -74,24 +74,7 @@
     </dx-{widget-name}>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/includes/data-binding-examples-arraystore-map.md
+++ b/includes/data-binding-examples-arraystore-map.md
@@ -39,11 +39,7 @@
     import { Component } from '@angular/core';
     import DataSource from 'devextreme/data/data_source';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         fruits = [
             { apples: 10 },

--- a/includes/data-binding-examples-arraystore.md
+++ b/includes/data-binding-examples-arraystore.md
@@ -66,24 +66,7 @@
     </dx-{widget-name}>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/includes/data-binding-examples-arraystore.md
+++ b/includes/data-binding-examples-arraystore.md
@@ -35,11 +35,7 @@
     import { Component } from '@angular/core';
     import DataSource from 'devextreme/data/data_source';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         fruits = [
             { fruit: 'Apples', count: 10 },

--- a/includes/data-binding-examples-js-array.md
+++ b/includes/data-binding-examples-js-array.md
@@ -46,24 +46,7 @@
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/includes/data-binding-examples-js-array.md
+++ b/includes/data-binding-examples-js-array.md
@@ -30,11 +30,7 @@
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         fruits = [
             { fruit: 'Apples', count: 10 },

--- a/includes/data-binding-examples-json.md
+++ b/includes/data-binding-examples-json.md
@@ -17,24 +17,7 @@
     </dx-{widget-name}>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/includes/data-binding-examples-jsonp.md
+++ b/includes/data-binding-examples-jsonp.md
@@ -17,24 +17,7 @@
     </dx-{widget-name}>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/includes/data-binding-examples-mongodb.md
+++ b/includes/data-binding-examples-mongodb.md
@@ -26,11 +26,7 @@
     import CustomStore from 'devextreme/data/odata/custom_store';
     import { createStore } from "devextreme-aspnet-data-nojquery";
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         store: CustomStore;
         constructor() {

--- a/includes/data-binding-examples-mongodb.md
+++ b/includes/data-binding-examples-mongodb.md
@@ -43,24 +43,7 @@
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/includes/data-binding-examples-odata-filter.md
+++ b/includes/data-binding-examples-odata-filter.md
@@ -33,11 +33,7 @@
     import 'devextreme/data/odata/store';
     import DataSource from 'devextreme/data/data_source';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         {widgetName}DataSource = new DataSource({
             store: {

--- a/includes/data-binding-examples-odata-filter.md
+++ b/includes/data-binding-examples-odata-filter.md
@@ -55,24 +55,7 @@
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/includes/data-binding-examples-odata.md
+++ b/includes/data-binding-examples-odata.md
@@ -28,11 +28,7 @@
     import 'devextreme/data/odata/store';
     import DataSource from 'devextreme/data/data_source';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         {widgetName}DataSource = new DataSource({
             store: {

--- a/includes/data-binding-examples-odata.md
+++ b/includes/data-binding-examples-odata.md
@@ -45,24 +45,7 @@
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/includes/data-binding-examples-php.md
+++ b/includes/data-binding-examples-php.md
@@ -26,11 +26,7 @@
     import CustomStore from 'devextreme/data/odata/custom_store';
     import { createStore } from "devextreme-aspnet-data-nojquery";
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         store: CustomStore;
         constructor() {

--- a/includes/data-binding-examples-php.md
+++ b/includes/data-binding-examples-php.md
@@ -43,24 +43,7 @@
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/includes/data-binding-examples-update-dx-datasource.md
+++ b/includes/data-binding-examples-update-dx-datasource.md
@@ -12,11 +12,7 @@
     import { Component, ViewChild } from '@angular/core';
     import { Dx{WidgetName}Component } from 'devextreme-angular';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         @ViewChild(Dx{WidgetName}Component, { static: false }) {widgetName}: Dx{WidgetName}Component;
         // Prior to Angular 8

--- a/includes/data-binding-examples-update-dx-datasource.md
+++ b/includes/data-binding-examples-update-dx-datasource.md
@@ -27,24 +27,7 @@
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/includes/data-binding-examples-webapi.md
+++ b/includes/data-binding-examples-webapi.md
@@ -26,11 +26,7 @@
     import CustomStore from 'devextreme/data/odata/custom_store';
     import { createStore } from "devextreme-aspnet-data-nojquery";
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         store: CustomStore;
         constructor() {

--- a/includes/data-binding-examples-webapi.md
+++ b/includes/data-binding-examples-webapi.md
@@ -43,24 +43,7 @@
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/includes/dataviz-legend-customizeitems-example.md
+++ b/includes/dataviz-legend-customizeitems-example.md
@@ -45,16 +45,7 @@ The following code shows how to use the **customizeItems** function to sort lege
     }
 
     <!-- tab: app.module.ts -->
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-    // ...
-    @NgModule({
-        imports: [
-            // ...
-            Dx{WidgetName}Module
-        ],
-        // ...
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/includes/ng-import-devextreme-modules.md
+++ b/includes/ng-import-devextreme-modules.md
@@ -26,11 +26,7 @@ Now you can use the DevExtreme UI component in your application:
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         helloWorld() {
             alert('Hello world!');

--- a/includes/tutorials-editors-create-an-editor.md
+++ b/includes/tutorials-editors-create-an-editor.md
@@ -31,18 +31,6 @@ Use the code below to create an empty {WidgetName}:
     <!-- tab: app.component.html -->
     <dx-{widget-name}></dx-{widget-name}>
 
-    <!-- tab: app.component.ts -->
-    import { Component } from '@angular/core';
-
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-
-    }
-
     <!-- tab: app.module.ts -->
     #include angular-app-module-ts
 

--- a/includes/tutorials-editors-create-an-editor.md
+++ b/includes/tutorials-editors-create-an-editor.md
@@ -44,24 +44,7 @@ Use the code below to create an empty {WidgetName}:
     }
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 

--- a/includes/tutorials-editors-handle-value-change.md
+++ b/includes/tutorials-editors-handle-value-change.md
@@ -24,11 +24,7 @@ Implement the [onValueChanged](/Documentation/ApiReference/UI_Components/dx{Widg
     <!-- tab: app.component.ts -->
     import { Component } from '@angular/core';
 
-    @Component({
-        selector: 'app-root',
-        templateUrl: './app.component.html',
-        styleUrls: ['./app.component.css']
-    })
+    #include angular-component-decorator
     export class AppComponent {
         // ...
         onValueChanged(e) {

--- a/includes/uiwidgets-nestedtoolbar-widgetoptions-fulldesc.md
+++ b/includes/uiwidgets-nestedtoolbar-widgetoptions-fulldesc.md
@@ -14,24 +14,7 @@
     </dx-{widget-name}>
 
     <!-- tab: app.module.ts -->
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    import { AppComponent } from './app.component';
-
-    import { Dx{WidgetName}Module } from 'devextreme-angular';
-
-    @NgModule({
-        declarations: [
-            AppComponent
-        ],
-        imports: [
-            BrowserModule,
-            Dx{WidgetName}Module
-        ],
-        providers: [ ],
-        bootstrap: [AppComponent]
-    })
-    export class AppModule { }
+    #include angular-app-module-ts
 
 ##### Vue
 


### PR DESCRIPTION
What's done:

- `app.module.ts` is moved to an include
- `@Component` decorator configuration is also moved to an include
- Some useless `app.component.ts` listings are removed