### PR TITLE
ColumnHeaderFilter - Merge inherited types members ref 4896

### DIFF
--- a/api-reference/_hidden/GridBaseColumn/headerFilter/search/search.md
+++ b/api-reference/_hidden/GridBaseColumn/headerFilter/search/search.md
@@ -1,7 +1,7 @@
 ---
 id: GridBaseColumn.headerFilter.search
 type: ColumnHeaderFilterSearchConfig
-inheritsType: ColumnHeaderFilterSearchConfig
+inheritsType: ColumnHeaderFilterSearchConfig,HeaderFilterSearchConfig
 ---
 ---
 ##### shortDescription


### PR DESCRIPTION
Display merged ColumnHeaderFilterSearchConfig + HeaderFilterSearchConfig members under GridBaseColumn/headerFilter/search node
Ref https://github.com/DevExpress/devextreme-documentation/pull/4896