### PR TITLE
dxOverlay: add obsolete message to copyRootClassesToWrapper

### DIFF
--- a/api-reference/10 UI Components/dxOverlay/1 Configuration/copyRootClassesToWrapper.md
+++ b/api-reference/10 UI Components/dxOverlay/1 Configuration/copyRootClassesToWrapper.md
@@ -2,7 +2,7 @@
 id: dxOverlay.Options.copyRootClassesToWrapper
 type: Boolean
 default: false
-deprecated: 
+deprecated: [important] Use the [wrapperAttr]({basewidgetpath}/Configuration/#wrapperAttr) property instead.
 ---
 ---
 ##### shortDescription


### PR DESCRIPTION
(cherry picked from commit f5f487df78dd1b3b73ea647ecdeeca7af71a6b22)