### PR TITLE
DataGrid: replace the deprecated toPromise method (#4485)

### DIFF
--- a/api-reference/10 UI Components/GridBase/1 Configuration/stateStoring/customSave.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/stateStoring/customSave.md
@@ -64,7 +64,7 @@ If you need to save and load the state from a remote storage, use the following 
     <!--TypeScript-->
     import { HttpClient, HttpClientModule, HttpHeaders, HttpRequest } from "@angular/common/http";
     import { Dx{WidgetName}Module } from "devextreme-angular";
-    import "rxjs/add/operator/toPromise";
+    import { lastValueFrom } from 'rxjs';
     import "rxjs/add/operator/catch";
     // ...
     export class AppComponent {
@@ -80,8 +80,7 @@ If you need to save and load the state from a remote storage, use the following 
                 responseType: dataType,
                 body: data ? JSON.stringify(data) : null
             });
-            return httpClient.request(req)
-                .toPromise();
+            return lastValueFrom(httpClient.request(req));
         }
 
         loadState = () => {


### PR DESCRIPTION
* DataGrid: replace the deprecated toPromise method

* add the lastValueFrom function as top-level function