### PR TITLE
Remove See Also: 'Column - HeaderFilter - Search - EditorOptions' link

### DIFF
--- a/api-reference/10 UI Components/GridBase/1 Configuration/headerFilter/search/editorOptions.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/headerFilter/search/editorOptions.md
@@ -1,4 +1,3 @@
-
 See the [TextBox Configuration](/Documentation/ApiReference/UI_Components/dxTextBox/Configuration/) topic for information about properties you can specify in this object.
 
 #include widgets-config-object-option-note with {
@@ -6,6 +5,3 @@ See the [TextBox Configuration](/Documentation/ApiReference/UI_Components/dxText
 }
 
 #include header-filter-editor-options-code
-
-#####See Also#####
-- [editorOptions](/Documentation/ApiReference/UI_Components/dx{WidgetName}/Configuration/columns/headerFilter/search/#editorOptions)

--- a/api-reference/40 Common Types/15 grids/HeaderFilterSearchConfig/editorOptions.md
+++ b/api-reference/40 Common Types/15 grids/HeaderFilterSearchConfig/editorOptions.md
@@ -3,6 +3,7 @@ id: HeaderFilterSearchConfig.editorOptions
 type: any
 default: {}
 ---
+---
 ##### shortDescription
 Configures the search box.
 


### PR DESCRIPTION
### Cherry-picks
- #7797

Patch for:
- #7388 

The `Configuration/columns/headerFilter/search/*` (`Configuration/columns/headerFilter/search/#editorOptions`) prop is no longer in a structure (moved to a type)