### PR TITLE
Fix T1033479 - Chart Annotations can be anchored to a series point but not to a series only (#2974)

### DIFF
--- a/api-reference/10 UI Components/dxChart/1 Configuration/annotations/annotations.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/annotations/annotations.md
@@ -189,7 +189,7 @@ Annotations can be unattached or anchored to a chart element. The following list
             axis: "Value axis 2" // in a chart with multiple value axes
         }]
 
-- **Annotation anchored to a series or series point**
+- **Annotation anchored to a series point**
 
         annotations: [{
             argument: new Date(2019, 1, 16),

--- a/api-reference/10 UI Components/dxPolarChart/1 Configuration/annotations/annotations.md
+++ b/api-reference/10 UI Components/dxPolarChart/1 Configuration/annotations/annotations.md
@@ -191,7 +191,7 @@ Annotations can be anchored to a PolarChart element. The following list shows ho
             value: 15
         }]
 
-- **Annotation anchored to a series or series point**
+- **Annotation anchored to a series point**
 
         annotations: [{
             argument: new Date(2019, 1, 16),


### PR DESCRIPTION
(cherry picked from commit ccc9f2958214c3326bcf0be3da15d8e48f325c3b)