### PR TITLE
Correct framework usage in new docs (#4782)

### DIFF
--- a/concepts/05 UI Components/ButtonGroup/00 Getting Started with ButtonGroup/1 Create the ButtonGroup.md
+++ b/concepts/05 UI Components/ButtonGroup/00 Getting Started with ButtonGroup/1 Create the ButtonGroup.md
@@ -1,4 +1,4 @@
-You can use the following library- or framework-specific code to create the ButtonGroup:
+You can use the following code to create the ButtonGroup:
 
 ---
 ##### jQuery

--- a/concepts/05 UI Components/Funnel/03 Data Binding/10 JSON Data.md
+++ b/concepts/05 UI Components/Funnel/03 Data Binding/10 JSON Data.md
@@ -2,7 +2,7 @@ To bind the Funnel to data in a JSON format, assign the data's URL to the [dataS
 
 #include data-binding-examples-json
 
-Note that you can also use a JSONP callback parameter supported by <a href="http://api.jquery.com/jQuery.ajax/" target="_blank">jQuery.ajax()</a>.
+Note that you can also use a JSONP callback parameter.
 
 #include data-binding-examples-jsonp
 

--- a/concepts/70 Data Binding/51 Data Source Examples/3 Custom Sources/0 Connect to RESTful Service.md
+++ b/concepts/70 Data Binding/51 Data Source Examples/3 Custom Sources/0 Connect to RESTful Service.md
@@ -10,43 +10,257 @@ Such services can have their own URL conventions and additional query-string par
 
 For the service type described above, you can apply the following simple custom DataSource implementation.
 
-    <!--JavaScript-->
-    new DevExpress.data.CustomStore({
+---
+##### jQuery
 
-        load: function(loadOptions) {
-            return $.getJSON(SERVICE_URL);
-        },
+    <!-- tab: index.js -->
+    $(function() {
+        var customDataSource = new DevExpress.data.CustomStore({
+            load: (loadOptions) => {
+                return $.getJSON(SERVICE_URL);
+            },
 
-        byKey: function(key) {
-            return $.getJSON(SERVICE_URL + "/" + encodeURIComponent(key));
-        },
+            byKey: (key) => {
+                return $.getJSON(SERVICE_URL + "/" + encodeURIComponent(key));
+            },
 
-        insert: function(values) {
-            return $.post(SERVICE_URL, values);
-        },
+            insert: (values) => {
+                return $.ajax({
+                    url: SERVICE_URL,
+                    method: "POST",
+                    data: values
+                });
+            },
 
-        update: function(key, values) {
-            return $.ajax({
-                url: SERVICE_URL + "/" + encodeURIComponent(key),
-                method: "PUT",
-                data: values
-            });
-        },
+            update: (key, values) => {
+                return $.ajax({
+                    url: SERVICE_URL + "/" + encodeURIComponent(key),
+                    method: "PUT",
+                    data: values
+                });
+            },
 
-        remove: function(key) {
-            return $.ajax({
-                url: SERVICE_URL + "/" + encodeURIComponent(key),
-                method: "DELETE",
+            remove: (key) => {
+                return $.ajax({
+                    url: SERVICE_URL + "/" + encodeURIComponent(key),
+                    method: "DELETE",
+                });
+            },
+        });
+    });
+
+Note that all user functions return the result of the jQuery AJAX call, which is compatible with the **jQuery.Deferred** promise. In fact, you may use any promise-compatible object to connect to any asynchronous data storage; for example - to an HTML5 File API, and not necessarily to HTTP endpoints.
+
+##### Angular
+
+    <!-- tab: app.component.ts -->
+    import { Component } from '@angular/core';
+    import { HttpClient } from '@angular/common/http';
+    import "rxjs/add/operator/toPromise";
+
+    import CustomStore from 'devextreme/data/custom_store';
+
+    @Component({
+        selector: 'app-root',
+        templateUrl: './app.component.html',
+        styleUrls: ['./app.component.css']
+    })
+
+    export class AppComponent {
+        customDataSource: CustomStore;
+        constructor(private http: HttpClient) {
+            this.customDataSource = new CustomStore({
+                load: (loadOptions) => {
+                    return httpClient.get(SERVICE_URL)
+                        .toPromise();
+                },
+
+                byKey: (key) => {
+                    return httpClient.get(SERVICE_URL + "/" + encodeURIComponent(key))
+                        .toPromise();
+                },
+
+                insert: (values) => {
+                    return httpClient.post(SERVICE_URL, values)
+                        .toPromise();
+                },
+
+                update: (key, values) => {
+                    return httpClient.put(SERVICE_URL + encodeURIComponent(key), values)
+                        .toPromise();
+                },
+
+                remove: (key) => {
+                    return httpClient.delete(SERVICE_URL + encodeURIComponent(key))
+                        .toPromise();
+                },
             });
         }
+    }
 
-    });
+##### Vue
+
+    <!-- tab: App.vue (Options API) -->
+    <template>
+        <!-- ... -->
+    </template>
+
+    <script>
+    // ...
+    import CustomStore from 'devextreme/data/custom_store';
+    import 'whatwg-fetch';
     
-Note that all user functions return the result of the jQuery AJAX call, which is compatible with the **jQuery.Deferred** promise. In fact, you may use any promise-compatible object to connect to any asynchronous data storage; for example - to an HTML5 File API, and not necessarily to HTTP endpoints.
+    const customDataSource = new CustomStore({
+
+        load: (loadOptions) => {
+            return fetch(SERVICE_URL);
+        },
+
+        byKey: (key) => {
+            return fetch(SERVICE_URL + "/" + encodeURIComponent(key));
+        },
+
+        insert: (values) => {
+            return fetch(SERVICE_URL, {
+                method: "POST",
+                body: JSON.stringify(values),
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+        },
+
+        update: (key, values) => {
+            return fetch(SERVICE_URL + "/" + encodeURIComponent(key), {
+                method: "PUT",
+                body: JSON.stringify(values),
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+        },
+
+        remove: (key) => {
+            return fetch(SERVICE_URL + "/" + encodeURIComponent(key), {
+                method: "DELETE",
+            });
+        },
+    });
+
+    export default {
+        components: {
+            // ...
+        },
+        data() {
+            return {
+                customDataSource
+            }
+        }
+    }
+    </script>
+
+    <!-- tab: App.vue (Composition API) -->
+    <template>
+        <!-- ... -->
+    </template>
+
+    <script setup>
+    // ...
+    import CustomStore from 'devextreme/data/custom_store';
+    import 'whatwg-fetch';
+    
+    const customDataSource = new CustomStore({
+        
+        load: (loadOptions) => {
+            return fetch(SERVICE_URL);
+        },
+
+        byKey: (key) => {
+            return fetch(SERVICE_URL + "/" + encodeURIComponent(key));
+        },
+
+        insert: (values) => {
+            return fetch(SERVICE_URL, {
+                method: "POST",
+                body: JSON.stringify(values),
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+        },
+
+        update: (key, values) => {
+            return fetch(SERVICE_URL + "/" + encodeURIComponent(key), {
+                method: "PUT",
+                body: JSON.stringify(values),
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+        },
+
+        remove: (key) => {
+            return fetch(SERVICE_URL + "/" + encodeURIComponent(key), {
+                method: "DELETE",
+            });
+        },
+    });
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    // ...
+    import CustomStore from 'devextreme/data/custom_store';
+    import 'whatwg-fetch';
+
+    const customDataSource = new CustomStore({
+        load: (loadOptions) => {
+            return fetch(SERVICE_URL);
+        },
+
+        byKey: (key) => {
+            return fetch(SERVICE_URL + "/" + encodeURIComponent(key));
+        },
+
+        insert: (values) => {
+            return fetch(SERVICE_URL, {
+                method: "POST",
+                body: JSON.stringify(values),
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+        },
+
+        update: (key, values) => {
+            return fetch(SERVICE_URL + "/" + encodeURIComponent(key), {
+                method: "PUT",
+                body: JSON.stringify(values),
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+        },
+
+        remove: (key) => {
+            return fetch(SERVICE_URL + "/" + encodeURIComponent(key), {
+                method: "DELETE",
+            });
+        },
+    });
+
+    export default function App() {
+        return (
+            {/* ... */}
+        );
+    }
+
+---
 
 The **load** function accepts a number of **loadOptions** (sorting, filtering, paging, etc.). Send them to a remote storage where you can generate the resulting dataset based on these properties.
 
-Note that certain UI components have peculiarities in the **CustomStore** implemenation. For example, in case of the [DataGrid](/api-reference/10%20UI%20Components/dxDataGrid '/Documentation/ApiReference/UI_Components/dxDataGrid/'), the **load** function should also return the total count of received records.
+Note that certain UI components have peculiarities in the **CustomStore** implementation. For example, in case of the [DataGrid](/api-reference/10%20UI%20Components/dxDataGrid '/Documentation/ApiReference/UI_Components/dxDataGrid/'), the **load** function should also return the total count of received records.
 
 #####See Also#####
 - [DataGrid - Use CustomStore](/concepts/70%20Data%20Binding/00%20Specify%20a%20Data%20Source/60%20Custom%20Data%20Sources '/Documentation/Guide/Data_Binding/Specify_a_Data_Source/Custom_Data_Sources/')

--- a/concepts/70 Data Binding/51 Data Source Examples/3 Custom Sources/1 Load Data in Raw Mode.md
+++ b/concepts/70 Data Binding/51 Data Source Examples/3 Custom Sources/1 Load Data in Raw Mode.md
@@ -1,26 +1,319 @@
 Loading data in raw mode allows you to configure the CustomStore more easily. You can use it only if all data shaping operations are supposed to be performed on the client. In raw mode, the [load](/api-reference/30%20Data%20Layer/CustomStore/1%20Configuration/load.md '/Documentation/ApiReference/Data_Layer/CustomStore/Configuration/#load') function should get raw, unprocessed data from the server, and the CustomStore will perform data shaping automatically, without any input from you. To switch to the raw mode, assign *"raw"* to the [loadMode](/api-reference/30%20Data%20Layer/CustomStore/1%20Configuration/loadMode.md '/Documentation/ApiReference/Data_Layer/CustomStore/Configuration/#loadMode') property.
 
-    <!--JavaScript-->
-    var store = new DevExpress.data.CustomStore({
-        loadMode: "raw",
-        load: function() {
-            return $.getJSON("url/to/the/resource");
-        }
+---
+##### jQuery
+
+    <!-- tab: index.js -->
+    $(function() {
+        var customDataSource = new DevExpress.data.CustomStore({
+            loadMode: "raw", // omit in the DataGrid, TreeList, PivotGrid, and Scheduler
+            load: function() {
+                // ...
+            },    
+            // ...
+        });
     });
+
+##### Angular
+
+    <!-- tab: app.component.ts -->
+    import { Component } from '@angular/core';
+    import { HttpClient } from '@angular/common/http';
+
+    import CustomStore from 'devextreme/data/custom_store';
+
+    @Component({
+        selector: 'app-root',
+        templateUrl: './app.component.html',
+        styleUrls: ['./app.component.css']
+    })
+
+    export class AppComponent {
+        customDataSource: CustomStore;
+        constructor(private http: HttpClient) {
+            this.customDataSource = new CustomStore({
+                loadMode: "raw", // omit in the DataGrid, TreeList, PivotGrid, and Scheduler
+                load: () => {
+                    // ...
+                },
+                // ...
+            });
+        }
+    }
+
+##### Vue
+
+    <!-- tab: App.vue (Options API) -->
+    <template>
+        <!-- ... -->
+    </template>
+
+    <script>
+    // ...
+    import CustomStore from 'devextreme/data/custom_store';
+    
+    const customDataSource = new CustomStore({
+        loadMode: "raw", // omit in the DataGrid, TreeList, PivotGrid, and Scheduler 
+        load: () => {
+            // ...
+        },
+    });
+
+    export default {
+        components: {
+            // ...
+        },
+        data() {
+            return {
+                customDataSource
+            }
+        }
+    }
+    </script>
+
+    <!-- tab: App.vue (Composition API) -->
+    <template>
+        <!-- ... -->
+    </template>
+
+    <script setup>
+    // ...
+    import CustomStore from 'devextreme/data/custom_store';
+    
+    const customDataSource = new CustomStore({
+        loadMode: "raw", // omit in the DataGrid, TreeList, PivotGrid, and Scheduler
+        load: () => {
+            // ...
+        },
+    });
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    // ...
+    import CustomStore from 'devextreme/data/custom_store';
+
+    export default function App() {
+        const customDataSource = new CustomStore({
+            loadMode: "raw", // omit in the DataGrid, TreeList, PivotGrid, and Scheduler
+            load: () => {
+                // ...
+            },
+            // ...
+        });
+
+        return (
+            {/* ... */}
+        );
+    }
+
+---
 
 Note that you are not required to implement the [byKey](/api-reference/30%20Data%20Layer/CustomStore/1%20Configuration/byKey.md '/Documentation/ApiReference/Data_Layer/CustomStore/Configuration/#byKey') and [totalCount](/api-reference/30%20Data%20Layer/CustomStore/1%20Configuration/totalCount.md '/Documentation/ApiReference/Data_Layer/CustomStore/Configuration/#totalCount') functions in raw mode, since they will be evaluated based on the results of the **load** function. If, however, you do implement them, your implementation will take precedence over the default one.
 
 Once loaded, data is stored in the cache. If you need to clear the cache at some point, call the [clearRawDataCache()](/api-reference/30%20Data%20Layer/CustomStore/3%20Methods/clearRawDataCache().md '/Documentation/ApiReference/Data_Layer/CustomStore/Methods/#clearRawDataCache') method.
 
-    <!--JavaScript-->
-    store.clearRawDataCache();
+---
+##### jQuery
+
+    <!-- tab: index.js -->
+    $(function() {
+        var customDataSource = new DevExpress.data.CustomStore({  
+            // ...
+        });
+    
+        customDataSource.clearRawDataCache();
+    });
+
+##### Angular
+
+    <!-- tab: app.component.ts -->
+    import { Component } from '@angular/core';
+    import { HttpClient } from '@angular/common/http';
+
+    import CustomStore from 'devextreme/data/custom_store';
+
+    @Component({
+        selector: 'app-root',
+        templateUrl: './app.component.html',
+        styleUrls: ['./app.component.css']
+    })
+
+    export class AppComponent {
+        customDataSource: CustomStore;
+        constructor(private http: HttpClient) {
+            this.customDataSource = new CustomStore({
+                // ...
+            });
+
+            this.customDataSource.clearRawDataCache();
+        }
+    }
+
+##### Vue
+
+    <!-- tab: App.vue (Options API) -->
+    <template>
+        <!-- ... -->
+    </template>
+
+    <script>
+    // ...
+    import CustomStore from 'devextreme/data/custom_store';
+    
+    const customDataSource = new CustomStore({
+        // ...
+    });
+
+    export default {
+        components: {
+            // ...
+        },
+        data() {
+            return {
+                customDataSource
+            }
+        },
+        mounted() {
+            customDataSource.clearRawDataCache(); 
+        },
+    }
+    </script>
+
+    <!-- tab: App.vue (Composition API) -->
+    <template>
+        <!-- ... -->
+    </template>
+
+    <script setup>
+    // ...
+    import CustomStore from 'devextreme/data/custom_store';
+    
+    const customDataSource = new CustomStore({
+        // ...
+    });
+
+    customDataSource.clearRawDataCache(); 
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    // ...
+    import CustomStore from 'devextreme/data/custom_store';
+
+    export default function App() {
+        const customDataSource = new CustomStore({
+            // ...
+        });
+
+        customDataSource.clearRawDataCache(); 
+
+        return (
+            {/* ... */}
+        );
+    }
+
+---
 
 To switch data caching off, assign **false** to the [cacheRawData](/api-reference/30%20Data%20Layer/CustomStore/1%20Configuration/cacheRawData.md '/Documentation/ApiReference/Data_Layer/CustomStore/Configuration/#cacheRawData') property. Note that in this case, the CustomStore will reload all data on every call of the **load**, **byKey** and **totalCount** functions.
 
-    <!--JavaScript-->
-    var store = new DevExpress.data.CustomStore({
-        // ...
-        cacheRawData: false
+---
+##### jQuery
+
+    <!-- tab: index.js -->
+    $(function() {
+        var customDataSource = new DevExpress.data.CustomStore({  
+            // ...
+            cacheRawData: false,
+        });
     });
+
+##### Angular
+
+    <!-- tab: app.component.ts -->
+    import { Component } from '@angular/core';
+    import { HttpClient } from '@angular/common/http';
+
+    import CustomStore from 'devextreme/data/custom_store';
+
+    @Component({
+        selector: 'app-root',
+        templateUrl: './app.component.html',
+        styleUrls: ['./app.component.css']
+    })
+
+    export class AppComponent {
+        customDataSource: CustomStore;
+        constructor(private http: HttpClient) {
+            this.customDataSource = new CustomStore({
+                // ...
+                cacheRawData: false,
+            });
+        }
+    }
+
+##### Vue
+
+    <!-- tab: App.vue (Options API) -->
+    <template>
+        <!-- ... -->
+    </template>
+
+    <script>
+    // ...
+    import CustomStore from 'devextreme/data/custom_store';
+    
+    const customDataSource = new CustomStore({
+        // ...
+        cacheRawData: false,
+    });
+
+    export default {
+        components: {
+            // ...
+        },
+        data() {
+            return {
+                customDataSource
+            }
+        },
+    }
+    </script>
+
+    <!-- tab: App.vue (Composition API) -->
+    <template>
+        <!-- ... -->
+    </template>
+
+    <script setup>
+    // ...
+    import CustomStore from 'devextreme/data/custom_store';
+    
+    const customDataSource = new CustomStore({
+        // ...
+        cacheRawData: false,
+    }); 
+    </script>
+
+##### React
+
+    <!-- tab: App.js -->
+    // ...
+    import CustomStore from 'devextreme/data/custom_store';
+
+    export default function App() {
+        const customDataSource = new CustomStore({
+            // ...
+            cacheRawData: false,
+        });
+
+        return (
+            {/* ... */}
+        );
+    }
+
+---
 
 Since the CustomStore loads all data in raw mode at once, we do not recommend using it with large amounts of data. If you notice a decrease in the CustomStore performance in raw mode, consider delegating some or all data shaping operations to the server and implementing the remaining operations in the [load](/api-reference/30%20Data%20Layer/CustomStore/1%20Configuration/load.md '/Documentation/ApiReference/Data_Layer/CustomStore/Configuration/#load') function yourself.

--- a/concepts/Common/Distribution Channels/05 CDN/05 CDN.md
+++ b/concepts/Common/Distribution Channels/05 CDN/05 CDN.md
@@ -147,3 +147,5 @@ Alternatively, you can get DevExtreme sources from DevExpress CDN:
     <!-- <link href="https://cdn3.devexpress.com/jslib/minor_22_1/css/dx-gantt.css" rel="stylesheet"> -->
 
 ---
+
+[tags] jquery

--- a/concepts/Common/Localization/01 Dictionaries/Dictionaries.md
+++ b/concepts/Common/Localization/01 Dictionaries/Dictionaries.md
@@ -8,82 +8,114 @@ DevExpress curates the following dictionaries:
 
 There are also dictionaries that the community contributes and curates. The list of dictionaries is available <a href="https://github.com/DevExpress/DevExtreme/tree/22_1/js/localization/messages" target="_blank">on GitHub</a>.
 
-You can find all the dictionaries on your local machine in the DevExtreme installation folder's or ZIP archive's Lib\js\localization directory. These dictionaries are also available on CDN or npm.
+---
+##### jQuery
 
-* **CDN or local file**        
+You can find all the dictionaries on your local machine in the DevExtreme installation folder's or ZIP archive's Lib\js\localization directory. These dictionaries are also available on CDN.
 
-    Link the required dictionaries using the `<script>` tag. Place the links *after* a link to the DevExtreme library:
+Use the `<script>` tag to link the required dictionaries, and place the links *after* a link to the DevExtreme library:
 
-    ---
-    ##### CDN
+    <!--HTML-->
+    <head>
+        <!-- ... -->
+        <!-- DevExtreme library -->
+        <script src="https://cdn3.devexpress.com/jslib/minor_22_2/js/dx.all.js"></script>
+        <!-- Dictionary files for German language -->
+        <script src="https://cdn3.devexpress.com/jslib/minor_22_2/js/localization/dx.messages.de.js"></script>
+    </head>
+    <body>
+        <script>
+            DevExpress.localization.locale(navigator.language);
+            // ...
+            // DevExtreme UI components are configured here
+            // ...
+        </script>
+    </body>
 
-        <!--HTML-->
-        <head>
-            <!-- ... -->
-            <!-- DevExtreme library -->
-            <script src="https://cdn3.devexpress.com/jslib/minor_22_1/js/dx.all.js"></script>
-            <!-- Dictionary files for German language -->
-            <script src="https://cdn3.devexpress.com/jslib/minor_22_1/js/localization/dx.messages.de.js"></script>
-        </head>
-        <body>
-            <script>
-                DevExpress.localization.locale(navigator.language);
-                // ...
-                // DevExtreme UI components are configured here
-                // ...
-            </script>
-        </body>
+##### Angular
 
-    ---
+You can find all the dictionaries on your local machine in the DevExtreme installation folder's or ZIP archive's Lib\js\localization directory. These dictionaries are also available on npm.
 
-* **npm**       
+Include the dictionaries using the `import` or `require` statement the statement depends on the syntax for working with modules. The following code shows ECMAScript 6 and CommonJS syntaxes:
 
-    Include the dictionaries using the `import` or `require` statement&mdash;the statement depends on the syntax for working with modules. The following code shows ECMAScript 6 and CommonJS syntaxes:
+    <!-- tab: ECMAScript 6 syntax -->
+    // ...
+    // Dictionaries for German language
+    import deMessages from "devextreme/localization/messages/de.json";
+    import { locale, loadMessages } from "devextreme/localization";
 
-    ---
-    ##### npm: ECMAScript 6 syntax
-
-        <!--JavaScript-->
-        // ...
-        // Dictionaries for German language
-        import deMessages from "devextreme/localization/messages/de.json";
-        import { locale, loadMessages } from "devextreme/localization";
-
-        // ===== Angular ======
-        export class AppComponent {
-            constructor() {
-                loadMessages(deMessages);
-                locale(navigator.language);
-            }
+    export class AppComponent {
+        constructor() {
+            loadMessages(deMessages);
+            locale(navigator.language);
         }
+    }
 
-        // ===== Vue ======
-        export default {
-            created() {
-                loadMessages(deMessages);
-                locale(navigator.language);
-            }
+    <!-- tab: CommonJS syntax -->
+    // ...
+    // Dictionaries for German language
+    const deMessages = require('devextreme/localization/messages/de.json');
+    const localization = require('devextreme/localization');
+
+    localization.loadMessages(deMessages);
+    localization.locale(navigator.language);
+
+##### Vue
+
+You can find all the dictionaries on your local machine in the DevExtreme installation folder's or ZIP archive's Lib\js\localization directory. These dictionaries are also available on npm.
+
+Include the dictionaries using the `import` or `require` statement the statement depends on the syntax for working with modules. The following code shows ECMAScript 6 and CommonJS syntaxes:
+
+    <!-- tab: ECMAScript 6 syntax -->
+    // ...
+    // Dictionaries for German language
+    import deMessages from "devextreme/localization/messages/de.json";
+    import { locale, loadMessages } from "devextreme/localization";
+
+    export default {
+        created() {
+            loadMessages(deMessages);
+            locale(navigator.language);
         }
+    }
 
-        // ===== React ======
-        class App extends React.Component {
-            constructor(props) {
-                super(props);
-                loadMessages(deMessages);
-                locale(navigator.language);
-            }
+    <!-- tab: CommonJS syntax -->
+    // ...
+    // Dictionaries for German language
+    const deMessages = require('devextreme/localization/messages/de.json');
+    const localization = require('devextreme/localization');
+
+    localization.loadMessages(deMessages);
+    localization.locale(navigator.language);
+
+##### React
+
+You can find all the dictionaries on your local machine in the DevExtreme installation folder's or ZIP archive's Lib\js\localization directory. These dictionaries are also available on npm.
+
+Include the dictionaries using the `import` or `require` statement the statement depends on the syntax for working with modules. The following code shows ECMAScript 6 and CommonJS syntaxes:
+
+    <!-- tab: ECMAScript 6 syntax -->
+    // ...
+    // Dictionaries for German language
+    import deMessages from "devextreme/localization/messages/de.json";
+    import { locale, loadMessages } from "devextreme/localization";
+
+    class App extends React.Component {
+        constructor(props) {
+            super(props);
+            loadMessages(deMessages);
+            locale(navigator.language);
         }
+    }
 
-    ##### npm: CommonJS syntax
+    <!-- tab: CommonJS syntax -->
+    // ...
+    // Dictionaries for German language
+    const deMessages = require('devextreme/localization/messages/de.json');
+    const localization = require('devextreme/localization');
 
-        <!--JavaScript-->
-        // ...
-        // Dictionaries for German language
-        const deMessages = require('devextreme/localization/messages/de.json');
-        const localization = require('devextreme/localization');
+    localization.loadMessages(deMessages);
+    localization.locale(navigator.language);
 
-        localization.loadMessages(deMessages);
-        localization.locale(navigator.language);
-        
-    ---
+---    
 

--- a/concepts/Common/Migrate to the New Version/10 Upgrade DevExtreme Sources/4 CDN Services.md
+++ b/concepts/Common/Migrate to the New Version/10 Upgrade DevExtreme Sources/4 CDN Services.md
@@ -1,1 +1,3 @@
 Replace the version in CDN links. Relevant links are listed in the [CDN Services](/concepts/Common/Distribution%20Channels/05%20CDN '/Documentation/Guide/Common/Distribution_Channels/CDN/') article.
+
+[tags] jquery

--- a/concepts/Common/Migrate to the New Version/10 Upgrade DevExtreme Sources/7 npm Packages.md
+++ b/concepts/Common/Migrate to the New Version/10 Upgrade DevExtreme Sources/7 npm Packages.md
@@ -3,13 +3,13 @@ Run the following commands:
 ---
 ##### jQuery
 
-    npm install devextreme@22.2 --save --save-exact
+    npm install devextreme@22.1 --save --save-exact
 
 ##### Angular
 
-    npm install devextreme@22.2 --save --save-exact
+    npm install devextreme@22.1 --save --save-exact
 
-    npm install devextreme-angular@22.2 --save --save-exact
+    npm install devextreme-angular@22.1 --save --save-exact
 
     // If the application is created using the DevExtreme CLI
     npm install devextreme-themebuilder@22.1 --save --save-exact
@@ -17,22 +17,22 @@ Run the following commands:
 
 ##### Vue
 
-    npm install devextreme@22.2 --save --save-exact
+    npm install devextreme@22.1 --save --save-exact
 
-    npm install devextreme-vue@22.2 --save --save-exact
+    npm install devextreme-vue@22.1 --save --save-exact
 
     // If the application is created using the DevExtreme CLI
-    npm install devextreme-themebuilder@22.2 --save --save-exact
+    npm install devextreme-themebuilder@22.1 --save --save-exact
     npm run build-themes
 
 ##### React
 
-    npm install devextreme@22.2 --save --save-exact
+    npm install devextreme@22.1 --save --save-exact
 
-    npm install devextreme-react@22.2 --save --save-exact
+    npm install devextreme-react@22.1 --save --save-exact
 
     // If the application is created using the DevExtreme CLI
-    npm install devextreme-themebuilder@22.2 --save --save-exact
+    npm install devextreme-themebuilder@22.1 --save --save-exact
     npm run build-themes
 
 ---

--- a/concepts/Common/Migrate to the New Version/10 Upgrade DevExtreme Sources/7 npm Packages.md
+++ b/concepts/Common/Migrate to the New Version/10 Upgrade DevExtreme Sources/7 npm Packages.md
@@ -1,14 +1,41 @@
 Run the following commands:
 
-    npm install devextreme@22.1 --save --save-exact
-    
-    npm install devextreme-angular@22.1 --save --save-exact // If you use DevExtreme with Angular
-    npm install devextreme-vue@22.1 --save --save-exact // If you use DevExtreme with Vue
-    npm install devextreme-react@22.1 --save --save-exact // If you use DevExtreme with React
+---
+##### jQuery
+
+    npm install devextreme@22.2 --save --save-exact
+
+##### Angular
+
+    npm install devextreme@22.2 --save --save-exact
+
+    npm install devextreme-angular@22.2 --save --save-exact
 
     // If the application is created using the DevExtreme CLI
     npm install devextreme-themebuilder@22.1 --save --save-exact
     npm run build-themes
+
+##### Vue
+
+    npm install devextreme@22.2 --save --save-exact
+
+    npm install devextreme-vue@22.2 --save --save-exact
+
+    // If the application is created using the DevExtreme CLI
+    npm install devextreme-themebuilder@22.2 --save --save-exact
+    npm run build-themes
+
+##### React
+
+    npm install devextreme@22.2 --save --save-exact
+
+    npm install devextreme-react@22.2 --save --save-exact
+
+    // If the application is created using the DevExtreme CLI
+    npm install devextreme-themebuilder@22.2 --save --save-exact
+    npm run build-themes
+
+---
 
 #####See Also#####
 - [DevExtreme CLI: Create a New Application](/concepts/Common/DevExtreme%20CLI/20%20DevExtreme%20Application '/Documentation/Guide/Common/DevExtreme_CLI/#DevExtreme_Application')

--- a/concepts/Common/Modularity/01 Link Modules/10 Use Webpack.md
+++ b/concepts/Common/Modularity/01 Link Modules/10 Use Webpack.md
@@ -38,10 +38,6 @@
 
         webpack
 
-Refer to the following examples to see how to use Webpack with <a href="https://github.com/DevExpress/devextreme-examples/tree/22_1/webpack-jquery" target="_blank">jQuery</a>, <a href="https://github.com/DevExpress/devextreme-examples/tree/22_1/webpack-angularjs" target="_blank">AngularJS</a>, and <a href="https://github.com/DevExpress/devextreme-examples/tree/22_1/webpack-knockout" target="_blank">Knockout</a> on GitHub. The **webpack.config.js**, **index.js**, and **index.html** files contain the main code. 
+To see how to use Webpack with <a href="https://github.com/DevExpress/devextreme-examples/tree/22_2/" target="_blank">jQuery</a>, refer to examples on GitHub. The **webpack.config.js**, **index.js**, and **index.html** files contain the main code. Note that jQuery components require additional [integration module](/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/jquery).
 
-The following list shows additional modules each library/framework requires: 
-
-- **jQuery**: DevExtreme [jQuery integration](/concepts/Common/Modularity/02%20DevExtreme%20Modules%20Structure/integration/jquery.md '/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/jquery') module;
-- **AngularJS**: jQuery, DevExtreme [AngularJS](/concepts/Common/Modularity/02%20DevExtreme%20Modules%20Structure/integration/angular.md '/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/angular') and [jQuery](/concepts/Common/Modularity/02%20DevExtreme%20Modules%20Structure/integration/jquery.md '/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/jquery') integration modules;
-- **Knockout**: DevExtreme [Knockout integration](/concepts/Common/Modularity/02%20DevExtreme%20Modules%20Structure/integration/knockout.md '/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/knockout') module.
+[tags] jquery

--- a/concepts/Common/Modularity/01 Link Modules/20 Use jspm.md
+++ b/concepts/Common/Modularity/01 Link Modules/20 Use jspm.md
@@ -25,10 +25,6 @@
             System.import('./index.js');
         </script>
 
-See examples of using jspm with <a href="https://github.com/DevExpress/devextreme-examples/tree/22_1/jspm-jquery" target="_blank">jQuery</a>, <a href="https://github.com/DevExpress/devextreme-examples/tree/22_1/jspm-angularjs" target="_blank">AngularJS</a>, and <a href="https://github.com/DevExpress/devextreme-examples/tree/22_1/jspm-knockout" target="_blank">Knockout</a> on GitHub. The **index.js** and **index.html** files contain the main code. 
+See examples on how to use jspm with <a href="https://github.com/DevExpress/devextreme-examples/tree/22_2/" target="_blank">jQuery</a> on GitHub. The **index.js** and **index.html** files contain the main code. Note that jQuery components require additional [integration module](/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/jquery).
 
-The following list shows additional modules each library/framework requires: 
-
-- **jQuery**: DevExtreme [jQuery integration](/concepts/Common/Modularity/02%20DevExtreme%20Modules%20Structure/integration/jquery.md '/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/jquery') module;
-- **AngularJS**: jQuery, DevExtreme [AngularJS](/concepts/Common/Modularity/02%20DevExtreme%20Modules%20Structure/integration/angular.md '/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/angular') and [jQuery](/concepts/Common/Modularity/02%20DevExtreme%20Modules%20Structure/integration/jquery.md '/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/jquery') integration modules;
-- **Knockout**: DevExtreme [Knockout integration](/concepts/Common/Modularity/02%20DevExtreme%20Modules%20Structure/integration/knockout.md '/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/knockout') module.
+[tags] jquery

--- a/concepts/Common/Modularity/01 Link Modules/30 Use RequireJS.md
+++ b/concepts/Common/Modularity/01 Link Modules/30 Use RequireJS.md
@@ -26,12 +26,8 @@
             });
         </script>
 
-See examples of using RequireJS with <a href="https://github.com/DevExpress/devextreme-examples/tree/22_1/requirejs-jquery" target="_blank">jQuery</a>, <a href="https://github.com/DevExpress/devextreme-examples/tree/22_1/requirejs-angularjs" target="_blank">AngularJS</a>, and <a href="https://github.com/DevExpress/devextreme-examples/tree/22_1/requirejs-knockout" target="_blank">Knockout</a> on GitHub. The **index.html** file contains the main code. 
+You can see examples on how to use RequireJS with <a href="https://github.com/DevExpress/devextreme-examples/tree/22_2/" target="_blank">jQuery</a> on GitHub. The **index.html** file contains the main code. jQuery components require additional [integration module](/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/jquery).
 
-The following list shows additional modules each library/framework requires: 
+[note] We recommend to use [Webpack](/concepts/Common/Modularity/01%20Link%20Modules/10%20Use%20Webpack.md '/Documentation/Guide/Common/Modularity/#Link_Modules/Use_Webpack') or [jspm](/concepts/Common/Modularity/01%20Link%20Modules/20%20Use%20jspm.md '/Documentation/Guide/Common/Modularity/#Link_Modules/Use_jspm') for better performance.
 
-- **jQuery**: DevExtreme [jQuery integration](/concepts/Common/Modularity/02%20DevExtreme%20Modules%20Structure/integration/jquery.md '/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/jquery') module;
-- **AngularJS**: jQuery, DevExtreme [AngularJS](/concepts/Common/Modularity/02%20DevExtreme%20Modules%20Structure/integration/angular.md '/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/angular') and [jQuery](/concepts/Common/Modularity/02%20DevExtreme%20Modules%20Structure/integration/jquery.md '/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/jquery') integration modules;
-- **Knockout**: DevExtreme [Knockout integration](/concepts/Common/Modularity/02%20DevExtreme%20Modules%20Structure/integration/knockout.md '/Documentation/Guide/Common/Modularity/DevExtreme_Modules_Structure/#integration/knockout') module.
-
-[note] We recommend using [Webpack](/concepts/Common/Modularity/01%20Link%20Modules/10%20Use%20Webpack.md '/Documentation/Guide/Common/Modularity/#Link_Modules/Use_Webpack') or [jspm](/concepts/Common/Modularity/01%20Link%20Modules/20%20Use%20jspm.md '/Documentation/Guide/Common/Modularity/#Link_Modules/Use_jspm') for better performance.
+[tags] jquery


### PR DESCRIPTION
* Correct framework usage in new docs: ButtonGroup

* Correct framework usage in new docs: Funnel

* Correct framework usage in new docs: Custom Sources

* Correct framework usage in new docs: CDN for jQuery only

* Correct framework usage in new docs: Localization

* Correct framework usage in new docs: Upgrade DevExtreme Sources

* Correct framework usage in new docs: Link modules for jQuery only
