### PR TITLE
Rename tools scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/DevExpress/devextreme-documentation.git"
   },
   "devDependencies": {
-    "devextreme-internal-tools": "^10.0.0-beta.18",
+    "devextreme-internal-tools": "^12.0.0-beta.1",
     "ts-node": "^10.9.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "ts-node": "^10.9.1"
   },
   "scripts": {
-    "generate-content-map": "dx-tools generate-content-map --docs-root ./ --version 23.2 --syntaxdata-path ./metadata/syntax-data.json",
-    "generate-syntax-data": "dx-tools generate-syntax-data --output-path ./metadata/syntax-data.json",
-    "generate-extra-topic": "dx-tools generate-extra-topics --docs-root ./ --version 23.2",
-    "update-topics": "dx-tools update-topics --docs-root ./",
-    "update-links": "dx-tools update-links --docs-root ./",
-    "validate-docs": "dx-tools validate-docs --docs-root ./",
-    "validate-modules-guide": "dx-tools validate-modules-guide --modules-meta ./metadata/modules-meta.json --modules-guide-path \"./concepts/Common/Modularity/02 DevExtreme Modules Structure\"",
-    "validate-links": "dx-tools update-links --docs-root ./ --validation true",
+    "generate-content-map": "dx-tools make-content-map --docs-root-path ./ --version 23.2 --syntax-meta-path ./metadata/syntax-data.json",
+    "generate-syntax-data": "dx-tools make-syntax-metadata --output-path ./metadata/syntax-data.json",
+    "generate-extra-topic": "dx-tools generate-extra-topics --docs-root-path ./ --version 23.2",
+    "update-topics": "dx-tools generate-topics --docs-root-path ./",
+    "update-links": "dx-tools convert-links --docs-root-path ./",
+    "validate-docs": "dx-tools validate-topics --docs-root-path ./",
+    "validate-modules-guide": "dx-tools validate-modules-guide --modules-meta-path ./metadata/modules-meta.json --modules-guide-path \"./concepts/Common/Modularity/02 DevExtreme Modules Structure\"",
+    "validate-links": "dx-tools convert-links --docs-root-path ./ --validation true",
     "rename-topics": "ts-node ./tools/updateFolder.ts",
     "rename-uid": "ts-node ./tools/rename-uid.ts ./api-reference uid-map.json"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/DevExpress/devextreme-documentation.git"
   },
   "devDependencies": {
-    "devextreme-internal-tools": "^12.0.0-beta.1",
+    "devextreme-internal-tools": "12.0.0-beta.1",
     "ts-node": "^10.9.1"
   },
   "scripts": {


### PR DESCRIPTION
Sync repo's scripts calls according to renamed tools' scripts. Own repo's scripts names are not changed.