### PR TITLE
Fix typo in documentation

### DIFF
--- a/concepts/50 React Components/60 Components Testing/00 Components Testing.md
+++ b/concepts/50 React Components/60 Components Testing/00 Components Testing.md
@@ -1,5 +1,5 @@
 To test DevExtreme UI components for React, add the [React Testing Library](https://github.com/testing-library/react-testing-library) library to your project. 
 
-This library is automatically added when you create a React project with the [Create React App](https://create-react-app.dev/). Alternatively, you can use the following nmp command to add the React testing library:
+This library is automatically added when you create a React project with the [Create React App](https://create-react-app.dev/). Alternatively, you can use the following npm command to add the React testing library:
 
     npm install --save-dev @testing-library/react


### PR DESCRIPTION
The typo was : nmp instead of npm 😉