### PR TITLE
HtmlEditor: Describe getText return value (#2919)

### DIFF
--- a/api-reference/10 UI Components/dxHtmlEditor/3 Methods/getText(index_length).md
+++ b/api-reference/10 UI Components/dxHtmlEditor/3 Methods/getText(index_length).md
@@ -12,7 +12,7 @@ A zero-based index at which the retrieved text starts.
 The number of characters to retrieve.
 
 ##### return: String
-<!-- Description goes here -->
+The retrieved text content.
 
 ---
 <!-- Description goes here -->


### PR DESCRIPTION
* HtmlEditor: Describe getText return value

* Fix a typo

(cherry picked from commit 600a1d4b3329e6f9536643fc739e8e8c4b2ac656)