### PR TITLE
Bump devextreme-internal-tools to "^14.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/DevExpress/devextreme-documentation.git"
   },
   "devDependencies": {
-    "devextreme-internal-tools": "^12.0.0-beta.16",
+    "devextreme-internal-tools": "^14.0.0",
     "ts-node": "^10.9.1"
   },
   "scripts": {


### PR DESCRIPTION
Fix DocGen CI:
Makes it possible to create a new topic, when adding a new "onABC" prop in sources:
`\api-reference\NewTopics\dx[COMPONENT_NAME]\4 Events\ABC` from `\api-reference\NewTopics\dx[COMPONENT_NAME]\1 Configuration\onABC`
https://github.com/DevExpress/devextreme-documentation/actions/runs/10033076545