### PR TITLE
Remove generate-modules-meta

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -35,10 +35,6 @@ jobs:
           run: npm i
 
 #Generation
-        - name: Discover ts declarations
-          working-direcory: devextreme
-          run: npm run discover-ts-declarations -- --artifacts ../artifacts --js-scripts ../devextreme/js
-
         - name: Discover declarations
           working-directory: devextreme
           run: npm run discover-declarations -- --artifacts ../artifacts

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -35,6 +35,10 @@ jobs:
           run: npm i
 
 #Generation
+        - name: Discover ts declarations
+          working-direcory: devextreme
+          run: npm run discover-ts-declarations -- --artifacts ../artifacts --js-scripts ../devextreme/js
+
         - name: Discover declarations
           working-directory: devextreme
           run: npm run discover-declarations -- --artifacts ../artifacts
@@ -50,10 +54,6 @@ jobs:
         - name: Generate Syntax metadata
           working-directory: documentation
           run: npm run generate-syntax-data -- --declarations-path $(realpath ../artifacts/Declarations.json)
-
-        - name: Generate Modules metadata
-          working-directory: documentation
-          run: npm run generate-modules-meta -- --declarations-path $(realpath ../artifacts/Declarations.json) --js-scripts ../devextreme/js
 
         - name: Generate ContentMap
           working-directory: documentation

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/DevExpress/devextreme-documentation.git"
   },
   "devDependencies": {
-    "devextreme-internal-tools": "^8.0.0-beta.1"
+    "devextreme-internal-tools": "^8.0.0-beta.4"
   },
   "scripts": {
     "generate-content-map": "dx-tools generate-content-map --docs-root ./ --version 22.1 --syntaxdata-path ./metadata/syntax-data.json",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/DevExpress/devextreme-documentation.git"
   },
   "devDependencies": {
-    "devextreme-internal-tools": "^7.1.0"
+    "devextreme-internal-tools": "^8.0.0-beta.1"
   },
   "scripts": {
     "generate-content-map": "dx-tools generate-content-map --docs-root ./ --version 22.1 --syntaxdata-path ./metadata/syntax-data.json",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "scripts": {
     "generate-content-map": "dx-tools generate-content-map --docs-root ./ --version 22.1 --syntaxdata-path ./metadata/syntax-data.json",
     "generate-syntax-data": "dx-tools generate-syntax-data --output-path ./metadata/syntax-data.json",
-    "generate-modules-meta": "dx-tools generate-modules-meta --output-path ./metadata/modules-meta.json",
     "generate-extra-topic": "dx-tools generate-extra-topics --docs-root ./ --version 22.1",
     "update-topics": "dx-tools update-topics --docs-root ./",
     "update-links": "dx-tools update-links --docs-root ./",


### PR DESCRIPTION
Command generate-modules-meta was removed in devextreme-internal-tools version 8. 

Before merge - need to merge PR that bump devextreme-internal-tools in DevExtreme, then publish new DevExtreme version and finally bum DevExtreme version here