### PR TITLE
CI: Use PAT in docgen

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -105,7 +105,7 @@ jobs:
             curl \
                 -X POST \
                 -H "Accept: application/vnd.github.v3+json" \
-                -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                -H "Authorization: Bearer ${{ secrets.DXROBOT_PAT }}" \
                 https://api.github.com/repos/${{ github.repository }}/pulls \
                 --data-binary @prdata.json
 


### PR DESCRIPTION
Create PR using PAT (instead of built-in token). No need to reopen PRs to run checks.