### PR TITLE
Update Theme Mentions to Fluent - ASP & Scheduler

### DIFF
--- a/api-reference/10 UI Components/dxDiagram/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxDiagram/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/allowedFileExtensions.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/allowedFileExtensions.md
@@ -64,7 +64,7 @@ The FileManager UI component cannot upload a file and displays an error message 
         </DxFileManager>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager
@@ -87,7 +87,7 @@ The FileManager UI component cannot upload a file and displays an error message 
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/currentPath.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/currentPath.md
@@ -59,7 +59,7 @@ Specifies the path that is used when the FileManager is initialized.
         </DxFileManager>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager
@@ -82,7 +82,7 @@ Specifies the path that is used when the FileManager is initialized.
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/currentPathKeys.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/currentPathKeys.md
@@ -58,7 +58,7 @@ Each path part has each own key. For example, path "directory1/directory2" has t
         </DxFileManager>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager
@@ -81,7 +81,7 @@ Each path part has each own key. For example, path "directory1/directory2" has t
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/customizeDetailColumns.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/customizeDetailColumns.md
@@ -88,7 +88,7 @@ The columns after customization.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileManager from 'devextreme-vue/file-manager';
 
@@ -112,7 +112,7 @@ The columns after customization.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/fileSystemProvider.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/fileSystemProvider.md
@@ -127,7 +127,7 @@ The following example illustrates how to configure an [Object](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';     
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';     
 
     import { 
         DxFileManager
@@ -175,7 +175,7 @@ The following example illustrates how to configure an [Object](/api-reference/10
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     import { fileSystem } from './data.js';

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/focusedItemKey.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/focusedItemKey.md
@@ -56,7 +56,7 @@ Specifies a key of the initially or currently focused item.
         </DxFileManager>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager
@@ -79,7 +79,7 @@ Specifies a key of the initially or currently focused item.
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/itemView/details/details.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/itemView/details/details.md
@@ -75,7 +75,7 @@ Configures the "Details" file system representation mode.
         </DxFileManager>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager,
@@ -104,7 +104,7 @@ Configures the "Details" file system representation mode.
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager, { ItemView, Details, Column } from 'devextreme-react/file-manager';
     

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/itemView/itemView.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/itemView/itemView.md
@@ -77,7 +77,7 @@ Configures the file and directory view.
         </DxFileManager>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager,
@@ -102,7 +102,7 @@ Configures the file and directory view.
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager, { ItemView } from 'devextreme-react/file-manager';
     

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/notifications/showPanel.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/notifications/showPanel.md
@@ -65,7 +65,7 @@ The **Refresh** button does not display notification marks if the **showPanel** 
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DxFileManager, DxNotifications } from 'devextreme-vue/file-manager';
     

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/notifications/showPopup.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/notifications/showPopup.md
@@ -60,7 +60,7 @@ Specifies whether to show the pop-up notification window.
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DxFileManager, DxNotifications } from 'devextreme-vue/file-manager';
     

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onContextMenuItemClick.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onContextMenuItemClick.md
@@ -119,7 +119,7 @@ Specifies whether the context menu is invoked in the navigation panel or in the 
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileManager, 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onContextMenuShowing.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onContextMenuShowing.md
@@ -99,7 +99,7 @@ Specifies whether the context menu is invoked in the navigation panel or in the 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileManager from 'devextreme-vue/file-manager';
   

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onCurrentDirectoryChanged.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onCurrentDirectoryChanged.md
@@ -83,7 +83,7 @@ The current directory.
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileManager

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onDirectoryCreated.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onDirectoryCreated.md
@@ -94,7 +94,7 @@ Use the **Create Directory** [context menu](/api-reference/10%20UI%20Components/
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileManager

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onDirectoryCreating.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onDirectoryCreating.md
@@ -93,7 +93,7 @@ The component executes the **onDirectoryCreating** function when a user enters a
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileManager from 'devextreme-vue/file-manager';
   

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onErrorOccurred.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onErrorOccurred.md
@@ -89,7 +89,7 @@ The processed file or directory.
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileManager

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onFileUploaded.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onFileUploaded.md
@@ -94,7 +94,7 @@ Use the **Upload Files** [context menu](/api-reference/10%20UI%20Components/dxFi
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileManager

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onFileUploading.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onFileUploading.md
@@ -123,7 +123,7 @@ The component executes the **onFileUploading** function when a user clicks **Ope
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileManager from 'devextreme-vue/file-manager';
   

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onFocusedItemChanged.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onFocusedItemChanged.md
@@ -86,7 +86,7 @@ The currently focused file or directory.
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileManager

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemCopied.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemCopied.md
@@ -102,7 +102,7 @@ Select a file/folder and use the **Copy To** [context menu](/api-reference/10%20
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileManager

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemCopying.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemCopying.md
@@ -95,7 +95,7 @@ The component executes the **onItemCopying** function when a user clicks **Copy*
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileManager from 'devextreme-vue/file-manager';
   

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemDeleted.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemDeleted.md
@@ -87,7 +87,7 @@ Select a file/folder and click the **Delete** [context menu](/api-reference/10%2
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileManager

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemDeleting.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemDeleting.md
@@ -84,7 +84,7 @@ The **onItemCopying** function is executed when a user clicks **Delete** in the 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileManager from 'devextreme-vue/file-manager';
   

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemDownloading.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemDownloading.md
@@ -82,7 +82,7 @@ The component executes the **onItemDownloading** function when a user clicks **D
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileManager from 'devextreme-vue/file-manager';
   

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemMoved.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemMoved.md
@@ -100,7 +100,7 @@ Select a file/folder and use the **Move To** [context menu](/api-reference/10%20
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileManager

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemMoving.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemMoving.md
@@ -93,7 +93,7 @@ The component executes the **onItemMoving** function when a user clicks **Move**
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileManager from 'devextreme-vue/file-manager';
   

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemRenamed.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemRenamed.md
@@ -94,7 +94,7 @@ Select a file/directory and click the **Rename** [context menu](/api-reference/1
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileManager

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemRenaming.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onItemRenaming.md
@@ -93,7 +93,7 @@ The component executes the **onItemRenaming** function when a user enters a new 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileManager from 'devextreme-vue/file-manager';
   

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onSelectedFileOpened.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onSelectedFileOpened.md
@@ -84,7 +84,7 @@ The opened file.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileManager from 'devextreme-vue/file-manager';
 
@@ -105,7 +105,7 @@ The opened file.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onSelectionChanged.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onSelectionChanged.md
@@ -93,7 +93,7 @@ The currently selected file system items.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileManager from 'devextreme-vue/file-manager';
 
@@ -114,7 +114,7 @@ The currently selected file system items.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/onToolbarItemClick.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/onToolbarItemClick.md
@@ -94,7 +94,7 @@ The clicked item's index.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileManager from 'devextreme-vue/file-manager';
 
@@ -115,7 +115,7 @@ The clicked item's index.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
 

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/permissions/permissions.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/permissions/permissions.md
@@ -78,7 +78,7 @@ Specifies actions that a user is allowed to perform on files and directories.
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DxFileManager, DxPermissions } from 'devextreme-vue/file-manager';
     

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/rootFolderName.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/rootFolderName.md
@@ -61,7 +61,7 @@ Specifies the root directory display name.
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager
@@ -84,7 +84,7 @@ Specifies the root directory display name.
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/selectedItemKeys.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/selectedItemKeys.md
@@ -56,7 +56,7 @@ Contains an array of initially or currently selected files and directories' keys
         </DxFileManager>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager
@@ -79,7 +79,7 @@ Contains an array of initially or currently selected files and directories' keys
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/selectionMode.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/selectionMode.md
@@ -59,7 +59,7 @@ Specifies whether a user can select a single or multiple files and directories i
         </DxFileManager>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager
@@ -82,7 +82,7 @@ Specifies whether a user can select a single or multiple files and directories i
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/toolbar/toolbar.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/toolbar/toolbar.md
@@ -120,7 +120,7 @@ To add a predefined item to the toolbar, specify its [name](/api-reference/_hidd
         </DxFileManager>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager,
@@ -149,7 +149,7 @@ To add a predefined item to the toolbar, specify its [name](/api-reference/_hidd
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager, { Toolbar, Item, FileSelectionItem } from 'devextreme-react/file-manager';
     
@@ -353,7 +353,7 @@ The [widget](/api-reference/_hidden/dxFileManagerToolbarItem/widget.md '/Documen
         </DxFileManager>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager,
@@ -411,7 +411,7 @@ The [widget](/api-reference/_hidden/dxFileManagerToolbarItem/widget.md '/Documen
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager, { Toolbar, Item } from 'devextreme-react/file-manager';    
 
     const App = () => {

--- a/api-reference/10 UI Components/dxFileManager/1 Configuration/upload/upload.md
+++ b/api-reference/10 UI Components/dxFileManager/1 Configuration/upload/upload.md
@@ -60,7 +60,7 @@ Configures upload settings.
         </DxFileManager>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager,
@@ -85,7 +85,7 @@ Configures upload settings.
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager, { Upload } from 'devextreme-react/file-manager';
     

--- a/api-reference/10 UI Components/dxFileManager/3 Methods/refresh().md
+++ b/api-reference/10 UI Components/dxFileManager/3 Methods/refresh().md
@@ -84,7 +84,7 @@ The following example illustrates how to use this method:
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager
@@ -120,7 +120,7 @@ The following example illustrates how to use this method:
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
 

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/abortFileUpload.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/abortFileUpload.md
@@ -97,7 +97,7 @@ A Promise that is resolved after the file upload in aborted.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import { DxFileManager } from 'devextreme-vue/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
 
@@ -127,7 +127,7 @@ A Promise that is resolved after the file upload in aborted.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager from 'devextreme-react/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
     

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/copyItem.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/copyItem.md
@@ -93,7 +93,7 @@ A Promise that is resolved after the file system item is copied.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import { DxFileManager } from 'devextreme-vue/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
 
@@ -123,7 +123,7 @@ A Promise that is resolved after the file system item is copied.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager from 'devextreme-react/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
     

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/createDirectory.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/createDirectory.md
@@ -93,7 +93,7 @@ A Promise that is resolved after a new directory is created.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import { DxFileManager } from 'devextreme-vue/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
 
@@ -123,7 +123,7 @@ A Promise that is resolved after a new directory is created.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager from 'devextreme-react/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
     

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/deleteItem.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/deleteItem.md
@@ -90,7 +90,7 @@ A Promise that is resolved after a file system item is deleted.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import { DxFileManager } from 'devextreme-vue/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
 
@@ -120,7 +120,7 @@ A Promise that is resolved after a file system item is deleted.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager from 'devextreme-react/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
     

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/downloadItems.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/downloadItems.md
@@ -87,7 +87,7 @@ The file system items.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import { DxFileManager } from 'devextreme-vue/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
 
@@ -117,7 +117,7 @@ The file system items.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager from 'devextreme-react/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
     

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/getItems.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/getItems.md
@@ -90,7 +90,7 @@ A Promise that is resolved after file system items are obtained.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import { DxFileManager } from 'devextreme-vue/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
 
@@ -120,7 +120,7 @@ A Promise that is resolved after file system items are obtained.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager from 'devextreme-react/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
     

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/getItemsContent.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/getItemsContent.md
@@ -90,7 +90,7 @@ A Promise that is resolved after the content of the file system items is obtaine
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import { DxFileManager } from 'devextreme-vue/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
 
@@ -120,7 +120,7 @@ A Promise that is resolved after the content of the file system items is obtaine
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager from 'devextreme-react/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
     

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/hasSubDirectoriesExpr.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/hasSubDirectoriesExpr.md
@@ -77,7 +77,7 @@ A function or the name of a data source field that provides information on wheth
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import { DxFileManager } from 'devextreme-vue/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
 
@@ -100,7 +100,7 @@ A function or the name of a data source field that provides information on wheth
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager from 'devextreme-react/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
     

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/moveItem.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/moveItem.md
@@ -93,7 +93,7 @@ A Promise that is resolved after the file system item is moved.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import { DxFileManager } from 'devextreme-vue/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
 
@@ -123,7 +123,7 @@ A Promise that is resolved after the file system item is moved.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager from 'devextreme-react/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
     

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/renameItem.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/renameItem.md
@@ -93,7 +93,7 @@ A Promise that is resolved after the file system item is renamed.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import { DxFileManager } from 'devextreme-vue/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
 
@@ -123,7 +123,7 @@ A Promise that is resolved after the file system item is renamed.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager from 'devextreme-react/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
     

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/uploadFileChunk.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/1 Configuration/uploadFileChunk.md
@@ -151,7 +151,7 @@ A Promise that is resolved after the file system item is uploaded.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import { DxFileManager } from 'devextreme-vue/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
 
@@ -208,7 +208,7 @@ A Promise that is resolved after the file system item is uploaded.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager from 'devextreme-react/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
     

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/Custom.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Custom/Custom.md
@@ -100,7 +100,7 @@ The following code shows how to create a custom file system provider and bind th
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import { DxFileManager } from 'devextreme-vue/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
 
@@ -133,7 +133,7 @@ The following code shows how to create a custom file system provider and bind th
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager from 'devextreme-react/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';
     

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Object/Object.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Object/Object.md
@@ -122,7 +122,7 @@ The following code shows how to bind the FileManager to the **Object** file syst
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';     
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';     
     
     import { 
         DxFileManager
@@ -169,7 +169,7 @@ The following code shows how to bind the FileManager to the **Object** file syst
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import FileManager from 'devextreme-react/file-manager';
     import ObjectFileSystemProvider from 'devextreme/file_management/object_provider';
     

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Remote/1 Configuration/beforeAjaxSend.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Remote/1 Configuration/beforeAjaxSend.md
@@ -99,7 +99,7 @@ An object (fieldName/fieldValue pairs) to set on the native <a href="https://api
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     
     import { DxFileManager } from 'devextreme-vue/file-manager';
     
@@ -131,7 +131,7 @@ An object (fieldName/fieldValue pairs) to set on the native <a href="https://api
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import FileManager from 'devextreme-react/file-manager';
     import RemoteFileSystemProvider from 'devextreme/file_management/remote_provider';

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Remote/1 Configuration/beforeSubmit.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Remote/1 Configuration/beforeSubmit.md
@@ -89,7 +89,7 @@ Custom data (key-value pairs) that are sent to the server with the request.
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     
     import { DxFileManager } from 'devextreme-vue/file-manager';
     
@@ -119,7 +119,7 @@ Custom data (key-value pairs) that are sent to the server with the request.
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import FileManager from 'devextreme-react/file-manager';
     import RemoteFileSystemProvider from 'devextreme/file_management/remote_provider';

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Remote/1 Configuration/requestHeaders.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Remote/1 Configuration/requestHeaders.md
@@ -85,7 +85,7 @@ Specifies the request headers.
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     
     import { DxFileManager } from 'devextreme-vue/file-manager';
     
@@ -115,7 +115,7 @@ Specifies the request headers.
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import FileManager from 'devextreme-react/file-manager';
     import RemoteFileSystemProvider from 'devextreme/file_management/remote_provider';

--- a/api-reference/10 UI Components/dxFileManager/5 File System Providers/Remote/Remote.md
+++ b/api-reference/10 UI Components/dxFileManager/5 File System Providers/Remote/Remote.md
@@ -99,7 +99,7 @@ The following code shows how to bind the FileManager to the **Remote** file syst
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     
     import { DxFileManager } from 'devextreme-vue/file-manager';
     
@@ -126,7 +126,7 @@ The following code shows how to bind the FileManager to the **Remote** file syst
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import FileManager from 'devextreme-react/file-manager';
     import RemoteFileSystemProvider from 'devextreme/file_management/remote_provider';

--- a/api-reference/10 UI Components/dxFileManager/7 Interfaces/FileSystemError/FileSystemError.md
+++ b/api-reference/10 UI Components/dxFileManager/7 Interfaces/FileSystemError/FileSystemError.md
@@ -177,7 +177,7 @@ An object that contains information about the error.
     import FileManager, { Permissions } from "devextreme-react/file-manager";
     import { fileItems } from "./data.js";
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     const objectProvider = new ObjectFileSystemProvider({
         data: fileItems

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/allowSelection.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/allowSelection.md
@@ -72,7 +72,7 @@ Specifies whether users can select tasks in the Gantt.
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -93,7 +93,7 @@ Specifies whether users can select tasks in the Gantt.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/columns/columns.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/columns/columns.md
@@ -101,7 +101,7 @@ The **columns** property accepts an array of columns. To configure a column, use
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -122,7 +122,7 @@ The **columns** property accepts an array of columns. To configure a column, use
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/columns/customizeText.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/columns/customizeText.md
@@ -97,7 +97,7 @@ The text the cell should display.
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DxGantt, DxColumn } from "devextreme-vue/gantt";
     
@@ -119,7 +119,7 @@ The text the cell should display.
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import Gantt, { Column } from "devextreme-react/gantt";
     

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/dependencies/dependencies.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/dependencies/dependencies.md
@@ -204,7 +204,7 @@ Use the [dataSource](/api-reference/10%20UI%20Components/dxGantt/1%20Configurati
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -247,7 +247,7 @@ Use the [dataSource](/api-reference/10%20UI%20Components/dxGantt/1%20Configurati
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/editing/editing.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/editing/editing.md
@@ -104,7 +104,7 @@ The UI component allows users to add, modify and delete tasks, resources and dep
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -127,7 +127,7 @@ The UI component allows users to add, modify and delete tasks, resources and dep
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/endDateRange.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/endDateRange.md
@@ -81,7 +81,7 @@ Specifies the end date of the date interval in the Gantt chart.
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -108,7 +108,7 @@ Specifies the end date of the date interval in the Gantt chart.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/firstDayOfWeek.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/firstDayOfWeek.md
@@ -83,7 +83,7 @@ The culture settings specify the property's default value.
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -104,7 +104,7 @@ The culture settings specify the property's default value.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/headerFilter.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/headerFilter.md
@@ -92,7 +92,7 @@ Set the **headerFilter**.[visible](/api-reference/_hidden/dxGanttHeaderFilter/vi
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -115,7 +115,7 @@ Set the **headerFilter**.[visible](/api-reference/_hidden/dxGanttHeaderFilter/vi
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onContextMenuPreparing.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onContextMenuPreparing.md
@@ -86,7 +86,7 @@ The type of right-clicked task or dependency.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -108,7 +108,7 @@ The type of right-clicked task or dependency.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onCustomCommand.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onCustomCommand.md
@@ -69,7 +69,7 @@ The name of the clicked item.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -90,7 +90,7 @@ The name of the clicked item.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onDependencyDeleted.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onDependencyDeleted.md
@@ -76,7 +76,7 @@ The values of the deleted dependency.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -98,7 +98,7 @@ The values of the deleted dependency.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onDependencyDeleting.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onDependencyDeleting.md
@@ -83,7 +83,7 @@ The values of the deleted dependency.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -107,7 +107,7 @@ The values of the deleted dependency.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onDependencyInserted.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onDependencyInserted.md
@@ -78,7 +78,7 @@ The values of the inserted dependency.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -101,7 +101,7 @@ The values of the inserted dependency.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onDependencyInserting.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onDependencyInserting.md
@@ -80,7 +80,7 @@ The values of the inserted dependency.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -104,7 +104,7 @@ The values of the inserted dependency.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceAssigned.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceAssigned.md
@@ -78,7 +78,7 @@ The values of the processed resource and task.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -101,7 +101,7 @@ The values of the processed resource and task.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceAssigning.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceAssigning.md
@@ -80,7 +80,7 @@ The values of the processed resource and task.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -104,7 +104,7 @@ The values of the processed resource and task.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceDeleted.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceDeleted.md
@@ -78,7 +78,7 @@ The values of the deleted resource.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -101,7 +101,7 @@ The values of the deleted resource.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceDeleting.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceDeleting.md
@@ -83,7 +83,7 @@ The values of the deleted resource.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -107,7 +107,7 @@ The values of the deleted resource.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceInserted.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceInserted.md
@@ -78,7 +78,7 @@ The values of the inserted resource.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -101,7 +101,7 @@ The values of the inserted resource.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceInserting.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceInserting.md
@@ -80,7 +80,7 @@ The values of the inserted resource.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -104,7 +104,7 @@ The values of the inserted resource.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceManagerDialogShowing.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceManagerDialogShowing.md
@@ -80,7 +80,7 @@ The resources.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -104,7 +104,7 @@ The resources.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceUnassigned.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceUnassigned.md
@@ -78,7 +78,7 @@ The values of the processed resource and task.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -101,7 +101,7 @@ The values of the processed resource and task.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceUnassigning.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onResourceUnassigning.md
@@ -83,7 +83,7 @@ The values of the processed resource and task.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -107,7 +107,7 @@ The values of the processed resource and task.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onScaleCellPrepared.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onScaleCellPrepared.md
@@ -106,7 +106,7 @@ The example below illustrates how to customize the scale.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -136,7 +136,7 @@ The example below illustrates how to customize the scale.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 
@@ -264,7 +264,7 @@ The code below colors the scale cells depending on the season:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -296,7 +296,7 @@ The code below colors the scale cells depending on the season:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onSelectionChanged.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onSelectionChanged.md
@@ -79,7 +79,7 @@ The key of the row whose selection state was changed.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -104,7 +104,7 @@ The key of the row whose selection state was changed.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskClick.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskClick.md
@@ -81,7 +81,7 @@ The task key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -104,7 +104,7 @@ The task key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskDblClick.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskDblClick.md
@@ -86,7 +86,7 @@ The task key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -110,7 +110,7 @@ The task key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskDeleted.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskDeleted.md
@@ -78,7 +78,7 @@ The values of the deleted task.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -101,7 +101,7 @@ The values of the deleted task.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskDeleting.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskDeleting.md
@@ -83,7 +83,7 @@ The values of the deleted task.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -107,7 +107,7 @@ The values of the deleted task.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskEditDialogShowing.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskEditDialogShowing.md
@@ -91,7 +91,7 @@ The **hiddenFields** and **readOnlyFields** parameters affect only task fields. 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -115,7 +115,7 @@ The **hiddenFields** and **readOnlyFields** parameters affect only task fields. 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskInserted.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskInserted.md
@@ -78,7 +78,7 @@ The values of the inserted task.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -101,7 +101,7 @@ The values of the inserted task.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskInserting.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskInserting.md
@@ -82,7 +82,7 @@ Note that you should not specify a task ID in the `onTaskInserting` function.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -106,7 +106,7 @@ Note that you should not specify a task ID in the `onTaskInserting` function.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskMoving.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskMoving.md
@@ -86,7 +86,7 @@ The task values before moving.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -110,7 +110,7 @@ The task values before moving.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskUpdated.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskUpdated.md
@@ -78,7 +78,7 @@ The task values after update.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -101,7 +101,7 @@ The task values after update.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskUpdating.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/onTaskUpdating.md
@@ -86,7 +86,7 @@ The task values before update.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
   
@@ -110,7 +110,7 @@ The task values before update.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/resourceAssignments/resourceAssignments.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/resourceAssignments/resourceAssignments.md
@@ -155,7 +155,7 @@ Use the [dataSource](/api-reference/10%20UI%20Components/dxGantt/1%20Configurati
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css';  
 
         import { 
@@ -196,7 +196,7 @@ Use the [dataSource](/api-reference/10%20UI%20Components/dxGantt/1%20Configurati
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/resources/resources.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/resources/resources.md
@@ -164,7 +164,7 @@ The 'color' field accepts the following values:
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css'; 
+        import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -206,7 +206,7 @@ The 'color' field accepts the following values:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/scaleType.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/scaleType.md
@@ -70,7 +70,7 @@ The **scaleType** property specifies the zoom level for tasks when the Gantt UI 
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -91,7 +91,7 @@ The **scaleType** property specifies the zoom level for tasks when the Gantt UI 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/scaleTypeRange/scaleTypeRange.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/scaleTypeRange/scaleTypeRange.md
@@ -77,7 +77,7 @@ Use the [scaleTypeRange.min](/api-reference/10%20UI%20Components/dxGantt/1%20Con
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -100,7 +100,7 @@ Use the [scaleTypeRange.min](/api-reference/10%20UI%20Components/dxGantt/1%20Con
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/selectedRowKey.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/selectedRowKey.md
@@ -71,7 +71,7 @@ Allows you to select a row or determine which row is selected.
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -92,7 +92,7 @@ Allows you to select a row or determine which row is selected.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/showDependencies.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/showDependencies.md
@@ -72,7 +72,7 @@ Specifies whether to display [dependencies](/api-reference/10%20UI%20Components/
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -93,7 +93,7 @@ Specifies whether to display [dependencies](/api-reference/10%20UI%20Components/
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/showResources.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/showResources.md
@@ -72,7 +72,7 @@ Specifies whether to display [task resources](/api-reference/10%20UI%20Component
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -93,7 +93,7 @@ Specifies whether to display [task resources](/api-reference/10%20UI%20Component
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/showRowLines.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/showRowLines.md
@@ -66,7 +66,7 @@ Specifies whether to show/hide horizontal faint lines that separate tasks.
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -87,7 +87,7 @@ Specifies whether to show/hide horizontal faint lines that separate tasks.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/sorting.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/sorting.md
@@ -104,7 +104,7 @@ To clear sorting for a column, hold Ctrl and click the column header. You can al
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -127,7 +127,7 @@ To clear sorting for a column, hold Ctrl and click the column header. You can al
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/startDateRange.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/startDateRange.md
@@ -81,7 +81,7 @@ Specifies the start date of the date interval in the Gantt chart.
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -108,7 +108,7 @@ Specifies the start date of the date interval in the Gantt chart.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/stripLines.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/stripLines.md
@@ -113,7 +113,7 @@ Strip lines allows you to highlight certain time or time intervals in the chart.
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -134,7 +134,7 @@ Strip lines allows you to highlight certain time or time intervals in the chart.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/taskContentTemplate.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/taskContentTemplate.md
@@ -121,7 +121,7 @@ To learn how to display current and planned tasks in the Gantt chart area with *
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DxGantt } from 'devextreme-vue/gantt';
     

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/taskListWidth.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/taskListWidth.md
@@ -74,7 +74,7 @@ Specifies the width of task list columns in pixels.
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -95,7 +95,7 @@ Specifies the width of task list columns in pixels.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/taskProgressTooltipContentTemplate.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/taskProgressTooltipContentTemplate.md
@@ -99,7 +99,7 @@ The task's progress.
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DxGantt } from 'devextreme-vue/gantt';
     

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/taskTimeTooltipContentTemplate.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/taskTimeTooltipContentTemplate.md
@@ -102,7 +102,7 @@ The task's start date.
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DxGantt } from 'devextreme-vue/gantt';
     

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/taskTitlePosition.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/taskTitlePosition.md
@@ -71,7 +71,7 @@ Titles can be displayed *"inside"* or *"outside"* the the task. Set the position
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -92,7 +92,7 @@ Titles can be displayed *"inside"* or *"outside"* the the task. Set the position
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/taskTooltipContentTemplate.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/taskTooltipContentTemplate.md
@@ -103,7 +103,7 @@ Note that the **container** parameter contains the content of the default toolti
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DxGantt } from 'devextreme-vue/gantt';
     

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/tasks/tasks.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/tasks/tasks.md
@@ -187,7 +187,7 @@ The 'color' field accepts the following values:
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -234,7 +234,7 @@ The 'color' field accepts the following values:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/validation/enablePredecessorGap.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/validation/enablePredecessorGap.md
@@ -88,7 +88,7 @@ The **enablePredecessorGap** option allows users to increase/decrease the gap be
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -111,7 +111,7 @@ The **enablePredecessorGap** option allows users to increase/decrease the gap be
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/validation/validation.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/validation/validation.md
@@ -79,7 +79,7 @@ Configures validation properties.
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -102,7 +102,7 @@ Configures validation properties.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/assignResourceToTask(resourceKey_taskKey).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/assignResourceToTask(resourceKey_taskKey).md
@@ -78,7 +78,7 @@ The task key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -113,7 +113,7 @@ The task key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/collapseAll().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/collapseAll().md
@@ -46,7 +46,7 @@ Collapses all tasks.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -81,7 +81,7 @@ Collapses all tasks.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/collapseTask(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/collapseTask(key).md
@@ -49,7 +49,7 @@ The task key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -84,7 +84,7 @@ The task key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/deleteDependency(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/deleteDependency(key).md
@@ -75,7 +75,7 @@ The dependency key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -110,7 +110,7 @@ The dependency key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/deleteResource(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/deleteResource(key).md
@@ -75,7 +75,7 @@ The resource key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -110,7 +110,7 @@ The resource key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/deleteTask(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/deleteTask(key).md
@@ -75,7 +75,7 @@ The task key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -110,7 +110,7 @@ The task key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/expandAll().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/expandAll().md
@@ -46,7 +46,7 @@ Expands all tasks.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -81,7 +81,7 @@ Expands all tasks.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/expandAllToLevel(level).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/expandAllToLevel(level).md
@@ -51,7 +51,7 @@ The **expandAllToLevel** method first collapses all expanded tasks and then expa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -86,7 +86,7 @@ The **expandAllToLevel** method first collapses all expanded tasks and then expa
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/expandTask(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/expandTask(key).md
@@ -51,7 +51,7 @@ The **expandTask** method expands a task's parent tasks and the task itself.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -86,7 +86,7 @@ The **expandTask** method expands a task's parent tasks and the task itself.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/expandToTask(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/expandToTask(key).md
@@ -51,7 +51,7 @@ The **expandToTask** method expands a task's parent tasks and does not expand th
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -86,7 +86,7 @@ The **expandToTask** method expands a task's parent tasks and does not expand th
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getDependencyData(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getDependencyData(key).md
@@ -78,7 +78,7 @@ The dependency key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -113,7 +113,7 @@ The dependency key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getResourceAssignmentData(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getResourceAssignmentData(key).md
@@ -78,7 +78,7 @@ The resource assignment key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -113,7 +113,7 @@ The resource assignment key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getResourceData(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getResourceData(key).md
@@ -78,7 +78,7 @@ The resource key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -113,7 +113,7 @@ The resource key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getTaskData(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getTaskData(key).md
@@ -78,7 +78,7 @@ The task key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -113,7 +113,7 @@ The task key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getTaskResources(key).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getTaskResources(key).md
@@ -79,7 +79,7 @@ The task's key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -114,7 +114,7 @@ The task's key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleDependencyKeys().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleDependencyKeys().md
@@ -76,7 +76,7 @@ The keys.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -111,7 +111,7 @@ The keys.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleResourceAssignmentKeys().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleResourceAssignmentKeys().md
@@ -76,7 +76,7 @@ The keys.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -111,7 +111,7 @@ The keys.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleResourceKeys().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleResourceKeys().md
@@ -76,7 +76,7 @@ The keys.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -111,7 +111,7 @@ The keys.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleTaskKeys().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/getVisibleTaskKeys().md
@@ -76,7 +76,7 @@ The keys.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -111,7 +111,7 @@ The keys.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/insertDependency(data).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/insertDependency(data).md
@@ -75,7 +75,7 @@ The dependency data.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -110,7 +110,7 @@ The dependency data.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/insertResource(data_taskKeys).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/insertResource(data_taskKeys).md
@@ -91,7 +91,7 @@ An array of task keys.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -132,7 +132,7 @@ An array of task keys.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/insertTask(data).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/insertTask(data).md
@@ -89,7 +89,7 @@ The **insertTask** method does not update the following data fields in the data 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -127,7 +127,7 @@ The **insertTask** method does not update the following data fields in the data 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/refresh().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/refresh().md
@@ -49,7 +49,7 @@ A Promise that is resolved after data is loaded.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -84,7 +84,7 @@ A Promise that is resolved after data is loaded.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/scrollToDate(date).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/scrollToDate(date).md
@@ -99,7 +99,7 @@ Specify a timeout if you call the **scrollToDate** method in the [contentReady](
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -134,7 +134,7 @@ Specify a timeout if you call the **scrollToDate** method in the [contentReady](
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/showDependencies(value).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/showDependencies(value).md
@@ -77,7 +77,7 @@ Specifies whether to show or hide dependencies.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -112,7 +112,7 @@ Specifies whether to show or hide dependencies.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/showResourceManagerDialog().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/showResourceManagerDialog().md
@@ -75,7 +75,7 @@ Invokes the "Resource Manager" dialog.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxGantt from 'devextreme-vue/gantt';
 
@@ -96,7 +96,7 @@ Invokes the "Resource Manager" dialog.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Gantt from 'devextreme-react/gantt';
 
     const App = () => {

--- a/api-reference/10 UI Components/dxGantt/3 Methods/showResources(value).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/showResources(value).md
@@ -77,7 +77,7 @@ Specifies whether to show or hide task resources.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -112,7 +112,7 @@ Specifies whether to show or hide task resources.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/showTaskDetailsDialog(taskKey).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/showTaskDetailsDialog(taskKey).md
@@ -77,7 +77,7 @@ A task key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -112,7 +112,7 @@ A task key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/unassignAllResourcesFromTask(taskKey).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/unassignAllResourcesFromTask(taskKey).md
@@ -77,7 +77,7 @@ The task key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -112,7 +112,7 @@ The task key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/unassignResourceFromTask(resourceKey_taskKey).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/unassignResourceFromTask(resourceKey_taskKey).md
@@ -80,7 +80,7 @@ The task key.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -115,7 +115,7 @@ The task key.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/updateTask(key_data).md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/updateTask(key_data).md
@@ -80,7 +80,7 @@ Note that the **updateTask** method does not allow you to change a task's parent
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -115,7 +115,7 @@ Note that the **updateTask** method does not allow you to change a task's parent
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/zoomIn().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/zoomIn().md
@@ -47,7 +47,7 @@ Zooms in the Gantt chart.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -82,7 +82,7 @@ Zooms in the Gantt chart.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxGantt/3 Methods/zoomOut().md
+++ b/api-reference/10 UI Components/dxGantt/3 Methods/zoomOut().md
@@ -47,7 +47,7 @@ Zooms out the Gantt chart.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css';
 
     import DxGantt from 'devextreme-vue/gantt';
@@ -82,7 +82,7 @@ Zooms out the Gantt chart.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Gantt from 'devextreme-react/gantt';
 

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/dataSource.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/dataSource.md
@@ -105,7 +105,7 @@ Use one of the following extensions to enable the server to process data accordi
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';
@@ -135,7 +135,7 @@ Use one of the following extensions to enable the server to process data accordi
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import CustomStore from 'devextreme/data/custom_store';
         import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/export/export.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/export/export.md
@@ -114,7 +114,7 @@ The following instructions show how to enable and configure client-side export:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { DxPivotGrid, 
             DxExport,
@@ -134,7 +134,7 @@ The following instructions show how to enable and configure client-side export:
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import PivotGrid, {
             Export,
@@ -254,7 +254,7 @@ The following instructions show how to enable and configure client-side export:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { DxPivotGrid, DxExport } from 'devextreme-vue/pivot-grid';
         import { exportPivotGrid } from 'devextreme/excel_exporter';
@@ -293,7 +293,7 @@ The following instructions show how to enable and configure client-side export:
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { Workbook } from 'devextreme-exceljs-fork';
         import saveAs from 'file-saver';

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onCellPrepared.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onCellPrepared.md
@@ -104,7 +104,7 @@ This function allows you to customize cells and modify their content. Common use
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxPivotGrid from 'devextreme-vue/pivot-grid';
 
@@ -127,7 +127,7 @@ This function allows you to customize cells and modify their content. Common use
 
         <!-- tab: App.js -->
         import React, { useCallback } from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import PivotGrid from 'devextreme-react/pivot-grid';
         
         export default function App() {
@@ -216,7 +216,7 @@ This function allows you to customize cells and modify their content. Common use
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxPivotGrid from 'devextreme-vue/pivot-grid';
 
@@ -239,7 +239,7 @@ This function allows you to customize cells and modify their content. Common use
 
         <!-- tab: App.js -->
         import React, { useCallback } from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import PivotGrid from 'devextreme-react/pivot-grid';
 

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onContextMenuPreparing.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onContextMenuPreparing.md
@@ -145,7 +145,7 @@ In the following code, the **onContextMenuPreparing** function adds a custom ite
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -182,7 +182,7 @@ In the following code, the **onContextMenuPreparing** function adds a custom ite
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxPivotGrid/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/allDayPanelMode.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/allDayPanelMode.md
@@ -68,7 +68,7 @@ To also display appointments that have a duration equal to or more than 24 hours
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler } from 'devextreme-vue/scheduler';
 
@@ -89,7 +89,7 @@ To also display appointments that have a duration equal to or more than 24 hours
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Scheduler } from 'devextreme-react/scheduler';
 

--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/appointmentCollectorTemplate.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/appointmentCollectorTemplate.md
@@ -86,7 +86,7 @@ Initially hidden appointments that are displayed after a user clicks an overflow
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler } from 'devextreme-vue/scheduler';
 
@@ -107,7 +107,7 @@ Initially hidden appointments that are displayed after a user clicks an overflow
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Scheduler } from 'devextreme-react/scheduler';
 

--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/customizeDateNavigatorText.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/customizeDateNavigatorText.md
@@ -102,7 +102,7 @@ In the following code, the **customizeDateNavigatorText** function is used to sh
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler } from 'devextreme-vue/scheduler';
 
@@ -140,7 +140,7 @@ In the following code, the **customizeDateNavigatorText** function is used to sh
     <!-- tab: App.js -->
     import React, { useCallback, useState } from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
 

--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/groups.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/groups.md
@@ -71,7 +71,7 @@ This array should contain one or more values that correspond to the [fieldExpr](
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler } from 'devextreme-vue/scheduler';
 
@@ -96,7 +96,7 @@ This array should contain one or more values that correspond to the [fieldExpr](
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler, { Resource } from 'devextreme-react/scheduler';
 

--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/resources/allowMultiple.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/resources/allowMultiple.md
@@ -156,7 +156,7 @@ Note that you should specify resources for appointments in your data source acco
         </DxScheduler>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-scheduler/dist/dx-gantt.css'; 
 
         import { 
@@ -220,7 +220,7 @@ Note that you should specify resources for appointments in your data source acco
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-scheduler/dist/dx-scheduler.css'; 
 
     import Scheduler, { 

--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/resources/dataSource.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/resources/dataSource.md
@@ -115,7 +115,7 @@ Use one of the following extensions to enable the server to process data accordi
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';
@@ -148,7 +148,7 @@ Use one of the following extensions to enable the server to process data accordi
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';

--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/views/allDayPanelMode.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/views/allDayPanelMode.md
@@ -80,7 +80,7 @@ To also display appointments that have a duration equal to or more than 24 hours
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler } from 'devextreme-vue/scheduler';
 
@@ -102,7 +102,7 @@ To also display appointments that have a duration equal to or more than 24 hours
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Scheduler } from 'devextreme-react/scheduler';
 

--- a/api-reference/10 UI Components/dxScheduler/1 Configuration/views/appointmentCollectorTemplate.md
+++ b/api-reference/10 UI Components/dxScheduler/1 Configuration/views/appointmentCollectorTemplate.md
@@ -86,7 +86,7 @@ A template name or container.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler, DxView } from 'devextreme-vue/scheduler';
 
@@ -108,7 +108,7 @@ A template name or container.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Scheduler, View } from 'devextreme-react/scheduler';
 

--- a/api-reference/10 UI Components/dxScheduler/3 Methods/deleteAppointment(appointment).md
+++ b/api-reference/10 UI Components/dxScheduler/3 Methods/deleteAppointment(appointment).md
@@ -147,7 +147,7 @@ If you delete a recurring appointment from the data source, all its occurrences 
         </div>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler from 'devextreme-vue/scheduler';
     import DxButton from 'devextreme-vue/button';
@@ -194,7 +194,7 @@ If you delete a recurring appointment from the data source, all its occurrences 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Scheduler from 'devextreme-react/scheduler';
     import Button from 'devextreme-react/button';
     import { appointments } from './data.js';

--- a/api-reference/10 UI Components/dxScheduler/3 Methods/deleteRecurrence(appointment_date_recurrenceEditMode).md
+++ b/api-reference/10 UI Components/dxScheduler/3 Methods/deleteRecurrence(appointment_date_recurrenceEditMode).md
@@ -130,7 +130,7 @@ An edit mode for recurring appointments.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxScheduler from 'devextreme-vue/scheduler';
     import { appointments } from './data.js';
 

--- a/concepts/05 UI Components/Diagram/00 Getting Started with Diagram/05 Add the Diagram Component to a Page.md
+++ b/concepts/05 UI Components/Diagram/00 Getting Started with Diagram/05 Add the Diagram Component to a Page.md
@@ -71,7 +71,7 @@
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-diagram/dist/dx-diagram.min.css';
     import { DxDiagram } from 'devextreme-vue/diagram';
     </script>
@@ -83,7 +83,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-diagram/dist/dx-diagram.min.css';
 
     import { Diagram } from 'devextreme-react/diagram';

--- a/concepts/05 UI Components/FileManager/00 Getting Started with File Manager/10 Create a File Manager.md
+++ b/concepts/05 UI Components/FileManager/00 Getting Started with File Manager/10 Create a File Manager.md
@@ -48,7 +48,7 @@ The following code creates the FileManager UI component and adds it to your page
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';     
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';     
 
         import { DxFileManager } from 'devextreme-vue/file-manager';
 
@@ -64,7 +64,7 @@ The following code creates the FileManager UI component and adds it to your page
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     

--- a/concepts/05 UI Components/FileManager/00 Getting Started with File Manager/20 Bind the File Manager Component to a File System.md
+++ b/concepts/05 UI Components/FileManager/00 Getting Started with File Manager/20 Bind the File Manager Component to a File System.md
@@ -125,7 +125,7 @@ In the example below, the FileManager UI component displays hierarchical data st
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';     
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';     
 
     import { 
         DxFileManager
@@ -173,7 +173,7 @@ In the example below, the FileManager UI component displays hierarchical data st
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     import { fileItems } from './data.js';

--- a/concepts/05 UI Components/FileManager/10 Bind to File Systems/10 Object File System.md
+++ b/concepts/05 UI Components/FileManager/10 Bind to File Systems/10 Object File System.md
@@ -128,7 +128,7 @@ In the example below, the FileManager UI component displays hierarchical data st
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';     
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';     
 
     import { 
         DxFileManager
@@ -176,7 +176,7 @@ In the example below, the FileManager UI component displays hierarchical data st
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     import { fileItems } from './data.js';
@@ -364,7 +364,7 @@ If the data source's field names differ from the standard field names mentioned 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';     
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';     
 
     import { DxFileManager } from 'devextreme-vue/file-manager';
     import ObjectFileSystemProvider from 'devextreme/file_management/object_provider';
@@ -418,7 +418,7 @@ If the data source's field names differ from the standard field names mentioned 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     import ObjectFileSystemProvider from 'devextreme/file_management/object_provider';

--- a/concepts/05 UI Components/FileManager/10 Bind to File Systems/20 Remote File System.md
+++ b/concepts/05 UI Components/FileManager/10 Bind to File Systems/20 Remote File System.md
@@ -109,7 +109,7 @@ The data object, which is sent back from the server, contains attributes that st
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     
     import { DxFileManager } from 'devextreme-vue/file-manager';
 
@@ -136,7 +136,7 @@ The data object, which is sent back from the server, contains attributes that st
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     import RemoteFileSystemProvider from 'devextreme/file_management/remote_provider';

--- a/concepts/05 UI Components/FileManager/10 Bind to File Systems/30 Custom File System.md
+++ b/concepts/05 UI Components/FileManager/10 Bind to File Systems/30 Custom File System.md
@@ -95,7 +95,7 @@ Assign the [Custom](/api-reference/10%20UI%20Components/dxFileManager/5%20File%2
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';     
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';     
         
         import { DxFileManager } from 'devextreme-vue/file-manager';
         import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';        
@@ -135,7 +135,7 @@ Assign the [Custom](/api-reference/10%20UI%20Components/dxFileManager/5%20File%2
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager from 'devextreme-react/file-manager';
     import CustomFileSystemProvider from 'devextreme/file_management/custom_provider';

--- a/concepts/05 UI Components/FileManager/30 Validation/10 Permissions.md
+++ b/concepts/05 UI Components/FileManager/30 Validation/10 Permissions.md
@@ -93,7 +93,7 @@ The UI component also has the [allowedFileExtensions](/api-reference/10%20UI%20C
         </DxFileManager>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager,
@@ -118,7 +118,7 @@ The UI component also has the [allowedFileExtensions](/api-reference/10%20UI%20C
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager, { 
         Permissions 

--- a/concepts/05 UI Components/FileManager/30 Validation/20 Upload Settings.md
+++ b/concepts/05 UI Components/FileManager/30 Validation/20 Upload Settings.md
@@ -79,7 +79,7 @@ The UI component allows you to configure upload settings:
         </DxFileManager>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';    
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';    
     
     import {
         DxFileManager,
@@ -106,7 +106,7 @@ The UI component allows you to configure upload settings:
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager, { 
         Upload, Permissions 

--- a/concepts/05 UI Components/Gantt/00 Getting Started with Gantt/10 Add the Gantt Component to a Page.md
+++ b/concepts/05 UI Components/Gantt/00 Getting Started with Gantt/10 Add the Gantt Component to a Page.md
@@ -70,7 +70,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.min.css';
     import { DxGantt } from 'devextreme-vue/gantt';
 
@@ -88,7 +88,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.min.css';
 
     import { Gantt } from 'devextreme-react/gantt';

--- a/concepts/05 UI Components/Gantt/15 Filter Data/10 Filter Row.md
+++ b/concepts/05 UI Components/Gantt/15 Filter Data/10 Filter Row.md
@@ -109,7 +109,7 @@ The **Gantt** allows you to define initial filter settings in code. Specify a co
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
     
     import {
@@ -133,7 +133,7 @@ The **Gantt** allows you to define initial filter settings in code. Specify a co
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, {
@@ -319,7 +319,7 @@ You can use the [filterOperations](/api-reference/10%20UI%20Components/dxGantt/1
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
     
     import {
@@ -343,7 +343,7 @@ You can use the [filterOperations](/api-reference/10%20UI%20Components/dxGantt/1
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, {

--- a/concepts/05 UI Components/Gantt/15 Filter Data/20 Header Filter.md
+++ b/concepts/05 UI Components/Gantt/15 Filter Data/20 Header Filter.md
@@ -165,7 +165,7 @@ Users can search for the filter values in the header filter. Enable the **header
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
     
     import {
@@ -189,7 +189,7 @@ Users can search for the filter values in the header filter. Enable the **header
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, {
@@ -386,7 +386,7 @@ The **Gantt** allows you to define initial filter settings in code. Specify the 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
     
     import {
@@ -410,7 +410,7 @@ The **Gantt** allows you to define initial filter settings in code. Specify the 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, {

--- a/concepts/05 UI Components/Gantt/20 Sort Data/20 Sort in Code.md
+++ b/concepts/05 UI Components/Gantt/20 Sort Data/20 Sort in Code.md
@@ -82,7 +82,7 @@ The following code sorts data by the "Start" and "End" columns:
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -107,7 +107,7 @@ The following code sorts data by the "Start" and "End" columns:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 
@@ -239,7 +239,7 @@ Use the [ascendingText](/api-reference/_hidden/dxGanttSorting/ascendingText.md '
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -262,7 +262,7 @@ Use the [ascendingText](/api-reference/_hidden/dxGanttSorting/ascendingText.md '
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/concepts/05 UI Components/Gantt/20 Sort Data/Sort Data.md
+++ b/concepts/05 UI Components/Gantt/20 Sort Data/Sort Data.md
@@ -71,7 +71,7 @@ To disable sorting for an individual column, set the **column.**[allowSorting](/
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -94,7 +94,7 @@ To disable sorting for an individual column, set the **column.**[allowSorting](/
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/concepts/05 UI Components/Gantt/50 Export Data.md
+++ b/concepts/05 UI Components/Gantt/50 Export Data.md
@@ -126,7 +126,7 @@ You can call this method at any point in your application. In this example, this
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -185,7 +185,7 @@ You can call this method at any point in your application. In this example, this
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/concepts/05 UI Components/Pagination/05 Getting Started with Pagination/05 Create Pagination.md
+++ b/concepts/05 UI Components/Pagination/05 Getting Started with Pagination/05 Create Pagination.md
@@ -71,7 +71,7 @@
     </template>
 
     <script setup lang="ts">
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxPagination } from 'devextreme-vue/pagination';
     </script>
 
@@ -81,7 +81,7 @@
 
     <!-- tab: App.tsx -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { Pagination } from 'devextreme-react/pagination';
 
     function App(): JSX.Element {

--- a/concepts/05 UI Components/PivotGrid/00 Getting Started with PivotGrid/02 Create a PivotGrid.md
+++ b/concepts/05 UI Components/PivotGrid/00 Getting Started with PivotGrid/02 Create a PivotGrid.md
@@ -90,7 +90,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPivotGrid } from 'devextreme-vue/pivot-grid';
 
@@ -112,7 +112,7 @@
 [Add DevExtreme to your React application](/concepts/50%20React%20Components/05%20Add%20DevExtreme%20to%20a%20React%20Application/00%20Add%20DevExtreme%20to%20a%20React%20Application.md '/Documentation/Guide/React_Components/Add_DevExtreme_to_a_React_Application/') and use the following code to create a PivotGrid:
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import './App.css';
 
     import {

--- a/concepts/05 UI Components/PivotGrid/00 Getting Started with PivotGrid/05 Bind the PivotGrid to Data.md
+++ b/concepts/05 UI Components/PivotGrid/00 Getting Started with PivotGrid/05 Bind the PivotGrid to Data.md
@@ -96,7 +96,7 @@ In this tutorial, we use the [XmlaStore](/api-reference/30%20Data%20Layer/XmlaSt
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPivotGrid } from 'devextreme-vue/pivot-grid';
     import AdventureWorksService from './adventureworks.service';
@@ -134,7 +134,7 @@ In this tutorial, we use the [XmlaStore](/api-reference/30%20Data%20Layer/XmlaSt
     }
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import AdventureWorksService from './adventureworks.service';
     import { PivotGrid } from 'devextreme-react/pivot-grid';

--- a/concepts/05 UI Components/PivotGrid/090 Export/20 Export to CSV.md
+++ b/concepts/05 UI Components/PivotGrid/090 Export/20 Export to CSV.md
@@ -70,7 +70,7 @@ You can also export PivotGrid to CSV. To do this, call the **exportPivotGrid(opt
     </template>
 
     <script setup lang="ts">
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxPivotGrid, DxPivotGridTypes } from 'devextreme-vue/pivot-grid';
     import { Workbook } from 'devextreme-exceljs-fork';
     import { saveAs } from 'file-saver-es';
@@ -94,7 +94,7 @@ You can also export PivotGrid to CSV. To do this, call the **exportPivotGrid(opt
 
     <!-- tab: App.tsx -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import PivotGrid, { PivotGridTypes } from 'devextreme-react/pivot-grid';
     import { Workbook } from 'devextreme-exceljs-fork';
     import { saveAs } from 'file-saver-es';

--- a/concepts/05 UI Components/PivotGrid/090 Export/30 Customize Cells.md
+++ b/concepts/05 UI Components/PivotGrid/090 Export/30 Customize Cells.md
@@ -77,7 +77,7 @@ For instance, to [outline (group)](https://support.microsoft.com/en-us/office/ou
     </template>
 
     <script setup lang="ts">
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxPivotGrid, DxPivotGridTypes } from 'devextreme-vue/pivot-grid';
     import { Workbook } from 'devextreme-exceljs-fork';
     import { saveAs } from 'file-saver-es';
@@ -106,7 +106,7 @@ For instance, to [outline (group)](https://support.microsoft.com/en-us/office/ou
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import PivotGrid, { PivotGridTypes } from 'devextreme-react/pivot-grid';
     import { Workbook } from 'devextreme-exceljs-fork';
     import { saveAs } from 'file-saver-es';


### PR DESCRIPTION
Replaced mentions of Generic themes with Fluent:
import `'devextreme/dist/css/dx.light.css';` > import `'devextreme/dist/css/dx.fluent.blue.light.css';`

Included files:
```
api-reference\10 UI Components\dxGantt\**\*.md,
concepts\05 UI Components\Gantt\**\*.md,
api-reference\10 UI Components\dxDiagram\**\*.md,
concepts\05 UI Components\Diagram\**\*.md,
api-reference\10 UI Components\dxFileManager\**\*.md,
concepts\05 UI Components\FileManager\**\*.md,
api-reference\10 UI Components\dxScheduler\**\*.md,
api-reference\10 UI Components\dxPivotGrid\**\*.md,
concepts\05 UI Components\PivotGrid\**\*.md,
concepts\05 UI Components\Pagination\**\*.md, 
```