### PR TITLE
Fix installed devextreme's tools version

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -28,7 +28,7 @@ jobs:
           working-directory: devextreme
           run: |
             npm ci
-            npm update devextreme-internal-tools
+            npm i devextreme-internal-tools@$(node -p "require('./package-lock').dependencies['devextreme-internal-tools'].version")
 
         - name: NPM - devextreme-documentation
           working-directory: documentation


### PR DESCRIPTION
The task should correctly install `devextreme-internal-tools` package for the devextreme repo. The version should be exactly the same that is stored in the package-lock.json file