### PR TITLE
Update Theme Mentions to Fluent - Grids Guides

### DIFF
--- a/concepts/05 UI Components/CardView/05 Getting Started with CardView/05 Create a CardView.md
+++ b/concepts/05 UI Components/CardView/05 Getting Started with CardView/05 Create a CardView.md
@@ -81,7 +81,7 @@
     </template>
 
     <script setup lang="ts">
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxCardView from 'devextreme-vue/card-view';
     </script>
 
@@ -91,7 +91,7 @@
 
     <!-- tab: App.tsx -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import CardView from 'devextreme-react/card-view';
 
     function App() {

--- a/concepts/05 UI Components/CardView/05 Getting Started with CardView/10 Bind CardView to Data.md
+++ b/concepts/05 UI Components/CardView/05 Getting Started with CardView/10 Bind CardView to Data.md
@@ -250,7 +250,7 @@ The CardView component can load and update data from different data source types
 
     <!-- tab: App.tsx -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import CardView from 'devextreme-react/card-view';
     import { employees } from './data.ts';
 

--- a/concepts/05 UI Components/CardView/05 Getting Started with CardView/15 Configure Columns (Fields).md
+++ b/concepts/05 UI Components/CardView/05 Getting Started with CardView/15 Configure Columns (Fields).md
@@ -64,7 +64,7 @@ The following code snippet restricts the CardView columns (fields) to `FullName`
 
     <!-- tab: App.tsx -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import CardView, { Column } from 'devextreme-react/card-view';
     import { employees } from './data.ts';
 

--- a/concepts/05 UI Components/CardView/05 Getting Started with CardView/20 Filter and Search Data.md
+++ b/concepts/05 UI Components/CardView/05 Getting Started with CardView/20 Filter and Search Data.md
@@ -49,7 +49,7 @@ In this tutorial, the header filter and the search panel are displayed:
 
     <!-- tab: App.tsx -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import CardView, { HeaderFilter, SearchPanel } from 'devextreme-react/card-view';
     import { employees } from './data.ts';
 

--- a/concepts/05 UI Components/CardView/05 Getting Started with CardView/25 Select Cards.md
+++ b/concepts/05 UI Components/CardView/05 Getting Started with CardView/25 Select Cards.md
@@ -38,7 +38,7 @@ CardView supports single and multiple selection modes. Use the **selection**.[mo
 
     <!-- tab: App.tsx -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import CardView, { Selection } from 'devextreme-react/card-view';
     import { employees } from './data.ts';
 

--- a/concepts/05 UI Components/CardView/05 Getting Started with CardView/30 Add Pagination.md
+++ b/concepts/05 UI Components/CardView/05 Getting Started with CardView/30 Add Pagination.md
@@ -56,7 +56,7 @@ To add pagination to CardView, configure the following settings:
 
     <!-- tab: App.tsx -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import CardView, { Paging, Pager } from 'devextreme-react/card-view';
     import { employees } from './data.ts';
 

--- a/concepts/05 UI Components/CardView/05 Getting Started with CardView/35 Configure Column Chooser.md
+++ b/concepts/05 UI Components/CardView/05 Getting Started with CardView/35 Configure Column Chooser.md
@@ -70,7 +70,7 @@ You can also specify other column chooser settings, such as [mode](/api-referenc
 
     <!-- tab: App.tsx -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import CardView, { ColumnChooser, Position, Selection } from 'devextreme-react/card-view';
     import { employees } from './data.ts';
 

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/02 Create a DataGrid.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/02 Create a DataGrid.md
@@ -93,7 +93,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid } from 'devextreme-vue/data-grid';
 
@@ -116,7 +116,7 @@
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DataGrid

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/05 Bind the DataGrid to Data.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/05 Bind the DataGrid to Data.md
@@ -576,7 +576,7 @@ The DataGrid component can load and update data from different data source types
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DataGrid

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/10 Customize Columns/3 Reorder Columns.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/10 Customize Columns/3 Reorder Columns.md
@@ -97,7 +97,7 @@ To reorder grid columns, change their order in the [columns](/api-reference/10%2
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DataGrid,

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/10 Customize Columns/5 Resize Columns.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/10 Customize Columns/5 Resize Columns.md
@@ -88,7 +88,7 @@ Grid columns have equal widths by default. You can set each column's [width](/ap
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DataGrid,

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/10 Customize Columns/6 Fix Columns.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/10 Customize Columns/6 Fix Columns.md
@@ -71,7 +71,7 @@ The following code fixes the `FullName` column to the default position and allow
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DataGrid,

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/10 Customize Columns/8 Hide Columns.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/10 Customize Columns/8 Hide Columns.md
@@ -60,7 +60,7 @@ The DataGrid displays all columns from the [columns](/api-reference/10%20UI%20Co
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DataGrid,

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/20 Sort Data.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/20 Sort Data.md
@@ -70,7 +70,7 @@ You can also set a column's [sortOrder](/api-reference/_hidden/GridBaseColumn/so
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DataGrid,

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/30 Filter and Search Data.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/30 Filter and Search Data.md
@@ -64,7 +64,7 @@ In this tutorial, the [filterRow](/api-reference/10%20UI%20Components/GridBase/1
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DataGrid,

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/35 Group Data.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/35 Group Data.md
@@ -74,7 +74,7 @@ To group data in code, specify a column's [groupIndex](/api-reference/_hidden/dx
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DataGrid,

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/40 Edit and Validate Data.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/40 Edit and Validate Data.md
@@ -132,7 +132,7 @@ DevExtreme includes a validation engine that checks edited values before they ar
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DataGrid,

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/50 Select Records.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/50 Select Records.md
@@ -163,7 +163,7 @@ You can obtain the selected record's data in the [onSelectionChanged](/api-refer
 
     <!-- tab: App.js -->
     import React, { useCallback, useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import './App.css';
 
     import {

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/60 Display Summaries.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/60 Display Summaries.md
@@ -76,7 +76,7 @@ The code below configures a group summary that counts grid records in each group
 
     <!-- tab: App.js -->
     import React, { useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import './App.css';
 
     import {

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/65 Customize the Toolbar.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/65 Customize the Toolbar.md
@@ -150,7 +150,7 @@
 
     <!-- tab: App.js -->
     import React, { useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import './App.css';
 
     import {

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/70 Configure Master-Detail Interface.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/70 Configure Master-Detail Interface.md
@@ -191,7 +191,7 @@ DataGrid allows you to display expandable detail sections under data rows. To co
 
     <!-- tab: App.js -->
     import React, { useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import './App.css';
 
     import {

--- a/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/80 Export Data.md
+++ b/concepts/05 UI Components/DataGrid/00 Getting Started with DataGrid/80 Export Data.md
@@ -198,7 +198,7 @@ When users click "Export all data to PDF", **pdfExporter**.[exportDataGrid(optio
 
     <!-- tab: App.js -->
     import React, { useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import './App.css';
 
     import {

--- a/concepts/05 UI Components/DataGrid/10 Enhance Performance on Large Datasets/010 Remote Operations.md
+++ b/concepts/05 UI Components/DataGrid/10 Enhance Performance on Large Datasets/010 Remote Operations.md
@@ -64,7 +64,7 @@ Specify the [remoteOperations](/api-reference/10%20UI%20Components/dxDataGrid/1%
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxRemoteOperations
@@ -84,7 +84,7 @@ Specify the [remoteOperations](/api-reference/10%20UI%20Components/dxDataGrid/1%
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         RemoteOperations

--- a/concepts/05 UI Components/DataGrid/10 Enhance Performance on Large Datasets/015 Deferred Selection.md
+++ b/concepts/05 UI Components/DataGrid/10 Enhance Performance on Large Datasets/015 Deferred Selection.md
@@ -69,7 +69,7 @@ Use deferred mode to increase the DataGrid's performance when [selecting multipl
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSelection
@@ -100,7 +100,7 @@ Use deferred mode to increase the DataGrid's performance when [selecting multipl
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Selection

--- a/concepts/05 UI Components/DataGrid/10 Enhance Performance on Large Datasets/020 Lookup Optimization.md
+++ b/concepts/05 UI Components/DataGrid/10 Enhance Performance on Large Datasets/020 Lookup Optimization.md
@@ -91,7 +91,7 @@ You can send the human-readable values from the server as a part of the main dat
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -129,7 +129,7 @@ You can send the human-readable values from the server as a part of the main dat
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,

--- a/concepts/05 UI Components/DataGrid/15 Columns/00 Overview.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/00 Overview.md
@@ -52,7 +52,7 @@ Columns represent sets of data values that have the same type. To configure colu
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -72,7 +72,7 @@ Columns represent sets of data values that have the same type. To configure colu
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column
@@ -148,7 +148,7 @@ The DataGrid generates a column per data field if you do not specify the **colum
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -170,7 +170,7 @@ The DataGrid generates a column per data field if you do not specify the **colum
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/1 Data Columns.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/1 Data Columns.md
@@ -54,7 +54,7 @@ A data column automatically detects the type of its values. However, if the valu
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -74,7 +74,7 @@ A data column automatically detects the type of its values. However, if the valu
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column

--- a/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/2 Band Columns.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/2 Band Columns.md
@@ -56,7 +56,7 @@ To set up this layout, describe the hierarchy of columns directly in an object o
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -76,7 +76,7 @@ To set up this layout, describe the hierarchy of columns directly in an object o
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column
@@ -168,7 +168,7 @@ If you use the [customizeColumns](/api-reference/10%20UI%20Components/dxDataGrid
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -198,7 +198,7 @@ If you use the [customizeColumns](/api-reference/10%20UI%20Components/dxDataGrid
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 
@@ -306,7 +306,7 @@ Band columns support hierarchies of any nesting level and enables you to use the
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -326,7 +326,7 @@ Band columns support hierarchies of any nesting level and enables you to use the
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column

--- a/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/3 Lookup Columns.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/3 Lookup Columns.md
@@ -94,7 +94,7 @@ Each lookup column has an individual [data source](/api-reference/_hidden/GridBa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -140,7 +140,7 @@ Each lookup column has an individual [data source](/api-reference/_hidden/GridBa
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,
@@ -255,7 +255,7 @@ Each lookup column has an individual [data source](/api-reference/_hidden/GridBa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -293,7 +293,7 @@ Each lookup column has an individual [data source](/api-reference/_hidden/GridBa
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,

--- a/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/4 Command Columns/05 Configure a Command Column.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/4 Command Columns/05 Configure a Command Column.md
@@ -47,7 +47,7 @@ The following example shows how to specify the adaptive column's [width](/api-re
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -71,7 +71,7 @@ The following example shows how to specify the adaptive column's [width](/api-re
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column
@@ -173,7 +173,7 @@ If a command column should have custom content, specify the column's [cellTempla
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -197,7 +197,7 @@ If a command column should have custom content, specify the column's [cellTempla
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column

--- a/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/4 Command Columns/15 Customize the Edit Column/1 Customize Buttons.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/4 Command Columns/15 Customize the Edit Column/1 Customize Buttons.md
@@ -61,7 +61,7 @@ In the following code, a CSS class is added to the **Save** button. The **Edit**
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -87,7 +87,7 @@ In the following code, a CSS class is added to the **Save** button. The **Edit**
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,
@@ -218,7 +218,7 @@ You can also declare custom logic in the button configuration. For instance, the
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,

--- a/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/4 Command Columns/15 Customize the Edit Column/2 Hide a Button.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/4 Command Columns/15 Customize the Edit Column/2 Hide a Button.md
@@ -63,7 +63,7 @@ The **Edit** and **Delete** buttons can be hidden by omitting them when declarin
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxEditing,
@@ -91,7 +91,7 @@ The **Edit** and **Delete** buttons can be hidden by omitting them when declarin
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Editing,

--- a/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/4 Command Columns/15 Customize the Edit Column/3 Add a Custom Button.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/4 Command Columns/15 Customize the Edit Column/3 Add a Custom Button.md
@@ -75,7 +75,7 @@ Add and configure custom buttons in the **columns[]**.[buttons](/api-reference/_
 
     <script>
     import { ref } from 'vue';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxDataGrid, { DxColumn, DxButton } from 'devextreme-vue/data-grid';
 
     const savedRows = ref([]);
@@ -89,7 +89,7 @@ Add and configure custom buttons in the **columns[]**.[buttons](/api-reference/_
 
     <!-- tab: App.js -->
     import React, { useCallback, useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DataGrid, { Column, Button } from 'devextreme-react/data-grid';
 
     function App () {
@@ -212,7 +212,7 @@ Specify the **buttons[]**.[template](/api-reference/_hidden/dxDataGridColumnButt
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -238,7 +238,7 @@ Specify the **buttons[]**.[template](/api-reference/_hidden/dxDataGridColumnButt
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,

--- a/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/4 Command Columns/30 Create a Column with Custom Buttons.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/10 Column Types/4 Command Columns/30 Create a Column with Custom Buttons.md
@@ -67,7 +67,7 @@ The following code shows how to add a command column with custom [buttons](/api-
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -93,7 +93,7 @@ The following code shows how to add a command column with custom [buttons](/api-
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,

--- a/concepts/05 UI Components/DataGrid/15 Columns/15 Customize Column Headers.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/15 Customize Column Headers.md
@@ -49,7 +49,7 @@ Specify the **columns**.[caption](/api-reference/_hidden/GridBaseColumn/caption.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -69,7 +69,7 @@ Specify the **columns**.[caption](/api-reference/_hidden/GridBaseColumn/caption.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column
@@ -172,7 +172,7 @@ If you need a more specific customization, define a custom template in the **col
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -192,7 +192,7 @@ If you need a more specific customization, define a custom template in the **col
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column
@@ -283,7 +283,7 @@ To hide column headers, assign **false** to the [showColumnHeaders](/api-referen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -300,7 +300,7 @@ To hide column headers, assign **false** to the [showColumnHeaders](/api-referen
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/15 Columns/25 Column Reordering/05 User Interaction.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/25 Column Reordering/05 User Interaction.md
@@ -49,7 +49,7 @@ If a specific column should not be moved, set its [allowReordering](/api-referen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -69,7 +69,7 @@ If a specific column should not be moved, set its [allowReordering](/api-referen
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column

--- a/concepts/05 UI Components/DataGrid/15 Columns/25 Column Reordering/10 API.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/25 Column Reordering/10 API.md
@@ -46,7 +46,7 @@ The [columns](/api-reference/10%20UI%20Components/dxDataGrid/1%20Configuration/c
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -67,7 +67,7 @@ The [columns](/api-reference/10%20UI%20Components/dxDataGrid/1%20Configuration/c
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 
@@ -131,7 +131,7 @@ The **visibleIndex** property can also be changed at runtime to reorder columns 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -160,7 +160,7 @@ The **visibleIndex** property can also be changed at runtime to reorder columns 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/15 Columns/30 Column Fixing.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/30 Column Fixing.md
@@ -54,7 +54,7 @@ To allow this, set the **columnFixing**.[enabled](/api-reference/10%20UI%20Compo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -76,7 +76,7 @@ To allow this, set the **columnFixing**.[enabled](/api-reference/10%20UI%20Compo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,
@@ -143,7 +143,7 @@ If a column should be fixed initially, assign **true** to its [fixed](/api-refer
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -164,7 +164,7 @@ If a column should be fixed initially, assign **true** to its [fixed](/api-refer
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column

--- a/concepts/05 UI Components/DataGrid/15 Columns/35 Hide a Column Using the API.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/35 Hide a Column Using the API.md
@@ -67,7 +67,7 @@ A column is considered hidden when its [visible](/api-reference/_hidden/GridBase
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -98,7 +98,7 @@ A column is considered hidden when its [visible](/api-reference/_hidden/GridBase
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column

--- a/concepts/05 UI Components/DataGrid/15 Columns/40 Customize Cells/1 Customize the Value and Text.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/40 Customize Cells/1 Customize the Value and Text.md
@@ -57,7 +57,7 @@ Use the [customizeText](/api-reference/_hidden/GridBaseColumn/customizeText.md '
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -81,7 +81,7 @@ Use the [customizeText](/api-reference/_hidden/GridBaseColumn/customizeText.md '
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column
@@ -173,7 +173,7 @@ To use the text displayed in cells in those data processing operations, specify 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -197,7 +197,7 @@ To use the text displayed in cells in those data processing operations, specify 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column

--- a/concepts/05 UI Components/DataGrid/15 Columns/40 Customize Cells/2 Customize Cell Appearance.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/40 Customize Cells/2 Customize Cell Appearance.md
@@ -62,7 +62,7 @@ Remove the `e.column.dataField === "Speed"` condition to apply the appearance to
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -89,7 +89,7 @@ Remove the `e.column.dataField === "Speed"` condition to apply the appearance to
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 
@@ -182,7 +182,7 @@ The example below shows how to use the [columns](/api-reference/10%20UI%20Compon
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -209,7 +209,7 @@ The example below shows how to use the [columns](/api-reference/10%20UI%20Compon
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column

--- a/concepts/05 UI Components/DataGrid/15 Columns/40 Customize Cells/3 Customize Row Apperance.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/40 Customize Cells/3 Customize Row Apperance.md
@@ -90,7 +90,7 @@ The following example demonstrates how to use the [onRowPrepared](/api-reference
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -119,7 +119,7 @@ The following example demonstrates how to use the [onRowPrepared](/api-reference
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/15 Columns/50 Adaptability/05 Hide Columns.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/50 Adaptability/05 Hide Columns.md
@@ -64,7 +64,7 @@ You can use the **columns[]**.[hidingPriority](/api-reference/_hidden/GridBaseCo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -84,7 +84,7 @@ You can use the **columns[]**.[hidingPriority](/api-reference/_hidden/GridBaseCo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column
@@ -149,7 +149,7 @@ If your DataGrid is inside a resizable container, you must call the [updateDimen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -181,7 +181,7 @@ If your DataGrid is inside a resizable container, you must call the [updateDimen
 
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DataGrid from 'devextreme-react/data-grid';
 
     export default function App() {

--- a/concepts/05 UI Components/DataGrid/15 Columns/50 Adaptability/15 Customize Adaptive Detail Row.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/50 Adaptability/15 Customize Adaptive Detail Row.md
@@ -53,7 +53,7 @@ Adaptive detail rows contain the [Form](/api-reference/10%20UI%20Components/dxFo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -78,7 +78,7 @@ Adaptive detail rows contain the [Form](/api-reference/10%20UI%20Components/dxFo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/15 Columns/50 Adaptability/20 Expand and Collapse Adaptive Detail Rows.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/50 Adaptability/20 Expand and Collapse Adaptive Detail Rows.md
@@ -43,7 +43,7 @@ You can call the [expandAdaptiveDetailRow(key)](/api-reference/10%20UI%20Compone
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -77,7 +77,7 @@ You can call the [expandAdaptiveDetailRow(key)](/api-reference/10%20UI%20Compone
 
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DataGrid from 'devextreme-react/data-grid';
 
     export default function App() {

--- a/concepts/05 UI Components/DataGrid/15 Columns/60 Column Chooser.md
+++ b/concepts/05 UI Components/DataGrid/15 Columns/60 Column Chooser.md
@@ -49,7 +49,7 @@ The column chooser allows a user to change the set of columns at runtime. It is 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumnChooser
@@ -69,7 +69,7 @@ The column chooser allows a user to change the set of columns at runtime. It is 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         ColumnChooser
@@ -156,7 +156,7 @@ Set a column's [allowHiding](/api-reference/_hidden/GridBaseColumn/allowHiding.m
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumnChooser,
@@ -178,7 +178,7 @@ Set a column's [allowHiding](/api-reference/_hidden/GridBaseColumn/allowHiding.m
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         ColumnChooser,
@@ -251,7 +251,7 @@ Call the [showColumnChooser()](/api-reference/10%20UI%20Components/GridBase/3%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -287,7 +287,7 @@ Call the [showColumnChooser()](/api-reference/10%20UI%20Components/GridBase/3%20
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/20 Editing/10 User Interaction/40 Form Mode.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/10 User Interaction/40 Form Mode.md
@@ -123,7 +123,7 @@ In the following code, the items with the specified **dataField** are simple ite
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxEditing,
@@ -155,7 +155,7 @@ In the following code, the items with the specified **dataField** are simple ite
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Editing,

--- a/concepts/05 UI Components/DataGrid/20 Editing/10 User Interaction/50 Popup Mode.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/10 User Interaction/50 Popup Mode.md
@@ -71,7 +71,7 @@ Use the **editing**.[popup](/api-reference/10%20UI%20Components/GridBase/1%20Con
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxEditing,
@@ -94,7 +94,7 @@ Use the **editing**.[popup](/api-reference/10%20UI%20Components/GridBase/1%20Con
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Editing,

--- a/concepts/05 UI Components/DataGrid/20 Editing/10 User Interaction/User Interaction.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/10 User Interaction/User Interaction.md
@@ -64,7 +64,7 @@ Grid data can be edited in several modes. Set the **editing**.[mode](/api-refere
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxEditing,
@@ -85,7 +85,7 @@ Grid data can be edited in several modes. Set the **editing**.[mode](/api-refere
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Editing,

--- a/concepts/05 UI Components/DataGrid/20 Editing/20 API/10 Add.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/20 API/10 Add.md
@@ -38,7 +38,7 @@ Use the [addRow()](/api-reference/10%20UI%20Components/dxDataGrid/3%20Methods/ad
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -59,7 +59,7 @@ Use the [addRow()](/api-reference/10%20UI%20Components/dxDataGrid/3%20Methods/ad
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 
@@ -142,7 +142,7 @@ You can specify initial values for a newly added row in the [onInitNewRow](/api-
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -166,7 +166,7 @@ You can specify initial values for a newly added row in the [onInitNewRow](/api-
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column

--- a/concepts/05 UI Components/DataGrid/20 Editing/20 API/20 Update.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/20 API/20 Update.md
@@ -62,7 +62,7 @@ The [cellValue(rowIndex, visibleColumnIndex, value)](/api-reference/10%20UI%20Co
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -98,7 +98,7 @@ The [cellValue(rowIndex, visibleColumnIndex, value)](/api-reference/10%20UI%20Co
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';
@@ -218,7 +218,7 @@ You can check if there are any unsaved changes by calling the [hasEditData()](/a
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -261,7 +261,7 @@ You can check if there are any unsaved changes by calling the [hasEditData()](/a
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/concepts/05 UI Components/DataGrid/20 Editing/30 Events/Events.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/30 Events/Events.md
@@ -55,7 +55,7 @@ The DataGrid UI component raises events before and after a row is inserted, upda
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -76,7 +76,7 @@ The DataGrid UI component raises events before and after a row is inserted, upda
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 
@@ -167,7 +167,7 @@ In addition, the DataGrid raises the [initNewRow](/api-reference/10%20UI%20Compo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -189,7 +189,7 @@ In addition, the DataGrid raises the [initNewRow](/api-reference/10%20UI%20Compo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/20 Editing/40 Customize Editors.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/40 Customize Editors.md
@@ -86,7 +86,7 @@ The columns's [dataType](/api-reference/_hidden/GridBaseColumn/dataType.md '/Doc
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -128,7 +128,7 @@ The columns's [dataType](/api-reference/_hidden/GridBaseColumn/dataType.md '/Doc
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column
@@ -293,7 +293,7 @@ Implement the column's [editCellTemplate](/api-reference/_hidden/dxDataGridColum
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -322,7 +322,7 @@ Implement the column's [editCellTemplate](/api-reference/_hidden/dxDataGridColum
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,
@@ -445,7 +445,7 @@ Editors are displayed in cells in the normal state too if you set the **columns*
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -464,7 +464,7 @@ Editors are displayed in cells in the normal state too if you set the **columns*
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column

--- a/concepts/05 UI Components/DataGrid/20 Editing/43 Customize Edit Form/10 Appearance and Editing/10 Form Layout Customization.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/43 Customize Edit Form/10 Appearance and Editing/10 Form Layout Customization.md
@@ -112,7 +112,7 @@ If you need to implement minor changes (for example, apply a style to a form ite
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxEditing,
@@ -142,7 +142,7 @@ If you need to implement minor changes (for example, apply a style to a form ite
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Editing,

--- a/concepts/05 UI Components/DataGrid/20 Editing/43 Customize Edit Form/10 Appearance and Editing/20 Editor Customization.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/43 Customize Edit Form/10 Appearance and Editing/20 Editor Customization.md
@@ -94,7 +94,7 @@ You can override the **onValueChanged** handler of the predefined editor and cha
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -125,7 +125,7 @@ You can override the **onValueChanged** handler of the predefined editor and cha
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/20 Editing/45 Disable Editing/20 Column.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/45 Disable Editing/20 Column.md
@@ -66,7 +66,7 @@ Set a column's [allowEditing](/api-reference/_hidden/GridBaseColumn/allowEditing
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, { Column } from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/20 Editing/45 Disable Editing/30 Row.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/45 Disable Editing/30 Row.md
@@ -75,7 +75,7 @@ To disable data editing within a specific row, follow the steps below:
 
     <!-- tab: App.js -->
     import React, { useCallback } from "react";
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid } from 'devextreme-react/data-grid';
 
@@ -182,7 +182,7 @@ DataGrid's [editing mode](/api-reference/10%20UI%20Components/dxDataGrid/1%20Con
 
     <!-- tab: App.js -->
     import React, { useCallback } from "react";
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, { Column, Button } from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/20 Editing/45 Disable Editing/40 Cell.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/45 Disable Editing/40 Cell.md
@@ -83,7 +83,7 @@ Handle the DataGrid's [onEditorPreparing](/api-reference/10%20UI%20Components/dx
 
     <!-- tab: App.js -->
     import React, { useCallback } from "react";
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid } from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/20 Editing/50 Data Validation.md
+++ b/concepts/05 UI Components/DataGrid/20 Editing/50 Data Validation.md
@@ -71,7 +71,7 @@ User input is validated against a set of [validation rules](/api-reference/10%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -94,7 +94,7 @@ User input is validated against a set of [validation rules](/api-reference/10%20
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,
@@ -178,7 +178,7 @@ The [onRowValidating](/api-reference/10%20UI%20Components/dxDataGrid/1%20Configu
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -202,7 +202,7 @@ The [onRowValidating](/api-reference/10%20UI%20Components/dxDataGrid/1%20Configu
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/25 Sorting/10 User Interaction.md
+++ b/concepts/05 UI Components/DataGrid/25 Sorting/10 User Interaction.md
@@ -44,7 +44,7 @@ With the DataGrid UI component, a user can sort by single and multiple columns. 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid, DxSorting } from 'devextreme-vue/data-grid';
 
@@ -61,7 +61,7 @@ With the DataGrid UI component, a user can sort by single and multiple columns. 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, Sorting } from 'devextreme-react/data-grid';
 
@@ -135,7 +135,7 @@ To disable sorting in the whole UI component, set the **sorting**.**mode** prope
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid, DxColumn } from 'devextreme-vue/data-grid';
 
@@ -152,7 +152,7 @@ To disable sorting in the whole UI component, set the **sorting**.**mode** prope
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, Column } from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/25 Sorting/20 API/1 Initial and Runtime Sorting.md
+++ b/concepts/05 UI Components/DataGrid/25 Sorting/20 API/1 Initial and Runtime Sorting.md
@@ -65,7 +65,7 @@ Rows are sorted according to the data source by default. Set the [sortOrder](/ap
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid, DxColumn } from 'devextreme-vue/data-grid';
 
@@ -82,7 +82,7 @@ Rows are sorted according to the data source by default. Set the [sortOrder](/ap
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, Column } from 'devextreme-react/data-grid';
 
@@ -160,7 +160,7 @@ Change the **sortOrder** and **sortIndex** properties using the [columnOption](/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid, DxColumn } from 'devextreme-vue/data-grid';
 
@@ -187,7 +187,7 @@ Change the **sortOrder** and **sortIndex** properties using the [columnOption](/
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, Column } from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/25 Sorting/20 API/5 Custom Sorting.md
+++ b/concepts/05 UI Components/DataGrid/25 Sorting/20 API/5 Custom Sorting.md
@@ -40,7 +40,7 @@ The following code snippet shows how to supply sorting values with a field name:
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxDataGrid, DxColumn } from 'devextreme-vue/data-grid';
     </script>
 
@@ -48,7 +48,7 @@ The following code snippet shows how to supply sorting values with a field name:
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, Column } from 'devextreme-react/data-grid';
 
@@ -124,7 +124,7 @@ The following code snippet shows how to use a function:
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxDataGrid, DxColumn } from 'devextreme-vue/data-grid';
 
     const calculateSortValue  = (rowData) => {
@@ -140,7 +140,7 @@ The following code snippet shows how to use a function:
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, Column } from 'devextreme-react/data-grid';
 
@@ -212,7 +212,7 @@ Alternatively, adjust sorting with [sortingMethod](/api-reference/_hidden/GridBa
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxDataGrid, DxColumn } from 'devextreme-vue/data-grid';
 
     const sortingMethod = (value1, value2) => {
@@ -225,7 +225,7 @@ Alternatively, adjust sorting with [sortingMethod](/api-reference/_hidden/GridBa
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, Column } from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/25 Sorting/20 API/8 Clear Sorting Settings.md
+++ b/concepts/05 UI Components/DataGrid/25 Sorting/20 API/8 Clear Sorting Settings.md
@@ -59,7 +59,7 @@ You can clear sorting settings for all columns by calling the [clearSorting()](/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid, DxColumn } from 'devextreme-vue/data-grid';
 
@@ -96,7 +96,7 @@ You can clear sorting settings for all columns by calling the [clearSorting()](/
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, Column } from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/30 Filtering and Searching/1 Filter Row.md
+++ b/concepts/05 UI Components/DataGrid/30 Filtering and Searching/1 Filter Row.md
@@ -59,7 +59,7 @@ To make the filter row visible, assign **true** to the [filterRow](/api-referenc
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -79,7 +79,7 @@ To make the filter row visible, assign **true** to the [filterRow](/api-referenc
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,
@@ -162,7 +162,7 @@ A user-specified filter is automatically applied with a delay by default. Altern
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxFilterRow
@@ -180,7 +180,7 @@ A user-specified filter is automatically applied with a delay by default. Altern
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         FilterRow
@@ -295,7 +295,7 @@ You can also preselect a filter operation and specify the initial filter value w
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -328,7 +328,7 @@ You can also preselect a filter operation and specify the initial filter value w
 
     <!-- tab: App.js -->
     import React, { useState, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,

--- a/concepts/05 UI Components/DataGrid/30 Filtering and Searching/2 Header Filter.md
+++ b/concepts/05 UI Components/DataGrid/30 Filtering and Searching/2 Header Filter.md
@@ -51,7 +51,7 @@ Assign **true** to the [headerFilter](/api-reference/10%20UI%20Components/GridBa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -71,7 +71,7 @@ Assign **true** to the [headerFilter](/api-reference/10%20UI%20Components/GridBa
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,
@@ -171,7 +171,7 @@ A user can change the applied filter by including or excluding values. Use a col
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -201,7 +201,7 @@ A user can change the applied filter by including or excluding values. Use a col
 
     <!-- tab: App.js -->
     import React, { useState, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column
@@ -325,7 +325,7 @@ You can use the **headerFilter.search.enabled** property to enable searching in 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -347,7 +347,7 @@ You can use the **headerFilter.search.enabled** property to enable searching in 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,

--- a/concepts/05 UI Components/DataGrid/30 Filtering and Searching/3 Search Panel.md
+++ b/concepts/05 UI Components/DataGrid/30 Filtering and Searching/3 Search Panel.md
@@ -51,7 +51,7 @@ To make the search panel visible, assign **true** to the [searchPanel](/api-refe
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -71,7 +71,7 @@ To make the search panel visible, assign **true** to the [searchPanel](/api-refe
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,
@@ -164,7 +164,7 @@ Use the **searchPanel**.[text](/api-reference/10%20UI%20Components/GridBase/1%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSearchPanel
@@ -192,7 +192,7 @@ Use the **searchPanel**.[text](/api-reference/10%20UI%20Components/GridBase/1%20
 
     <!-- tab: App.js -->
     import React, { useState, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         SearchPanel

--- a/concepts/05 UI Components/DataGrid/30 Filtering and Searching/4 Filter Panel with Filter Builder.md
+++ b/concepts/05 UI Components/DataGrid/30 Filtering and Searching/4 Filter Panel with Filter Builder.md
@@ -40,7 +40,7 @@ Set the **filterPanel**.[visible](/api-reference/10%20UI%20Components/GridBase/1
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {      
         DxFilterPanel
@@ -58,7 +58,7 @@ Set the **filterPanel**.[visible](/api-reference/10%20UI%20Components/GridBase/1
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         FilterPanel
@@ -114,7 +114,7 @@ If a user changes the filter expression in the filter panel or filter builder, t
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -129,7 +129,7 @@ If a user changes the filter expression in the filter panel or filter builder, t
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 
@@ -214,7 +214,7 @@ The **filterValue** is updated when a user changes the filter expression from th
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxFilterPanel
@@ -242,7 +242,7 @@ The **filterValue** is updated when a user changes the filter expression from th
 
     <!-- tab: App.js -->
     import React, { useState, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         FilterPanel
@@ -395,7 +395,7 @@ The DataGrid provides the [filterBuilder](/api-reference/10%20UI%20Components/Gr
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxButton from 'devextreme-vue/button';
 
@@ -439,7 +439,7 @@ The DataGrid provides the [filterBuilder](/api-reference/10%20UI%20Components/Gr
 
     <!-- tab: App.js -->
     import React, { useState, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Button from 'devextreme-react/button';
 

--- a/concepts/05 UI Components/DataGrid/30 Filtering and Searching/5 Standalone Filter Builder.md
+++ b/concepts/05 UI Components/DataGrid/30 Filtering and Searching/5 Standalone Filter Builder.md
@@ -74,7 +74,7 @@ The DataGrid UI component has an integrated filter builder that can be invoked u
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxFilterBuilder from 'devextreme-vue/filter-builder';
@@ -107,7 +107,7 @@ The DataGrid UI component has an integrated filter builder that can be invoked u
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import FilterBuilder from 'devextreme-react/filter-builder';
@@ -248,7 +248,7 @@ Then, add a button that updates a filter of the DataGrid's data source according
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxFilterBuilder from 'devextreme-vue/filter-builder';
@@ -290,7 +290,7 @@ Then, add a button that updates a filter of the DataGrid's data source according
 
     <!-- tab: App.js -->
     import React, { useRef, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import FilterBuilder from 'devextreme-react/filter-builder';

--- a/concepts/05 UI Components/DataGrid/30 Filtering and Searching/6 API/1 Initial and Runtime Filtering.md
+++ b/concepts/05 UI Components/DataGrid/30 Filtering and Searching/6 API/1 Initial and Runtime Filtering.md
@@ -46,7 +46,7 @@ The initial and runtime filtering API depends on the UI element and is described
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -83,7 +83,7 @@ The initial and runtime filtering API depends on the UI element and is described
 
     <!-- tab: App.js -->
     import React, { useRef, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 
@@ -166,7 +166,7 @@ You can create a filter that combines all the applied filters by calling the [ge
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -199,7 +199,7 @@ You can create a filter that combines all the applied filters by calling the [ge
 
     <!-- tab: App.js -->
     import React, { useRef, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/30 Filtering and Searching/6 API/5 Filtering Columns Bound to Collection/10 Client-Side Filtering.md
+++ b/concepts/05 UI Components/DataGrid/30 Filtering and Searching/6 API/5 Filtering Columns Bound to Collection/10 Client-Side Filtering.md
@@ -96,7 +96,7 @@ The following code example demonstrates how to filter data on the client. To imp
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -139,7 +139,7 @@ The following code example demonstrates how to filter data on the client. To imp
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column, RemoteOperations, 

--- a/concepts/05 UI Components/DataGrid/30 Filtering and Searching/6 API/5 Filtering Columns Bound to Collection/20 Server-Side Filtering.md
+++ b/concepts/05 UI Components/DataGrid/30 Filtering and Searching/6 API/5 Filtering Columns Bound to Collection/20 Server-Side Filtering.md
@@ -86,7 +86,7 @@ The following code example demonstrates how to bind the DataGrid to the [OData s
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -123,7 +123,7 @@ The following code example demonstrates how to bind the DataGrid to the [OData s
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column, 

--- a/concepts/05 UI Components/DataGrid/30 Filtering and Searching/6 API/8 Clear Filtering Settings.md
+++ b/concepts/05 UI Components/DataGrid/30 Filtering and Searching/6 API/8 Clear Filtering Settings.md
@@ -39,7 +39,7 @@ The [clearFilter(filterName)](/api-reference/10%20UI%20Components/GridBase/3%20M
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -72,7 +72,7 @@ The [clearFilter(filterName)](/api-reference/10%20UI%20Components/GridBase/3%20M
 
     <!-- tab: App.js -->
     import React, { useRef, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/35 Paging/10 User Interaction.md
+++ b/concepts/05 UI Components/DataGrid/35 Paging/10 User Interaction.md
@@ -59,7 +59,7 @@ Set the [showNavigationButtons](/api-reference/10%20UI%20Components/GridBase/1%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxPager
@@ -78,7 +78,7 @@ Set the [showNavigationButtons](/api-reference/10%20UI%20Components/GridBase/1%2
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Pager
@@ -157,7 +157,7 @@ Assign **true** to the [showInfo](/api-reference/10%20UI%20Components/GridBase/1
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxPager
@@ -176,7 +176,7 @@ Assign **true** to the [showInfo](/api-reference/10%20UI%20Components/GridBase/1
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Pager

--- a/concepts/05 UI Components/DataGrid/35 Paging/20 API.md
+++ b/concepts/05 UI Components/DataGrid/35 Paging/20 API.md
@@ -39,7 +39,7 @@ Call the [pageCount()](/api-reference/10%20UI%20Components/GridBase/3%20Methods/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -60,7 +60,7 @@ Call the [pageCount()](/api-reference/10%20UI%20Components/GridBase/3%20Methods/
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 
@@ -141,7 +141,7 @@ The DataGrid also provides the [pageIndex(newIndex)](/api-reference/10%20UI%20Co
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxPaging
@@ -175,7 +175,7 @@ The DataGrid also provides the [pageIndex(newIndex)](/api-reference/10%20UI%20Co
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Paging

--- a/concepts/05 UI Components/DataGrid/35 Paging/Paging.md
+++ b/concepts/05 UI Components/DataGrid/35 Paging/Paging.md
@@ -52,7 +52,7 @@ Paging is used to load data in portions, which improves the UI component's perfo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxPaging
@@ -71,7 +71,7 @@ Paging is used to load data in portions, which improves the UI component's perfo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Paging
@@ -138,7 +138,7 @@ When working with small datasets, you can disable paging by setting the **paging
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxPaging
@@ -157,7 +157,7 @@ When working with small datasets, you can disable paging by setting the **paging
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Paging

--- a/concepts/05 UI Components/DataGrid/40 Scrolling/Scrolling.md
+++ b/concepts/05 UI Components/DataGrid/40 Scrolling/Scrolling.md
@@ -70,7 +70,7 @@ Use the **scrolling**.[mode](/api-reference/10%20UI%20Components/dxDataGrid/1%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxScrolling
@@ -89,7 +89,7 @@ Use the **scrolling**.[mode](/api-reference/10%20UI%20Components/dxDataGrid/1%20
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Scrolling
@@ -156,7 +156,7 @@ The DataGrid adapts its scrolling mechanism to the current platform. It utilizes
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxScrolling
@@ -175,7 +175,7 @@ The DataGrid adapts its scrolling mechanism to the current platform. It utilizes
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Scrolling
@@ -252,7 +252,7 @@ The current platform determines the native scrolling settings and you cannot adj
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxScrolling
@@ -271,7 +271,7 @@ The current platform determines the native scrolling settings and you cannot adj
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Scrolling

--- a/concepts/05 UI Components/DataGrid/45 Grouping/10 User Interaction/10 Group Data.md
+++ b/concepts/05 UI Components/DataGrid/45 Grouping/10 User Interaction/10 Group Data.md
@@ -58,7 +58,7 @@ Assigning **true** to the **grouping**.[contextMenuEnabled](/api-reference/10%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxDataGrid,
@@ -80,7 +80,7 @@ Assigning **true** to the **grouping**.[contextMenuEnabled](/api-reference/10%20
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Grouping,
@@ -163,7 +163,7 @@ You can prevent a user from dragging columns to the group panel, in which case i
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxDataGrid,
@@ -183,7 +183,7 @@ You can prevent a user from dragging columns to the group panel, in which case i
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         GroupPanel
@@ -271,7 +271,7 @@ If a specific column should never take part in grouping, set its [allowGrouping]
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxDataGrid,
@@ -291,7 +291,7 @@ If a specific column should never take part in grouping, set its [allowGrouping]
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column

--- a/concepts/05 UI Components/DataGrid/45 Grouping/10 User Interaction/20 Expand and Collapse Groups.md
+++ b/concepts/05 UI Components/DataGrid/45 Grouping/10 User Interaction/20 Expand and Collapse Groups.md
@@ -52,7 +52,7 @@ Set the **grouping**.[expandMode](/api-reference/10%20UI%20Components/dxDataGrid
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxDataGrid,
@@ -72,7 +72,7 @@ Set the **grouping**.[expandMode](/api-reference/10%20UI%20Components/dxDataGrid
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Grouping,
@@ -146,7 +146,7 @@ You can prevent a user from expanding and collapsing groups by assigning **false
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxDataGrid,
@@ -166,7 +166,7 @@ You can prevent a user from expanding and collapsing groups by assigning **false
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Grouping,

--- a/concepts/05 UI Components/DataGrid/45 Grouping/20 API/10 Initial and Runtime Grouping.md
+++ b/concepts/05 UI Components/DataGrid/45 Grouping/20 API/10 Initial and Runtime Grouping.md
@@ -61,7 +61,7 @@ Assign a non-negative integer to the **columns**.[groupIndex](/api-reference/_hi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxDataGrid,
@@ -81,7 +81,7 @@ Assign a non-negative integer to the **columns**.[groupIndex](/api-reference/_hi
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,
@@ -181,7 +181,7 @@ You can change a column's **groupIndex** at runtime using the [columnOption(id, 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid, DxColumn } from 'devextreme-vue/data-grid';
 
@@ -208,7 +208,7 @@ You can change a column's **groupIndex** at runtime using the [columnOption(id, 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, Column } from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/45 Grouping/20 API/20 Expand and Collapse Groups.md
+++ b/concepts/05 UI Components/DataGrid/45 Grouping/20 API/20 Expand and Collapse Groups.md
@@ -68,7 +68,7 @@ The DataGrid provides the following API for expanding and collapsing groups:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import {
             DxDataGrid,
@@ -107,7 +107,7 @@ The DataGrid provides the following API for expanding and collapsing groups:
         
         <!-- tab: App.js -->
         import React, { useRef } from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
         import DataGrid, {
             Grouping
@@ -210,7 +210,7 @@ The DataGrid provides the following API for expanding and collapsing groups:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import {
             DxDataGrid,
@@ -246,7 +246,7 @@ The DataGrid provides the following API for expanding and collapsing groups:
         
         <!-- tab: App.js -->
         import React, { useRef } from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
         import DataGrid, {
             Column
@@ -329,7 +329,7 @@ The DataGrid provides the following API for expanding and collapsing groups:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import {
             DxDataGrid,
@@ -369,7 +369,7 @@ The DataGrid provides the following API for expanding and collapsing groups:
         
         <!-- tab: App.js -->
         import React, { useRef } from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
         import DataGrid, {
             // ...

--- a/concepts/05 UI Components/DataGrid/45 Grouping/20 API/30 Clear Grouping.md
+++ b/concepts/05 UI Components/DataGrid/45 Grouping/20 API/30 Clear Grouping.md
@@ -50,7 +50,7 @@ Set a column's [groupIndex](/api-reference/_hidden/dxDataGridColumn/groupIndex.m
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid, DxColumn } from 'devextreme-vue/data-grid';
 
@@ -77,7 +77,7 @@ Set a column's [groupIndex](/api-reference/_hidden/dxDataGridColumn/groupIndex.m
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, Column } from 'devextreme-react/data-grid';
 
@@ -160,7 +160,7 @@ You can ungroup data by all columns at once using the [clearGrouping()](/api-ref
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxDataGrid,
@@ -196,7 +196,7 @@ You can ungroup data by all columns at once using the [clearGrouping()](/api-ref
     
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         // ...

--- a/concepts/05 UI Components/DataGrid/45 Grouping/30 Events.md
+++ b/concepts/05 UI Components/DataGrid/45 Grouping/30 Events.md
@@ -68,7 +68,7 @@ You can execute certain commands before or after a row was expanded or collapsed
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid, DxColumn } from 'devextreme-vue/data-grid';
 
@@ -100,7 +100,7 @@ You can execute certain commands before or after a row was expanded or collapsed
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, Column } from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/50 Selection/10 User Interaction.md
+++ b/concepts/05 UI Components/DataGrid/50 Selection/10 User Interaction.md
@@ -45,7 +45,7 @@ The DataGrid UI component supports single and multiple row selection. Use the **
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSelection
@@ -64,7 +64,7 @@ The DataGrid UI component supports single and multiple row selection. Use the **
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Selection
@@ -140,7 +140,7 @@ The check box in the column's header selects all rows or only the currently rend
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSelection
@@ -159,7 +159,7 @@ The check box in the column's header selects all rows or only the currently rend
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Selection
@@ -232,7 +232,7 @@ You can prevent users from selecting all rows by setting the **selection**.[allo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSelection
@@ -251,7 +251,7 @@ You can prevent users from selecting all rows by setting the **selection**.[allo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Selection
@@ -324,7 +324,7 @@ The [showCheckBoxesMode](/api-reference/10%20UI%20Components/dxDataGrid/1%20Conf
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSelection
@@ -343,7 +343,7 @@ The [showCheckBoxesMode](/api-reference/10%20UI%20Components/dxDataGrid/1%20Conf
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Selection

--- a/concepts/05 UI Components/DataGrid/50 Selection/20 API/1 Initial and Runtime Selection.md
+++ b/concepts/05 UI Components/DataGrid/50 Selection/20 API/1 Initial and Runtime Selection.md
@@ -59,7 +59,7 @@ Use the [selectedRowKeys](/api-reference/10%20UI%20Components/dxDataGrid/1%20Con
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DataSource from 'devextreme/data/data_source';
@@ -92,7 +92,7 @@ Use the [selectedRowKeys](/api-reference/10%20UI%20Components/dxDataGrid/1%20Con
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import DataSource from 'devextreme/data/data_source';
@@ -191,7 +191,7 @@ The DataGrid provides two methods that select rows at runtime: [selectRows(keys,
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -218,7 +218,7 @@ The DataGrid provides two methods that select rows at runtime: [selectRows(keys,
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 
@@ -301,7 +301,7 @@ To select all rows at once, call the [selectAll()](/api-reference/10%20UI%20Comp
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -334,7 +334,7 @@ To select all rows at once, call the [selectAll()](/api-reference/10%20UI%20Comp
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 
@@ -412,7 +412,7 @@ Call the [getSelectedRowKeys()](/api-reference/10%20UI%20Components/dxDataGrid/3
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -448,7 +448,7 @@ Call the [getSelectedRowKeys()](/api-reference/10%20UI%20Components/dxDataGrid/3
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/50 Selection/20 API/8 Clear Selection Settings.md
+++ b/concepts/05 UI Components/DataGrid/50 Selection/20 API/8 Clear Selection Settings.md
@@ -37,7 +37,7 @@ Call the [deselectRows(keys)](/api-reference/10%20UI%20Components/GridBase/3%20M
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -71,7 +71,7 @@ Call the [deselectRows(keys)](/api-reference/10%20UI%20Components/GridBase/3%20M
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 
@@ -164,7 +164,7 @@ Call the [clearSelection()](/api-reference/10%20UI%20Components/GridBase/3%20Met
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -193,7 +193,7 @@ Call the [clearSelection()](/api-reference/10%20UI%20Components/GridBase/3%20Met
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/50 Selection/30 Events.md
+++ b/concepts/05 UI Components/DataGrid/50 Selection/30 Events.md
@@ -52,7 +52,7 @@ The DataGrid UI component raises the [selectionChanged](/api-reference/10%20UI%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -77,7 +77,7 @@ The DataGrid UI component raises the [selectionChanged](/api-reference/10%20UI%2
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/55 Load Panel/Load Panel.md
+++ b/concepts/05 UI Components/DataGrid/55 Load Panel/Load Panel.md
@@ -48,7 +48,7 @@ The load panel is shown only for remote data sources by default. To show it rega
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxLoadPanel
@@ -67,7 +67,7 @@ The load panel is shown only for remote data sources by default. To show it rega
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         LoadPanel
@@ -127,7 +127,7 @@ You can also control the load panel programmatically using the [beginCustomLoadi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         // ...
@@ -164,7 +164,7 @@ You can also control the load panel programmatically using the [beginCustomLoadi
 
     <!-- tab: App.js -->
     import React, { useRef, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         // ...
@@ -241,7 +241,7 @@ Since the load panel is a DevExtreme [LoadPanel](/concepts/05%20UI%20Components/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxLoadPanel
@@ -260,7 +260,7 @@ Since the load panel is a DevExtreme [LoadPanel](/concepts/05%20UI%20Components/
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         LoadPanel

--- a/concepts/05 UI Components/DataGrid/60 Master-Detail Interface/10 User Interaction.md
+++ b/concepts/05 UI Components/DataGrid/60 Master-Detail Interface/10 User Interaction.md
@@ -79,7 +79,7 @@ The master-detail interface becomes available after you specify the detail secti
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxMasterDetail
@@ -98,7 +98,7 @@ The master-detail interface becomes available after you specify the detail secti
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         MasterDetail

--- a/concepts/05 UI Components/DataGrid/60 Master-Detail Interface/20 API.md
+++ b/concepts/05 UI Components/DataGrid/60 Master-Detail Interface/20 API.md
@@ -44,7 +44,7 @@ Pass *-1* to the [expandAll(groupIndex)](/api-reference/10%20UI%20Components/dxD
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxDataGrid, { ... } from 'devextreme-vue/data-grid';
 
     const dataGridRefKey = "my-data-grid";
@@ -79,7 +79,7 @@ Pass *-1* to the [expandAll(groupIndex)](/api-reference/10%20UI%20Components/dxD
 
     <!-- tab: App.js -->
     import React, { useRef, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, { ... } from 'devextreme-react/data-grid';
 
@@ -155,7 +155,7 @@ The [expandRow(key)](/api-reference/10%20UI%20Components/dxDataGrid/3%20Methods/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxDataGrid, { ... } from 'devextreme-vue/data-grid';
 
     const dataGridRefKey = "my-data-grid";
@@ -191,7 +191,7 @@ The [expandRow(key)](/api-reference/10%20UI%20Components/dxDataGrid/3%20Methods/
 
     <!-- tab: App.js -->
     import React, { useRef, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, { ... } from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/65 Summaries/07 Custom Aggregate Function/10 Client-Side Data Aggregation.md
+++ b/concepts/05 UI Components/DataGrid/65 Summaries/07 Custom Aggregate Function/10 Client-Side Data Aggregation.md
@@ -69,7 +69,7 @@ Follow the steps below to configure custom client-side data aggregation.
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDataGrid, { 
             DxSummary,
@@ -90,7 +90,7 @@ Follow the steps below to configure custom client-side data aggregation.
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DataGrid, { 
             Summary,

--- a/concepts/05 UI Components/DataGrid/65 Summaries/07 Custom Aggregate Function/20 Server-Side Data Aggregation.md
+++ b/concepts/05 UI Components/DataGrid/65 Summaries/07 Custom Aggregate Function/20 Server-Side Data Aggregation.md
@@ -62,7 +62,7 @@ Follow the instructions below to implement custom server-side data aggregation. 
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDataGrid, { 
             DxSummary,
@@ -83,7 +83,7 @@ Follow the instructions below to implement custom server-side data aggregation. 
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DataGrid, { 
             Summary,

--- a/concepts/05 UI Components/DataGrid/65 Summaries/10 Total Summary/10 Alignment and Location.md
+++ b/concepts/05 UI Components/DataGrid/65 Summaries/10 Total Summary/10 Alignment and Location.md
@@ -65,7 +65,7 @@ A summary item is under the [column providing data](/api-reference/10%20UI%20Com
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSummary,
@@ -86,7 +86,7 @@ A summary item is under the [column providing data](/api-reference/10%20UI%20Com
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Summary,

--- a/concepts/05 UI Components/DataGrid/65 Summaries/10 Total Summary/Total Summary.md
+++ b/concepts/05 UI Components/DataGrid/65 Summaries/10 Total Summary/Total Summary.md
@@ -78,7 +78,7 @@ Configure each summary item in the **summary**.[totalItems](/api-reference/10%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -101,7 +101,7 @@ Configure each summary item in the **summary**.[totalItems](/api-reference/10%20
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column, 

--- a/concepts/05 UI Components/DataGrid/65 Summaries/20 Group Summary/10 Alignment and Location.md
+++ b/concepts/05 UI Components/DataGrid/65 Summaries/20 Group Summary/10 Alignment and Location.md
@@ -98,7 +98,7 @@ All group items are displayed in parentheses after the group header by default. 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -121,7 +121,7 @@ All group items are displayed in parentheses after the group header by default. 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column, 

--- a/concepts/05 UI Components/DataGrid/65 Summaries/20 Group Summary/15 Sort by Group Summary.md
+++ b/concepts/05 UI Components/DataGrid/65 Summaries/20 Group Summary/15 Sort by Group Summary.md
@@ -74,7 +74,7 @@ Groups are sorted by values of a column they are grouped by. You can also sort t
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSummary,
@@ -97,7 +97,7 @@ Groups are sorted by values of a column they are grouped by. You can also sort t
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Summary,
@@ -226,7 +226,7 @@ Summary-based sorting is applied when you group data by any column. If you need 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSummary,
@@ -249,7 +249,7 @@ Summary-based sorting is applied when you group data by any column. If you need 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Summary,

--- a/concepts/05 UI Components/DataGrid/65 Summaries/20 Group Summary/Group Summary.md
+++ b/concepts/05 UI Components/DataGrid/65 Summaries/20 Group Summary/Group Summary.md
@@ -89,7 +89,7 @@ Configure each summary item in the **summary**.[groupItems](/api-reference/10%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn,
@@ -112,7 +112,7 @@ Configure each summary item in the **summary**.[groupItems](/api-reference/10%20
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column, 

--- a/concepts/05 UI Components/DataGrid/65 Summaries/40 Format Text and Value.md
+++ b/concepts/05 UI Components/DataGrid/65 Summaries/40 Format Text and Value.md
@@ -68,7 +68,7 @@ Customize a summary item's text and value format using the [displayFormat](/api-
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSummary,
@@ -89,7 +89,7 @@ Customize a summary item's text and value format using the [displayFormat](/api-
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Summary,
@@ -182,7 +182,7 @@ Specify the **customizeText** function for a more detailed customization.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSummary,
@@ -208,7 +208,7 @@ Specify the **customizeText** function for a more detailed customization.
 
     <!-- tab: App.js -->
     import React, { useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Summary,

--- a/concepts/05 UI Components/DataGrid/70 Custom Keyboard Navigation/05 Change the Default Focused Cell.md
+++ b/concepts/05 UI Components/DataGrid/70 Custom Keyboard Navigation/05 Change the Default Focused Cell.md
@@ -47,7 +47,7 @@ To specify cell focus order when a user navigates through DataGrid, call the [on
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxDataGrid from 'devextreme-vue/data-grid';
     
     export default {
@@ -69,7 +69,7 @@ To specify cell focus order when a user navigates through DataGrid, call the [on
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DataGrid from 'devextreme-react/data-grid';
 
     const onFocusedCellChanging = (e) => {

--- a/concepts/05 UI Components/DataGrid/70 Custom Keyboard Navigation/15 Override and Create Keys.md
+++ b/concepts/05 UI Components/DataGrid/70 Custom Keyboard Navigation/15 Override and Create Keys.md
@@ -55,7 +55,7 @@ The following example shows how to override the **Space Bar** keystroke so it sw
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxDataGrid from 'devextreme-vue/data-grid';
 
     export default {
@@ -80,7 +80,7 @@ The following example shows how to override the **Space Bar** keystroke so it sw
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DataGrid from 'devextreme-react/data-grid';
 
     const onKeyDown = (e) => {

--- a/concepts/05 UI Components/DataGrid/73 Focused Row.md
+++ b/concepts/05 UI Components/DataGrid/73 Focused Row.md
@@ -81,7 +81,7 @@ You can specify the initially focused row using the [focusedRowKey](/api-referen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -97,7 +97,7 @@ You can specify the initially focused row using the [focusedRowKey](/api-referen
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/concepts/05 UI Components/DataGrid/99 How To/Bind a Lookup Column to a Custom Data Source.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Bind a Lookup Column to a Custom Data Source.md
@@ -102,7 +102,7 @@ In the following code snippet, `Author Name` is a [lookup column](/concepts/05%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxDataGrid, {
         DxColumn,
         DxLookup
@@ -143,7 +143,7 @@ In the following code snippet, `Author Name` is a [lookup column](/concepts/05%2
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,
@@ -309,7 +309,7 @@ The following alternative **CustomStore** configuration delegates data processin
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxDataGrid, {
         DxColumn,
         DxLookup
@@ -374,7 +374,7 @@ The following alternative **CustomStore** configuration delegates data processin
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column,

--- a/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/10 Specify a Custom Data Source.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/10 Specify a Custom Data Source.md
@@ -102,7 +102,7 @@ The following code shows how to specify a custom data source:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Dx{WidgetName},
@@ -137,7 +137,7 @@ The following code shows how to specify a custom data source:
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName}, Column, HeaderFilter } from 'devextreme-react/{widget-name}';
 

--- a/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/20 Map Data Source Fields.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/20 Map Data Source Fields.md
@@ -115,7 +115,7 @@ In the following code, the `categoryName` and `categoryId` fields are mapped to 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Dx{WidgetName},
@@ -159,7 +159,7 @@ In the following code, the `categoryName` and `categoryId` fields are mapped to 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName}, Column, HeaderFilter } from 'devextreme-react/{widget-name}';
     import ArrayStore from 'devextreme/data/array_store';

--- a/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/30 Change the Generated Data Source.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/30 Change the Generated Data Source.md
@@ -101,7 +101,7 @@ In the following code, the **postProcess** function adds a custom item to the ge
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Dx{WidgetName},
@@ -137,7 +137,7 @@ In the following code, the **postProcess** function adds a custom item to the ge
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName}, Column, HeaderFilter } from 'devextreme-react/{widget-name}';
 

--- a/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/40 Customize Item Appearance.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Customize Header Filter Data Source/40 Customize Item Appearance.md
@@ -117,7 +117,7 @@ You can use [templates](/api-reference/50%20Common/Object%20Structures/template 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Dx{WidgetName},
@@ -159,7 +159,7 @@ You can use [templates](/api-reference/50%20Common/Object%20Structures/template 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName}, Column, HeaderFilter } from 'devextreme-react/{widget-name}';
 

--- a/concepts/05 UI Components/DataGrid/99 How To/Dynamically Change Editor Properties in the Editing State.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Dynamically Change Editor Properties in the Editing State.md
@@ -95,7 +95,7 @@ Use the **editorOptions** parameter of [onEditorPreparing](/api-reference/10%20U
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, { 
         DxColumn,
@@ -128,7 +128,7 @@ Use the **editorOptions** parameter of [onEditorPreparing](/api-reference/10%20U
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, { 
         Column,

--- a/concepts/05 UI Components/DataGrid/99 How To/Dynamically Change Form Item Properties in the Editing State.md
+++ b/concepts/05 UI Components/DataGrid/99 How To/Dynamically Change Form Item Properties in the Editing State.md
@@ -131,7 +131,7 @@ This function allows you to change form item properties dynamically. Within this
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDataGrid, { 
             DxColumn,
@@ -179,7 +179,7 @@ This function allows you to change form item properties dynamically. Within this
         <!--tab: App.js-->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DataGrid, { 
             Column,

--- a/concepts/05 UI Components/FilterBuilder/010 Overview.md
+++ b/concepts/05 UI Components/FilterBuilder/010 Overview.md
@@ -107,7 +107,7 @@ The following code adds a simple FilterBuilder to your page. Note that each item
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFilterBuilder, {
         DxField
@@ -142,7 +142,7 @@ The following code adds a simple FilterBuilder to your page. Note that each item
 
     <!-- tab: App.js -->
     import { useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FilterBuilder, {
         Field

--- a/concepts/05 UI Components/FilterBuilder/020 Integrate with a DevExtreme UI Component.md
+++ b/concepts/05 UI Components/FilterBuilder/020 Integrate with a DevExtreme UI Component.md
@@ -114,7 +114,7 @@ contain data fields from a UI component's data source. For example, the followin
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFilterBuilder, { DxField } from 'devextreme-vue/filter-builder';
     import DxList from 'devextreme-vue/list';
@@ -149,7 +149,7 @@ contain data fields from a UI component's data source. For example, the followin
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FilterBuilder, { Field } from 'devextreme-react/filter-builder';
     import List from 'devextreme-react/list';

--- a/concepts/05 UI Components/FilterBuilder/030 Filter Hierarchical Fields.md
+++ b/concepts/05 UI Components/FilterBuilder/030 Filter Hierarchical Fields.md
@@ -82,7 +82,7 @@ In the following code, the FilterBuilder can filter data by three fields, two of
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFilterBuilder, {
         DxField
@@ -120,7 +120,7 @@ In the following code, the FilterBuilder can filter data by three fields, two of
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FilterBuilder, {
         Field

--- a/concepts/05 UI Components/FilterBuilder/040 Predefine Filter Values.md
+++ b/concepts/05 UI Components/FilterBuilder/040 Predefine Filter Values.md
@@ -68,7 +68,7 @@ Each lookup field has an individual [data source](/api-reference/_hidden/dxFilte
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFilterBuilder, {
         DxField,
@@ -99,7 +99,7 @@ Each lookup field has an individual [data source](/api-reference/_hidden/dxFilte
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FilterBuilder, {
         Field,
@@ -199,7 +199,7 @@ Each lookup field has an individual [data source](/api-reference/_hidden/dxFilte
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFilterBuilder, {
         DxField,
@@ -230,7 +230,7 @@ Each lookup field has an individual [data source](/api-reference/_hidden/dxFilte
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FilterBuilder, {
         Field,

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/02 Create a TreeList.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/02 Create a TreeList.md
@@ -93,7 +93,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeList } from 'devextreme-vue/tree-list';
 
@@ -116,7 +116,7 @@
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TreeList } from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/05 Bind the TreeList to Data.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/05 Bind the TreeList to Data.md
@@ -1233,7 +1233,7 @@ The TreeList component can load and update data from different data source types
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         TreeList

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/10 Customize Columns/3 Reorder Columns.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/10 Customize Columns/3 Reorder Columns.md
@@ -86,7 +86,7 @@ To reorder columns, change their order in the **columns** array. Users can also 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         TreeList,

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/10 Customize Columns/5 Resize Columns.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/10 Customize Columns/5 Resize Columns.md
@@ -88,7 +88,7 @@ TreeList columns have equal widths (the default setting). You can set each colum
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         TreeList,

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/10 Customize Columns/6 Fix Columns.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/10 Customize Columns/6 Fix Columns.md
@@ -71,7 +71,7 @@ The following code fixes the `FullName` column to the default position and allow
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         TreeList,

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/10 Customize Columns/8 Hide Columns.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/10 Customize Columns/8 Hide Columns.md
@@ -60,7 +60,7 @@ The TreeList displays all columns from the **columns** array. To hide a column, 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         TreeList,

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/20 Sort Data.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/20 Sort Data.md
@@ -70,7 +70,7 @@ You can also set a column's [sortOrder](/api-reference/_hidden/GridBaseColumn/so
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         TreeList,

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/30 Filter and Search Data.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/30 Filter and Search Data.md
@@ -64,7 +64,7 @@ In this tutorial, the **filterRow** and **searchPanel** are displayed:
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         TreeList,

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/40 Edit and Validate Data.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/40 Edit and Validate Data.md
@@ -131,7 +131,7 @@ DevExtreme includes a validation engine that checks edited values before they ar
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         TreeList,

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/50 Select Records.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/50 Select Records.md
@@ -163,7 +163,7 @@ You can obtain the selected record's data in the [onSelectionChanged](/api-refer
 
     <!-- tab: App.js -->
     import React, { useCallback, useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import './App.css';
 
     import {

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/55 Customize the Toolbar.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/55 Customize the Toolbar.md
@@ -135,7 +135,7 @@
 
     <!-- tab: App.js -->
     import React, { useCallback, useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import './App.css';
 
     import {

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/60 Enable Row Drag & Drop.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/60 Enable Row Drag & Drop.md
@@ -204,7 +204,7 @@ Users can drag and drop nodes to reorder them or change their hierarchy. To conf
 
     <!-- tab: App.js -->
     import React, { useCallback, useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import './App.css';
 
     import {

--- a/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/70 Enable Pagination.md
+++ b/concepts/05 UI Components/TreeList/00 Getting Started with TreeList/70 Enable Pagination.md
@@ -60,7 +60,7 @@ When pagination is enabled, TreeList loads records page by page instead of loadi
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         // ...

--- a/concepts/05 UI Components/TreeList/10 Columns/00 Overview.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/00 Overview.md
@@ -56,7 +56,7 @@ Columns represent sets of data values that have the same type. To configure colu
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn
@@ -76,7 +76,7 @@ Columns represent sets of data values that have the same type. To configure colu
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column
@@ -144,7 +144,7 @@ The TreeList generates a column per data field if you do not specify the **colum
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList from 'devextreme-vue/tree-list';
 
     export default {
@@ -164,7 +164,7 @@ The TreeList generates a column per data field if you do not specify the **colum
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/1 Data Columns.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/1 Data Columns.md
@@ -48,7 +48,7 @@ If data column values should be cast to another type (for example, date values s
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn
     } from 'devextreme-vue/tree-list';
@@ -66,7 +66,7 @@ If data column values should be cast to another type (for example, date values s
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column

--- a/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/2 Band Columns.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/2 Band Columns.md
@@ -56,7 +56,7 @@ To set up this layout, describe the hierarchy of columns directly in an object o
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn
     } from 'devextreme-vue/tree-list';
@@ -74,7 +74,7 @@ To set up this layout, describe the hierarchy of columns directly in an object o
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column
@@ -159,7 +159,7 @@ If you use the [customizeColumns](/api-reference/10%20UI%20Components/dxTreeList
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList from 'devextreme-vue/tree-list';
 
     export default {
@@ -187,7 +187,7 @@ If you use the [customizeColumns](/api-reference/10%20UI%20Components/dxTreeList
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList from 'devextreme-react/tree-list';
 
     const customizeColumns = (columns) => {
@@ -291,7 +291,7 @@ Band columns support hierarchies of any nesting level making the following struc
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn
     } from 'devextreme-vue/tree-list';
@@ -309,7 +309,7 @@ Band columns support hierarchies of any nesting level making the following struc
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList, {
         Column
     } from 'devextreme-react/tree-list';

--- a/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/3 Lookup Columns.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/3 Lookup Columns.md
@@ -77,7 +77,7 @@ Each lookup column has an individual [data source](/api-reference/_hidden/GridBa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn,
         DxLookup
@@ -121,7 +121,7 @@ Each lookup column has an individual [data source](/api-reference/_hidden/GridBa
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList, {
         Column,
         Lookup
@@ -232,7 +232,7 @@ Each lookup column has an individual [data source](/api-reference/_hidden/GridBa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn,
         DxLookup
@@ -268,7 +268,7 @@ Each lookup column has an individual [data source](/api-reference/_hidden/GridBa
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList, {
         Column,
         Lookup

--- a/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/4 Command Columns/05 Configure a Command Column.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/4 Command Columns/05 Configure a Command Column.md
@@ -47,7 +47,7 @@ The following example shows how to specify the adaptive column's [width](/api-re
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn
     } from 'devextreme-vue/tree-list';
@@ -69,7 +69,7 @@ The following example shows how to specify the adaptive column's [width](/api-re
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList, {
         Column
     } from 'devextreme-react/tree-list';

--- a/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/4 Command Columns/15 Customize the Edit Column/1 Customize Buttons.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/4 Command Columns/15 Customize the Edit Column/1 Customize Buttons.md
@@ -63,7 +63,7 @@ In the following code, a CSS class is added to the **Save** button. The **Add**,
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn,
         DxButton
@@ -87,7 +87,7 @@ In the following code, a CSS class is added to the **Save** button. The **Add**,
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList, {
         Column,
         Button

--- a/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/4 Command Columns/15 Customize the Edit Column/2 Hide a Button.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/4 Command Columns/15 Customize the Edit Column/2 Hide a Button.md
@@ -63,7 +63,7 @@ The **Add**, **Edit**, and **Delete** buttons can be hidden by omitting them whe
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxEditing,
         DxColumn,
@@ -89,7 +89,7 @@ The **Add**, **Edit**, and **Delete** buttons can be hidden by omitting them whe
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList, {
         Editing,
         Column,

--- a/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/4 Command Columns/15 Customize the Edit Column/3 Add a Custom Button.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/4 Command Columns/15 Customize the Edit Column/3 Add a Custom Button.md
@@ -74,7 +74,7 @@ Add an object to the [buttons](/api-reference/_hidden/dxTreeListColumn/buttons '
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn,
         DxButton
@@ -103,7 +103,7 @@ Add an object to the [buttons](/api-reference/_hidden/dxTreeListColumn/buttons '
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList, {
         Column,
         Button
@@ -202,7 +202,7 @@ Add an object to the [buttons](/api-reference/_hidden/dxTreeListColumn/buttons '
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn,
         DxButton
@@ -227,7 +227,7 @@ Add an object to the [buttons](/api-reference/_hidden/dxTreeListColumn/buttons '
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column,

--- a/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/4 Command Columns/30 Create a Column with Custom Buttons.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/10 Column Types/4 Command Columns/30 Create a Column with Custom Buttons.md
@@ -68,7 +68,7 @@ The following code shows how to add a command column with custom [buttons](/api-
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn,
         DxButton
@@ -92,7 +92,7 @@ The following code shows how to add a command column with custom [buttons](/api-
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList, {
         Column,
         Button

--- a/concepts/05 UI Components/TreeList/10 Columns/15 Customize Column Headers.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/15 Customize Column Headers.md
@@ -49,7 +49,7 @@ Specify the **columns**.[caption](/api-reference/_hidden/GridBaseColumn/caption.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn
@@ -69,7 +69,7 @@ Specify the **columns**.[caption](/api-reference/_hidden/GridBaseColumn/caption.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column
@@ -169,7 +169,7 @@ If you need a more specific customization, define a custom template in the **col
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn
@@ -188,7 +188,7 @@ If you need a more specific customization, define a custom template in the **col
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList, {
         Column
     } from 'devextreme-react/tree-list';
@@ -262,7 +262,7 @@ To hide column headers, assign **false** to the [showColumnHeaders](/api-referen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -279,7 +279,7 @@ To hide column headers, assign **false** to the [showColumnHeaders](/api-referen
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/10 Columns/25 Column Reordering/05 User Interaction.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/25 Column Reordering/05 User Interaction.md
@@ -49,7 +49,7 @@ If a specific column should not be moved, set its [allowReordering](/api-referen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn
@@ -69,7 +69,7 @@ If a specific column should not be moved, set its [allowReordering](/api-referen
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column

--- a/concepts/05 UI Components/TreeList/10 Columns/25 Column Reordering/10 API.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/25 Column Reordering/10 API.md
@@ -46,7 +46,7 @@ The [columns](/api-reference/10%20UI%20Components/dxTreeList/1%20Configuration/c
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList from 'devextreme-vue/tree-list';
 
     export default {
@@ -65,7 +65,7 @@ The [columns](/api-reference/10%20UI%20Components/dxTreeList/1%20Configuration/c
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList from 'devextreme-react/tree-list';
 
     const customizeColumns = (columns) => {
@@ -125,7 +125,7 @@ The **visibleIndex** property can also be changed at runtime to reorder columns 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn
     } from 'devextreme-vue/tree-list';
@@ -152,7 +152,7 @@ The **visibleIndex** property can also be changed at runtime to reorder columns 
 
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList from 'devextreme-react/tree-list';
     
     export default function App() {

--- a/concepts/05 UI Components/TreeList/10 Columns/30 Column Fixing.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/30 Column Fixing.md
@@ -54,7 +54,7 @@ To allow this, set the **columnFixing**.[enabled](/api-reference/10%20UI%20Compo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn,
@@ -76,7 +76,7 @@ To allow this, set the **columnFixing**.[enabled](/api-reference/10%20UI%20Compo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column,
@@ -140,7 +140,7 @@ If a column should be fixed initially, assign **true** to its [fixed](/api-refer
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn
@@ -161,7 +161,7 @@ If a column should be fixed initially, assign **true** to its [fixed](/api-refer
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column

--- a/concepts/05 UI Components/TreeList/10 Columns/35 Hide a Column Using the API.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/35 Hide a Column Using the API.md
@@ -63,7 +63,7 @@ A column is considered hidden when its [visible](/api-reference/_hidden/GridBase
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn
@@ -91,7 +91,7 @@ A column is considered hidden when its [visible](/api-reference/_hidden/GridBase
 
     <!-- tab: App.js -->
     import React, { useState, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column

--- a/concepts/05 UI Components/TreeList/10 Columns/40 Customize Cells/1 Customize the Value and Text.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/40 Customize Cells/1 Customize the Value and Text.md
@@ -52,7 +52,7 @@ Use the [customizeText](/api-reference/_hidden/GridBaseColumn/customizeText.md '
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn
     } from 'devextreme-vue/tree-list';
@@ -74,7 +74,7 @@ Use the [customizeText](/api-reference/_hidden/GridBaseColumn/customizeText.md '
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList, {
         Column
     } from 'devextreme-react/tree-list';
@@ -150,7 +150,7 @@ To use the text displayed in cells in those data processing operations, specify 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn
@@ -174,7 +174,7 @@ To use the text displayed in cells in those data processing operations, specify 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column

--- a/concepts/05 UI Components/TreeList/10 Columns/40 Customize Cells/2 Customize the Appearance.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/40 Customize Cells/2 Customize the Appearance.md
@@ -57,7 +57,7 @@ To customize cell appearance, use a column's [cellTemplate](/api-reference/_hidd
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn
     } from 'devextreme-vue/tree-list';
@@ -75,7 +75,7 @@ To customize cell appearance, use a column's [cellTemplate](/api-reference/_hidd
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList, {
         Column
     } from 'devextreme-react/tree-list';
@@ -161,7 +161,7 @@ While **cellTemplate** customizes data cells only, the [onCellPrepared](/api-ref
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList from 'devextreme-vue/tree-list';
 
     export default {
@@ -188,7 +188,7 @@ While **cellTemplate** customizes data cells only, the [onCellPrepared](/api-ref
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList from 'devextreme-react/tree-list';
 
     const onCellPrepared = (e) => {

--- a/concepts/05 UI Components/TreeList/10 Columns/50 Adaptability/05 Hide Columns.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/50 Adaptability/05 Hide Columns.md
@@ -64,7 +64,7 @@ You can use the **columns[]**.[hidingPriority](/api-reference/_hidden/GridBaseCo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn
@@ -84,7 +84,7 @@ You can use the **columns[]**.[hidingPriority](/api-reference/_hidden/GridBaseCo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column
@@ -149,7 +149,7 @@ If your TreeList is inside a resizable container, you must call the [updateDimen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -181,7 +181,7 @@ If your TreeList is inside a resizable container, you must call the [updateDimen
 
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList from 'devextreme-react/tree-list';
 
     export default function App() {

--- a/concepts/05 UI Components/TreeList/10 Columns/50 Adaptability/15 Customize Adaptive Detail Row.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/50 Adaptability/15 Customize Adaptive Detail Row.md
@@ -53,7 +53,7 @@ Adaptive detail rows contain the [Form](/api-reference/10%20UI%20Components/dxFo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -78,7 +78,7 @@ Adaptive detail rows contain the [Form](/api-reference/10%20UI%20Components/dxFo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/10 Columns/50 Adaptability/20 Expand and Collapse Adaptive Detail Rows.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/50 Adaptability/20 Expand and Collapse Adaptive Detail Rows.md
@@ -43,7 +43,7 @@ You can call the [expandAdaptiveDetailRow(key)](/api-reference/10%20UI%20Compone
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -77,7 +77,7 @@ You can call the [expandAdaptiveDetailRow(key)](/api-reference/10%20UI%20Compone
 
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList from 'devextreme-react/tree-list';
 
     export default function App() {

--- a/concepts/05 UI Components/TreeList/10 Columns/60 Column Chooser.md
+++ b/concepts/05 UI Components/TreeList/10 Columns/60 Column Chooser.md
@@ -49,7 +49,7 @@ The column chooser allows a user to change the set of columns at runtime. It is 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumnChooser
@@ -69,7 +69,7 @@ The column chooser allows a user to change the set of columns at runtime. It is 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         ColumnChooser
@@ -153,7 +153,7 @@ Set a column's [allowHiding](/api-reference/_hidden/GridBaseColumn/allowHiding.m
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumnChooser,
@@ -175,7 +175,7 @@ Set a column's [allowHiding](/api-reference/_hidden/GridBaseColumn/allowHiding.m
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         ColumnChooser,
@@ -245,7 +245,7 @@ Call the [showColumnChooser()](/api-reference/10%20UI%20Components/GridBase/3%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -280,7 +280,7 @@ Call the [showColumnChooser()](/api-reference/10%20UI%20Components/GridBase/3%20
 
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TreeList from 'devextreme-react/tree-list';
 
     export default function App() {

--- a/concepts/05 UI Components/TreeList/20 Editing/10 User Interaction/40 Form Mode.md
+++ b/concepts/05 UI Components/TreeList/20 Editing/10 User Interaction/40 Form Mode.md
@@ -121,7 +121,7 @@ In the following code, the items with the specified **dataField** are simple ite
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxEditing,
@@ -152,7 +152,7 @@ In the following code, the items with the specified **dataField** are simple ite
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Editing,

--- a/concepts/05 UI Components/TreeList/20 Editing/10 User Interaction/50 Popup Mode.md
+++ b/concepts/05 UI Components/TreeList/20 Editing/10 User Interaction/50 Popup Mode.md
@@ -71,7 +71,7 @@ Use the **editing**.[popup](/api-reference/10%20UI%20Components/GridBase/1%20Con
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxEditing,
@@ -94,7 +94,7 @@ Use the **editing**.[popup](/api-reference/10%20UI%20Components/GridBase/1%20Con
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Editing,

--- a/concepts/05 UI Components/TreeList/20 Editing/10 User Interaction/User Interaction.md
+++ b/concepts/05 UI Components/TreeList/20 Editing/10 User Interaction/User Interaction.md
@@ -60,7 +60,7 @@ The TreeList UI component allows a user to add, delete and update data. Assign *
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxEditing,
@@ -81,7 +81,7 @@ The TreeList UI component allows a user to add, delete and update data. Assign *
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Editing,
@@ -155,7 +155,7 @@ With the TreeList you can edit data in several modes. Use the **editing**.[mode]
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxEditing
@@ -174,7 +174,7 @@ With the TreeList you can edit data in several modes. Use the **editing**.[mode]
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Editing

--- a/concepts/05 UI Components/TreeList/20 Editing/20 API/10 Add.md
+++ b/concepts/05 UI Components/TreeList/20 Editing/20 API/10 Add.md
@@ -38,7 +38,7 @@ Use the [addRow()](/api-reference/10%20UI%20Components/dxTreeList/3%20Methods/ad
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -59,7 +59,7 @@ Use the [addRow()](/api-reference/10%20UI%20Components/dxTreeList/3%20Methods/ad
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 
@@ -142,7 +142,7 @@ You can specify initial values for a newly added row in the [onInitNewRow](/api-
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn
@@ -166,7 +166,7 @@ You can specify initial values for a newly added row in the [onInitNewRow](/api-
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column

--- a/concepts/05 UI Components/TreeList/20 Editing/20 API/20 Update.md
+++ b/concepts/05 UI Components/TreeList/20 Editing/20 API/20 Update.md
@@ -61,7 +61,7 @@ The [cellValue (rowIndex, visibleColumnIndex, value)](/api-reference/10%20UI%20C
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
     import DxButton from 'devextreme-vue/button';
@@ -97,7 +97,7 @@ The [cellValue (rowIndex, visibleColumnIndex, value)](/api-reference/10%20UI%20C
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
     import Button from 'devextreme-react/button';
@@ -217,7 +217,7 @@ Call the [hasEditData()](/api-reference/10%20UI%20Components/GridBase/3%20Method
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
     import DxButton from 'devextreme-vue/button';
@@ -260,7 +260,7 @@ Call the [hasEditData()](/api-reference/10%20UI%20Components/GridBase/3%20Method
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
     import Button from 'devextreme-react/button';

--- a/concepts/05 UI Components/TreeList/20 Editing/30 Events/Events.md
+++ b/concepts/05 UI Components/TreeList/20 Editing/30 Events/Events.md
@@ -55,7 +55,7 @@ The TreeList UI component raises events before and after a row is inserted, upda
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -76,7 +76,7 @@ The TreeList UI component raises events before and after a row is inserted, upda
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 
@@ -168,7 +168,7 @@ In addition, the TreeList raises the [initNewRow](/api-reference/10%20UI%20Compo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -190,7 +190,7 @@ In addition, the TreeList raises the [initNewRow](/api-reference/10%20UI%20Compo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/20 Editing/40 Customize Editors.md
+++ b/concepts/05 UI Components/TreeList/20 Editing/40 Customize Editors.md
@@ -86,7 +86,7 @@ The columns's [dataType](/api-reference/_hidden/GridBaseColumn/dataType.md '/Doc
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn
@@ -128,7 +128,7 @@ The columns's [dataType](/api-reference/_hidden/GridBaseColumn/dataType.md '/Doc
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column
@@ -293,7 +293,7 @@ Implement the column's [editCellTemplate](/api-reference/_hidden/dxTreeListColum
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn,
@@ -322,7 +322,7 @@ Implement the column's [editCellTemplate](/api-reference/_hidden/dxTreeListColum
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column,
@@ -445,7 +445,7 @@ Editors are displayed in cells in the normal state too if you set the **columns*
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn
@@ -464,7 +464,7 @@ Editors are displayed in cells in the normal state too if you set the **columns*
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column

--- a/concepts/05 UI Components/TreeList/20 Editing/50 Data Validation.md
+++ b/concepts/05 UI Components/TreeList/20 Editing/50 Data Validation.md
@@ -71,7 +71,7 @@ User input is validated against a set of [validation rules](/api-reference/10%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn,
@@ -94,7 +94,7 @@ User input is validated against a set of [validation rules](/api-reference/10%20
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column,
@@ -177,7 +177,7 @@ The [onRowValidating](/api-reference/10%20UI%20Components/dxTreeList/1%20Configu
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -201,7 +201,7 @@ The [onRowValidating](/api-reference/10%20UI%20Components/dxTreeList/1%20Configu
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/30 Sorting/10 User Interaction.md
+++ b/concepts/05 UI Components/TreeList/30 Sorting/10 User Interaction.md
@@ -44,7 +44,7 @@ With the TreeList UI component, a user can sort by single and multiple columns. 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeList, DxSorting } from 'devextreme-vue/tree-list';
 
@@ -61,7 +61,7 @@ With the TreeList UI component, a user can sort by single and multiple columns. 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TreeList, Sorting } from 'devextreme-react/tree-list';
 
@@ -135,7 +135,7 @@ To disable sorting in the whole UI component, set the **sorting**.**mode** prope
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeList, DxColumn } from 'devextreme-vue/tree-list';
 
@@ -152,7 +152,7 @@ To disable sorting in the whole UI component, set the **sorting**.**mode** prope
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TreeList, Column } from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/30 Sorting/20 API/1 Initial and Runtime Sorting.md
+++ b/concepts/05 UI Components/TreeList/30 Sorting/20 API/1 Initial and Runtime Sorting.md
@@ -55,7 +55,7 @@ Rows are sorted according to the data source by default. Set the [sortOrder](/ap
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeList, DxColumn } from 'devextreme-vue/tree-list';
 
@@ -72,7 +72,7 @@ Rows are sorted according to the data source by default. Set the [sortOrder](/ap
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TreeList, Column } from 'devextreme-react/tree-list';
 
@@ -145,7 +145,7 @@ Change the **sortOrder** and **sortIndex** properties using the [columnOption](/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeList, DxColumn } from 'devextreme-vue/tree-list';
 
@@ -172,7 +172,7 @@ Change the **sortOrder** and **sortIndex** properties using the [columnOption](/
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TreeList, Column } from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/30 Sorting/20 API/5 Custom Sorting.md
+++ b/concepts/05 UI Components/TreeList/30 Sorting/20 API/5 Custom Sorting.md
@@ -51,7 +51,7 @@ Implement a custom sorting routine using the [calculateSortValue](/api-reference
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeList, DxColumn } from 'devextreme-vue/tree-list';
 
@@ -68,7 +68,7 @@ Implement a custom sorting routine using the [calculateSortValue](/api-reference
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TreeList, Column } from 'devextreme-react/tree-list';
 
@@ -154,7 +154,7 @@ Implement a custom sorting routine using the [calculateSortValue](/api-reference
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeList, DxColumn } from 'devextreme-vue/tree-list';
 
@@ -181,7 +181,7 @@ Implement a custom sorting routine using the [calculateSortValue](/api-reference
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TreeList, Column } from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/30 Sorting/20 API/8 Clear Sorting Settings.md
+++ b/concepts/05 UI Components/TreeList/30 Sorting/20 API/8 Clear Sorting Settings.md
@@ -45,7 +45,7 @@ You can clear sorting settings for all columns by calling the [clearSorting()](/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeList, DxColumn } from 'devextreme-vue/tree-list';
 
@@ -82,7 +82,7 @@ You can clear sorting settings for all columns by calling the [clearSorting()](/
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TreeList, Column } from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/35 Paging/10 User Interaction.md
+++ b/concepts/05 UI Components/TreeList/35 Paging/10 User Interaction.md
@@ -59,7 +59,7 @@ Set the [showNavigationButtons](/api-reference/10%20UI%20Components/GridBase/1%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxPager
@@ -78,7 +78,7 @@ Set the [showNavigationButtons](/api-reference/10%20UI%20Components/GridBase/1%2
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Pager
@@ -161,7 +161,7 @@ Assign **true** to the [showInfo](/api-reference/10%20UI%20Components/GridBase/1
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxPager
@@ -180,7 +180,7 @@ Assign **true** to the [showInfo](/api-reference/10%20UI%20Components/GridBase/1
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Pager

--- a/concepts/05 UI Components/TreeList/35 Paging/20 API.md
+++ b/concepts/05 UI Components/TreeList/35 Paging/20 API.md
@@ -39,7 +39,7 @@ Call the [pageCount()](/api-reference/10%20UI%20Components/dxTreeList/3%20Method
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -60,7 +60,7 @@ Call the [pageCount()](/api-reference/10%20UI%20Components/dxTreeList/3%20Method
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 
@@ -141,7 +141,7 @@ The TreeList also provides the [pageIndex(newIndex)](/api-reference/10%20UI%20Co
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxPaging
@@ -175,7 +175,7 @@ The TreeList also provides the [pageIndex(newIndex)](/api-reference/10%20UI%20Co
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Paging

--- a/concepts/05 UI Components/TreeList/35 Paging/Paging.md
+++ b/concepts/05 UI Components/TreeList/35 Paging/Paging.md
@@ -55,7 +55,7 @@ Paging improves the UI component's performance on large datasets because it rend
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxPaging
@@ -74,7 +74,7 @@ Paging improves the UI component's performance on large datasets because it rend
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Paging

--- a/concepts/05 UI Components/TreeList/40 Filtering and Searching/1 Filter Row.md
+++ b/concepts/05 UI Components/TreeList/40 Filtering and Searching/1 Filter Row.md
@@ -63,7 +63,7 @@ To make the filter row visible, assign **true** to the [filterRow](/api-referenc
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn,
@@ -83,7 +83,7 @@ To make the filter row visible, assign **true** to the [filterRow](/api-referenc
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column,
@@ -155,7 +155,7 @@ A user-specified filter is automatically applied with a delay by default. Altern
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxFilterRow
@@ -173,7 +173,7 @@ A user-specified filter is automatically applied with a delay by default. Altern
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         FilterRow
@@ -272,7 +272,7 @@ The set of available filter operations can be restricted using the [filterOperat
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn,
@@ -305,7 +305,7 @@ The set of available filter operations can be restricted using the [filterOperat
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column,

--- a/concepts/05 UI Components/TreeList/40 Filtering and Searching/2 Header Filter.md
+++ b/concepts/05 UI Components/TreeList/40 Filtering and Searching/2 Header Filter.md
@@ -55,7 +55,7 @@ Assign **true** to the [headerFilter](/api-reference/10%20UI%20Components/GridBa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn,
@@ -75,7 +75,7 @@ Assign **true** to the [headerFilter](/api-reference/10%20UI%20Components/GridBa
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column,
@@ -163,7 +163,7 @@ A user can change the applied filter by including or excluding values. Use a col
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn
@@ -193,7 +193,7 @@ A user can change the applied filter by including or excluding values. Use a col
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column
@@ -304,7 +304,7 @@ You can use the **headerFilter**.[allowSearch](/api-reference/10%20UI%20Componen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn,
@@ -326,7 +326,7 @@ You can use the **headerFilter**.[allowSearch](/api-reference/10%20UI%20Componen
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column,

--- a/concepts/05 UI Components/TreeList/40 Filtering and Searching/3 Search Panel.md
+++ b/concepts/05 UI Components/TreeList/40 Filtering and Searching/3 Search Panel.md
@@ -55,7 +55,7 @@ To make the search panel visible, assign **true** to the [searchPanel](/api-refe
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn,
@@ -75,7 +75,7 @@ To make the search panel visible, assign **true** to the [searchPanel](/api-refe
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column,
@@ -156,7 +156,7 @@ Use the **searchPanel**.[text](/api-reference/10%20UI%20Components/GridBase/1%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxSearchPanel
@@ -184,7 +184,7 @@ Use the **searchPanel**.[text](/api-reference/10%20UI%20Components/GridBase/1%20
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         SearchPanel

--- a/concepts/05 UI Components/TreeList/40 Filtering and Searching/4 Filter Panel with Filter Builder.md
+++ b/concepts/05 UI Components/TreeList/40 Filtering and Searching/4 Filter Panel with Filter Builder.md
@@ -40,7 +40,7 @@ Set the **filterPanel**.[visible](/api-reference/10%20UI%20Components/GridBase/1
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {      
         DxFilterPanel
@@ -58,7 +58,7 @@ Set the **filterPanel**.[visible](/api-reference/10%20UI%20Components/GridBase/1
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         FilterPanel
@@ -106,7 +106,7 @@ If a user changes the filter expression in the filter panel or filter builder, t
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -121,7 +121,7 @@ If a user changes the filter expression in the filter panel or filter builder, t
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 
@@ -198,7 +198,7 @@ The **filterValue** is updated when a user changes the filter expression from th
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxFilterPanel
@@ -226,7 +226,7 @@ The **filterValue** is updated when a user changes the filter expression from th
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         FilterPanel
@@ -368,7 +368,7 @@ The TreeList provides the [filterBuilder](/api-reference/10%20UI%20Components/Gr
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxButton from 'devextreme-vue/button';
 
@@ -412,7 +412,7 @@ The TreeList provides the [filterBuilder](/api-reference/10%20UI%20Components/Gr
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Button from 'devextreme-react/button';
 

--- a/concepts/05 UI Components/TreeList/40 Filtering and Searching/5 Standalone Filter Builder.md
+++ b/concepts/05 UI Components/TreeList/40 Filtering and Searching/5 Standalone Filter Builder.md
@@ -75,7 +75,7 @@ The TreeList UI component has an integrated filter builder that can be invoked u
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
     import DxFilterBuilder from 'devextreme-vue/filter-builder';
@@ -108,7 +108,7 @@ The TreeList UI component has an integrated filter builder that can be invoked u
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
     import FilterBuilder from 'devextreme-react/filter-builder';
@@ -211,7 +211,7 @@ Then, add a button that updates a filter of the TreeList's data source according
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
     import DxFilterBuilder from 'devextreme-vue/filter-builder';
@@ -253,7 +253,7 @@ Then, add a button that updates a filter of the TreeList's data source according
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
     import FilterBuilder from 'devextreme-react/filter-builder';

--- a/concepts/05 UI Components/TreeList/40 Filtering and Searching/6 API/1 Initial and Runtime Filtering.md
+++ b/concepts/05 UI Components/TreeList/40 Filtering and Searching/6 API/1 Initial and Runtime Filtering.md
@@ -45,7 +45,7 @@ The initial and runtime filtering API depends on the UI element and is described
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -82,7 +82,7 @@ The initial and runtime filtering API depends on the UI element and is described
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 
@@ -154,7 +154,7 @@ You can create a filter that combines all the applied filters by calling the [ge
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -187,7 +187,7 @@ You can create a filter that combines all the applied filters by calling the [ge
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/40 Filtering and Searching/6 API/8 Clear Filtering Settings.md
+++ b/concepts/05 UI Components/TreeList/40 Filtering and Searching/6 API/8 Clear Filtering Settings.md
@@ -40,7 +40,7 @@ The [clearFilter(filterName)](/api-reference/10%20UI%20Components/GridBase/3%20M
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -73,7 +73,7 @@ The [clearFilter(filterName)](/api-reference/10%20UI%20Components/GridBase/3%20M
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/42 Server-Side Data Processing.md
+++ b/concepts/05 UI Components/TreeList/42 Server-Side Data Processing.md
@@ -55,7 +55,7 @@ Specify the [remoteOperations](/api-reference/10%20UI%20Components/dxTreeList/1%
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxRemoteOperations
@@ -74,7 +74,7 @@ Specify the [remoteOperations](/api-reference/10%20UI%20Components/dxTreeList/1%
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         RemoteOperations

--- a/concepts/05 UI Components/TreeList/45 Scrolling/Scrolling.md
+++ b/concepts/05 UI Components/TreeList/45 Scrolling/Scrolling.md
@@ -52,7 +52,7 @@ Use the **scrolling**.[mode](/api-reference/10%20UI%20Components/dxTreeList/1%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxScrolling
@@ -71,7 +71,7 @@ Use the **scrolling**.[mode](/api-reference/10%20UI%20Components/dxTreeList/1%20
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Scrolling
@@ -138,7 +138,7 @@ The TreeList adapts its scrolling mechanism to the current platform. It utilizes
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxScrolling
@@ -157,7 +157,7 @@ The TreeList adapts its scrolling mechanism to the current platform. It utilizes
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Scrolling
@@ -234,7 +234,7 @@ The current platform determines the native scrolling settings and you cannot adj
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxScrolling
@@ -253,7 +253,7 @@ The current platform determines the native scrolling settings and you cannot adj
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Scrolling

--- a/concepts/05 UI Components/TreeList/50 Selection/10 User Interaction.md
+++ b/concepts/05 UI Components/TreeList/50 Selection/10 User Interaction.md
@@ -44,7 +44,7 @@ The TreeList UI component supports single and multiple row selection. Use the **
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxSelection
@@ -63,7 +63,7 @@ The TreeList UI component supports single and multiple row selection. Use the **
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Selection
@@ -137,7 +137,7 @@ You can disable the latter feature by setting the **selection**.[allowSelectAll]
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxSelection
@@ -156,7 +156,7 @@ You can disable the latter feature by setting the **selection**.[allowSelectAll]
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Selection
@@ -229,7 +229,7 @@ Selection is non-recursive by default, that is, only the clicked row is selected
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxSelection
@@ -248,7 +248,7 @@ Selection is non-recursive by default, that is, only the clicked row is selected
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Selection

--- a/concepts/05 UI Components/TreeList/50 Selection/20 API/1 Initial and Runtime Selection.md
+++ b/concepts/05 UI Components/TreeList/50 Selection/20 API/1 Initial and Runtime Selection.md
@@ -59,7 +59,7 @@ Use the [selectedRowKeys](/api-reference/10%20UI%20Components/GridBase/1%20Confi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
     import DataSource from 'devextreme/data/data_source';
@@ -92,7 +92,7 @@ Use the [selectedRowKeys](/api-reference/10%20UI%20Components/GridBase/1%20Confi
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
     import DataSource from 'devextreme/data/data_source';
@@ -177,7 +177,7 @@ You can select rows at runtime using the [selectRows(keys, preserve)](/api-refer
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -205,7 +205,7 @@ You can select rows at runtime using the [selectRows(keys, preserve)](/api-refer
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 
@@ -292,7 +292,7 @@ Call the [getSelectedRowKeys(mode)](/api-reference/10%20UI%20Components/dxTreeLi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -328,7 +328,7 @@ Call the [getSelectedRowKeys(mode)](/api-reference/10%20UI%20Components/dxTreeLi
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/50 Selection/20 API/8 Clear Selection Settings.md
+++ b/concepts/05 UI Components/TreeList/50 Selection/20 API/8 Clear Selection Settings.md
@@ -37,7 +37,7 @@ Call the [deselectRows(keys)](/api-reference/10%20UI%20Components/GridBase/3%20M
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -71,7 +71,7 @@ Call the [deselectRows(keys)](/api-reference/10%20UI%20Components/GridBase/3%20M
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 
@@ -164,7 +164,7 @@ The [deselectAll()](/api-reference/10%20UI%20Components/dxTreeList/3%20Methods/d
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -193,7 +193,7 @@ The [deselectAll()](/api-reference/10%20UI%20Components/dxTreeList/3%20Methods/d
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/50 Selection/30 Events.md
+++ b/concepts/05 UI Components/TreeList/50 Selection/30 Events.md
@@ -52,7 +52,7 @@ The TreeList UI component raises the [selectionChanged](/api-reference/10%20UI%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -77,7 +77,7 @@ The TreeList UI component raises the [selectionChanged](/api-reference/10%20UI%2
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/60 Expand and Collapse Rows/30 Events.md
+++ b/concepts/05 UI Components/TreeList/60 Expand and Collapse Rows/30 Events.md
@@ -68,7 +68,7 @@ To execute certain commands before or after a row was expanded or collapsed, han
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -98,7 +98,7 @@ To execute certain commands before or after a row was expanded or collapsed, han
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/65 Load Panel/Load Panel.md
+++ b/concepts/05 UI Components/TreeList/65 Load Panel/Load Panel.md
@@ -48,7 +48,7 @@ The load panel is shown only for remote data sources by default. To show it rega
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxLoadPanel
@@ -67,7 +67,7 @@ The load panel is shown only for remote data sources by default. To show it rega
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         LoadPanel
@@ -127,7 +127,7 @@ You can also control the load panel programmatically using the [beginCustomLoadi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         // ...
@@ -164,7 +164,7 @@ You can also control the load panel programmatically using the [beginCustomLoadi
 
     <!-- tab: App.js -->
     import React, { useRef, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         // ...
@@ -241,7 +241,7 @@ Since the load panel is a DevExtreme [LoadPanel](/concepts/05%20UI%20Components/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxLoadPanel
@@ -260,7 +260,7 @@ Since the load panel is a DevExtreme [LoadPanel](/concepts/05%20UI%20Components/
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         LoadPanel

--- a/concepts/05 UI Components/TreeList/69 Focused Row.md
+++ b/concepts/05 UI Components/TreeList/69 Focused Row.md
@@ -77,7 +77,7 @@ You can use the [focusedRowKey](/api-reference/10%20UI%20Components/GridBase/1%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -93,7 +93,7 @@ You can use the [focusedRowKey](/api-reference/10%20UI%20Components/GridBase/1%2
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/concepts/05 UI Components/TreeList/99 How To/Bind a Lookup Column to a Custom Data Source.md
+++ b/concepts/05 UI Components/TreeList/99 How To/Bind a Lookup Column to a Custom Data Source.md
@@ -102,7 +102,7 @@ In the following code snippet, `Author Name` is a [lookup column](/concepts/05%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn,
         DxLookup
@@ -143,7 +143,7 @@ In the following code snippet, `Author Name` is a [lookup column](/concepts/05%2
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column,
@@ -308,7 +308,7 @@ The following alternative **CustomStore** configuration delegates data processin
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTreeList, {
         DxColumn,
         DxLookup
@@ -373,7 +373,7 @@ The following alternative **CustomStore** configuration delegates data processin
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column,


### PR DESCRIPTION
Replaced mentions of Generic themes with Fluent:
`import 'devextreme/dist/css/dx.light.css';` > `import 'devextreme/dist/css/dx.fluent.blue.light.css';`

Included files:
```
concepts\05 UI Components\DataGrid\**\*.md, 
concepts\05 UI Components\TreeList\**\*.md, 
concepts\05 UI Components\FilterBuilder\**\*.md, 
concepts\05 UI Components\CardView\**\*.md, 
```