### PR TITLE
Add type for dxLoadPanel.contentTemplate (T1089001)

### DIFF
--- a/api-reference/10 UI Components/dxLoadPanel/1 Configuration/contentTemplate.md
+++ b/api-reference/10 UI Components/dxLoadPanel/1 Configuration/contentTemplate.md
@@ -1,4 +1,5 @@
 ---
 id: dxLoadPanel.Options.contentTemplate
+type: template
 hidden: 
 ---


### PR DESCRIPTION
https://supportcenter.devexpress.com/ticket/details/t1089001/loadpanel-the-contentrender-contentcomponent-option-appears-in-the-documentation