### PR TITLE
dxTreeListColumnButton.onClick: Use own field description

### DIFF
--- a/api-reference/_hidden/dxTreeListColumnButton/onClick.md
+++ b/api-reference/_hidden/dxTreeListColumnButton/onClick.md
@@ -22,7 +22,7 @@ type: function(e)
 <!-- %field(e.event)% -->
 
 ##### field(e.model): any
-<!-- %field(e.model)% -->
+The model data. Available only if you use Knockout.
 
 ##### field(e.row): dxTreeListRowObject
 <!-- %field(e.row)% -->


### PR DESCRIPTION
The Full ContentMap Preparer fails on attempt to calculate an imported field description, removed for DataGrid counterpart at:
#5712

The DataGrid Type was changed at:
#5506