### PR TITLE
Fix T1041754 - One of the selectedRowKeys' demo buttons points to a TreeList demo but it says DataGrid demo (#3074)

### DIFF
--- a/api-reference/10 UI Components/GridBase/1 Configuration/selectedRowKeys.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/selectedRowKeys.md
@@ -18,7 +18,7 @@ To access a row using its key, specify the data field that provides key values. 
 }
 #include common-demobutton-named with {
     url: "https://js.devexpress.com/Demos/WidgetsGallery/Demo/TreeList/Overview/",
-    name: "DataGrid"
+    name: "TreeList"
 }
 
 #####See Also#####


### PR DESCRIPTION
…

(cherry picked from commit e85419588e161b786f243f9225b96974eaf43753)