### PR TITLE
Update Theme Mentions to Fluent - Editors Guides

### DIFF
--- a/concepts/05 UI Components/Calendar/00 Getting Started with Calendar/05 Create a Calendar.md
+++ b/concepts/05 UI Components/Calendar/00 Getting Started with Calendar/05 Create a Calendar.md
@@ -72,7 +72,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxCalendar } from 'devextreme-vue/calendar';
 
     export default {
@@ -89,7 +89,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Calendar } from 'devextreme-react/calendar';
 

--- a/concepts/05 UI Components/Calendar/05 Handle the Value Change Event.md
+++ b/concepts/05 UI Components/Calendar/05 Handle the Value Change Event.md
@@ -53,7 +53,7 @@ To process a new calendar value, you need to handle the value change event. If t
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxCalendar from 'devextreme-vue/calendar';
 
@@ -79,7 +79,7 @@ To process a new calendar value, you need to handle the value change event. If t
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Calendar from 'devextreme-react/calendar';
 

--- a/concepts/05 UI Components/Calendar/10 Specify Zoom Level.md
+++ b/concepts/05 UI Components/Calendar/10 Specify Zoom Level.md
@@ -39,7 +39,7 @@ To specify which calendar view (month, year, decade or century) should be displa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxCalendar from 'devextreme-vue/calendar';
 
@@ -55,7 +55,7 @@ To specify which calendar view (month, year, decade or century) should be displa
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Calendar from 'devextreme-react/calendar';
 
@@ -116,7 +116,7 @@ To make certain calendar views inaccessible, specify the [maxZoomLevel](/api-ref
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxCalendar from 'devextreme-vue/calendar';
 
@@ -132,7 +132,7 @@ To make certain calendar views inaccessible, specify the [maxZoomLevel](/api-ref
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Calendar from 'devextreme-react/calendar';
 

--- a/concepts/05 UI Components/Calendar/12 Specify the Value Range.md
+++ b/concepts/05 UI Components/Calendar/12 Specify the Value Range.md
@@ -49,7 +49,7 @@ Use the [min](/api-reference/10%20UI%20Components/dxCalendar/1%20Configuration/m
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxCalendar from 'devextreme-vue/calendar';
 
@@ -72,7 +72,7 @@ Use the [min](/api-reference/10%20UI%20Components/dxCalendar/1%20Configuration/m
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Calendar from 'devextreme-react/calendar';
 
@@ -150,7 +150,7 @@ If you need to disable specific dates, use the [disabledDates](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxCalendar from 'devextreme-vue/calendar';
 
@@ -178,7 +178,7 @@ If you need to disable specific dates, use the [disabledDates](/api-reference/10
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Calendar from 'devextreme-react/calendar';
 

--- a/concepts/05 UI Components/ColorBox/00 Getting Started with ColorBox/05 Create a ColorBox.md
+++ b/concepts/05 UI Components/ColorBox/00 Getting Started with ColorBox/05 Create a ColorBox.md
@@ -73,7 +73,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxColorBox } from 'devextreme-vue/color-box';
 
     export default {
@@ -90,7 +90,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ColorBox } from 'devextreme-react/color-box';
 

--- a/concepts/05 UI Components/ColorBox/15 Support Alpha Channel.md
+++ b/concepts/05 UI Components/ColorBox/15 Support Alpha Channel.md
@@ -44,7 +44,7 @@ By default, the ColorBox does _not_ allow an end user to control the transparenc
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxColorBox from 'devextreme-vue/color-box';
 
@@ -64,7 +64,7 @@ By default, the ColorBox does _not_ allow an end user to control the transparenc
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import ColorBox from 'devextreme-react/color-box';
 

--- a/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/05 Create the DateBox.md
+++ b/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/05 Create the DateBox.md
@@ -74,7 +74,7 @@ Use the following code to create a basic DateBox:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateBox } from 'devextreme-vue/date-box';
 
@@ -90,7 +90,7 @@ Use the following code to create a basic DateBox:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateBox } from 'devextreme-react/date-box';
 

--- a/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/10 Set the DateBox Type.md
+++ b/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/10 Set the DateBox Type.md
@@ -35,7 +35,7 @@ To allow users to specify the date and time, set the [type](/api-reference/10%20
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateBox } from 'devextreme-react/date-box';
 

--- a/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/13 Set the Accepted Date Range.md
+++ b/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/13 Set the Accepted Date Range.md
@@ -45,7 +45,7 @@ To define the range from which users can select dates, specify the [min](/api-re
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateBox } from 'devextreme-vue/date-box';
 
@@ -67,7 +67,7 @@ To define the range from which users can select dates, specify the [min](/api-re
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateBox } from 'devextreme-react/date-box';
 

--- a/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/15 Set the Value.md
+++ b/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/15 Set the Value.md
@@ -42,7 +42,7 @@ To set the UI component's value, specify the [value](/api-reference/10%20UI%20Co
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateBox } from 'devextreme-vue/date-box';
 
@@ -64,7 +64,7 @@ To set the UI component's value, specify the [value](/api-reference/10%20UI%20Co
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateBox } from 'devextreme-react/date-box';
 

--- a/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/20 Handle the Value Change Event.md
+++ b/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/20 Handle the Value Change Event.md
@@ -47,7 +47,7 @@ To handle value changes, implement the [onValueChanged](/api-reference/10%20UI%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateBox } from 'devextreme-vue/date-box';
 
@@ -67,7 +67,7 @@ To handle value changes, implement the [onValueChanged](/api-reference/10%20UI%2
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateBox } from 'devextreme-react/date-box';
 

--- a/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/25 Disable Specific Dates.md
+++ b/concepts/05 UI Components/DateBox/00 Getting Started with DateBox/25 Disable Specific Dates.md
@@ -125,7 +125,7 @@ To prevent users from setting specific dates, use the [disabledDates](/api-refer
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateBox } from 'devextreme-vue/date-box';
     
@@ -173,7 +173,7 @@ To prevent users from setting specific dates, use the [disabledDates](/api-refer
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateBox } from 'devextreme-react/date-box';
 

--- a/concepts/05 UI Components/DateBox/03 Platform-Specific Value Pickers.md
+++ b/concepts/05 UI Components/DateBox/03 Platform-Specific Value Pickers.md
@@ -69,7 +69,7 @@ For the List picker, you can specify the step of available time values in minute
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDateBox from 'devextreme-vue/date-box';
 
@@ -89,7 +89,7 @@ For the List picker, you can specify the step of available time values in minute
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DateBox from 'devextreme-react/date-box';
 

--- a/concepts/05 UI Components/DateBox/04 Value Formatting and Masked Input.md
+++ b/concepts/05 UI Components/DateBox/04 Value Formatting and Masked Input.md
@@ -52,7 +52,7 @@ In addition to value formatting, the **displayFormat** can be used as a mask to 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDateBox from 'devextreme-vue/date-box';
 
@@ -67,7 +67,7 @@ In addition to value formatting, the **displayFormat** can be used as a mask to 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DateBox from 'devextreme-react/date-box';
 

--- a/concepts/05 UI Components/DateBox/05 Control the Behavior.md
+++ b/concepts/05 UI Components/DateBox/05 Control the Behavior.md
@@ -49,7 +49,7 @@ The DateBox UI component allows an end user to pick or type a value. To specify 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDateBox from 'devextreme-vue/date-box';
 
@@ -69,7 +69,7 @@ The DateBox UI component allows an end user to pick or type a value. To specify 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DateBox from 'devextreme-react/date-box';
 

--- a/concepts/05 UI Components/DateRangeBox/00 Getting Started with DateRangeBox/05 Create the DateRangeBox.md
+++ b/concepts/05 UI Components/DateRangeBox/00 Getting Started with DateRangeBox/05 Create the DateRangeBox.md
@@ -73,7 +73,7 @@ Use the following code to create a basic DateRangeBox:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
 
@@ -92,7 +92,7 @@ Use the following code to create a basic DateRangeBox:
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
     // ...
@@ -103,7 +103,7 @@ Use the following code to create a basic DateRangeBox:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateRangeBox } from 'devextreme-react/date-range-box';
 

--- a/concepts/05 UI Components/DateRangeBox/00 Getting Started with DateRangeBox/10 Set the Accepted Date Range.md
+++ b/concepts/05 UI Components/DateRangeBox/00 Getting Started with DateRangeBox/10 Set the Accepted Date Range.md
@@ -49,7 +49,7 @@ You can define constraints for date ranges that can be selected by end users. Sp
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
 
@@ -77,7 +77,7 @@ You can define constraints for date ranges that can be selected by end users. Sp
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
 
@@ -91,7 +91,7 @@ You can define constraints for date ranges that can be selected by end users. Sp
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateRangeBox } from 'devextreme-react/date-range-box';
 

--- a/concepts/05 UI Components/DateRangeBox/00 Getting Started with DateRangeBox/15 Set the Initial Date Range Values.md
+++ b/concepts/05 UI Components/DateRangeBox/00 Getting Started with DateRangeBox/15 Set the Initial Date Range Values.md
@@ -45,7 +45,7 @@ To specify a date range selected at startup, use the [startDate](/api-reference/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
 
@@ -71,7 +71,7 @@ To specify a date range selected at startup, use the [startDate](/api-reference/
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
 
@@ -84,7 +84,7 @@ To specify a date range selected at startup, use the [startDate](/api-reference/
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateRangeBox } from 'devextreme-react/date-range-box';
 

--- a/concepts/05 UI Components/DateRangeBox/00 Getting Started with DateRangeBox/20 Add Labels.md
+++ b/concepts/05 UI Components/DateRangeBox/00 Getting Started with DateRangeBox/20 Add Labels.md
@@ -43,7 +43,7 @@ If you want to define start date and end date labels, use [startDateLabel](/api-
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
 
@@ -64,7 +64,7 @@ If you want to define start date and end date labels, use [startDateLabel](/api-
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
     // ...
@@ -75,7 +75,7 @@ If you want to define start date and end date labels, use [startDateLabel](/api-
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateRangeBox } from 'devextreme-react/date-range-box';
  

--- a/concepts/05 UI Components/DateRangeBox/00 Getting Started with DateRangeBox/25 Handle the Value Change Event.md
+++ b/concepts/05 UI Components/DateRangeBox/00 Getting Started with DateRangeBox/25 Handle the Value Change Event.md
@@ -47,7 +47,7 @@ To respond to a date range change, handle the [onValueChanged](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
 
@@ -70,7 +70,7 @@ To respond to a date range change, handle the [onValueChanged](/api-reference/10
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
 
@@ -85,7 +85,7 @@ To respond to a date range change, handle the [onValueChanged](/api-reference/10
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateRangeBox } from 'devextreme-react/date-range-box';
 

--- a/concepts/05 UI Components/DateRangeBox/05 Control the Behavior.md
+++ b/concepts/05 UI Components/DateRangeBox/05 Control the Behavior.md
@@ -43,7 +43,7 @@ The DateRangeBox UI component allows users to type dates or pick them from a dro
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDateRangeBox from 'devextreme-vue/date-range-box';
 
@@ -63,7 +63,7 @@ The DateRangeBox UI component allows users to type dates or pick them from a dro
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDateRangeBox from 'devextreme-vue/date-range-box';
     // ...
@@ -74,7 +74,7 @@ The DateRangeBox UI component allows users to type dates or pick them from a dro
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DateRangeBox from 'devextreme-react/date-range-box';
 

--- a/concepts/05 UI Components/DateRangeBox/10 Value Formatting and Masked Input.md
+++ b/concepts/05 UI Components/DateRangeBox/10 Value Formatting and Masked Input.md
@@ -49,7 +49,7 @@ If [useMaskBehavior](/api-reference/10%20UI%20Components/DateBoxBase/1%20Configu
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDateRangeBox from 'devextreme-vue/date-range-box';
 
@@ -70,7 +70,7 @@ If [useMaskBehavior](/api-reference/10%20UI%20Components/DateBoxBase/1%20Configu
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDateRangeBox from 'devextreme-vue/date-range-box';
     // ...
@@ -81,7 +81,7 @@ If [useMaskBehavior](/api-reference/10%20UI%20Components/DateBoxBase/1%20Configu
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DateRangeBox from 'devextreme-react/date-range-box';
 

--- a/concepts/05 UI Components/DropDownBox/00 Getting Started with DropDownBox/05 Create DropDownBox.md
+++ b/concepts/05 UI Components/DropDownBox/00 Getting Started with DropDownBox/05 Create DropDownBox.md
@@ -73,7 +73,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxDropDownBox } from 'devextreme-vue/drop-down-box';
 
     export default {
@@ -90,7 +90,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DropDownBox } from 'devextreme-react/drop-down-box';
 

--- a/concepts/05 UI Components/DropDownBox/00 Getting Started with DropDownBox/10 Add an Embedded Element.md
+++ b/concepts/05 UI Components/DropDownBox/00 Getting Started with DropDownBox/10 Add an Embedded Element.md
@@ -99,7 +99,7 @@ The following code adds the List component, [binds it to data](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxDropDownBox } from 'devextreme-vue/drop-down-box';
     import DxList from "devextreme-vue/list";
 
@@ -133,7 +133,7 @@ The following code adds the List component, [binds it to data](/api-reference/10
     <!-- tab: App.js -->
     import React, { useState, useRef, useCallback } from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DropDownBox } from 'devextreme-react/drop-down-box';
     import { List } from "devextreme-react/list";

--- a/concepts/05 UI Components/DropDownBox/00 Getting Started with DropDownBox/15 Configure Selection.md
+++ b/concepts/05 UI Components/DropDownBox/00 Getting Started with DropDownBox/15 Configure Selection.md
@@ -90,7 +90,7 @@ Refer to the article to learn more.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxDropDownBox } from 'devextreme-vue/drop-down-box';
     import DxList from "devextreme-vue/list";
 
@@ -122,7 +122,7 @@ Refer to the article to learn more.
     <!-- tab: App.js -->
     import React, { useState, useRef, useCallback } from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DropDownBox } from 'devextreme-react/drop-down-box';
     import { List } from "devextreme-react/list";

--- a/concepts/05 UI Components/DropDownBox/00 Getting Started with DropDownBox/20 Handle Events.md
+++ b/concepts/05 UI Components/DropDownBox/00 Getting Started with DropDownBox/20 Handle Events.md
@@ -64,7 +64,7 @@ You can allow users to type in the DropDownBox text field to add more values to 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxDropDownBox } from 'devextreme-vue/drop-down-box';
     import DxList from "devextreme-vue/list";
 
@@ -92,7 +92,7 @@ You can allow users to type in the DropDownBox text field to add more values to 
     <!-- tab: App.js -->
     import React, { useState, useRef, useCallback } from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DropDownBox } from 'devextreme-react/drop-down-box';
     import { List } from "devextreme-react/list";

--- a/concepts/05 UI Components/DropDownBox/00 Getting Started with DropDownBox/25 Customize Appearance.md
+++ b/concepts/05 UI Components/DropDownBox/00 Getting Started with DropDownBox/25 Customize Appearance.md
@@ -74,7 +74,7 @@ Use the [buttons](/api-reference/10%20UI%20Components/dxDropDownEditor/1%20Confi
     <!-- tab: App.js -->
     import React, { useState, useRef, useCallback } from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DropDownBox } from 'devextreme-react/drop-down-box';
     import { List } from "devextreme-react/list";

--- a/concepts/05 UI Components/DropDownBox/05 Accessibility/15 Keyboard Navigation.md
+++ b/concepts/05 UI Components/DropDownBox/05 Accessibility/15 Keyboard Navigation.md
@@ -59,7 +59,7 @@ Use the [registerKeyHandler(key, handler)](/api-reference/10%20UI%20Components/W
         <DxDropDownBox :ref="myDropDownBoxRef" />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDropDownBox from 'devextreme-vue/{widget-name}';
 
@@ -94,7 +94,7 @@ Use the [registerKeyHandler(key, handler)](/api-reference/10%20UI%20Components/W
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DropDownBox } from 'devextreme-react/{widget-name}';
 

--- a/concepts/05 UI Components/DropDownBox/15 Synchronize with the Embedded Element.md
+++ b/concepts/05 UI Components/DropDownBox/15 Synchronize with the Embedded Element.md
@@ -96,7 +96,7 @@ Assign the field's name to the DropDownBox's [valueExpr](/api-reference/10%20UI%
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDropDownBox from "devextreme-vue/drop-down-box";
         import DxDataGrid, DxSelection from "devextreme-vue/data-grid";
@@ -123,7 +123,7 @@ Assign the field's name to the DropDownBox's [valueExpr](/api-reference/10%20UI%
     ##### React
 
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { DropDownBox } from 'devextreme-react/drop-down-box';
         import { DataGrid, Selection } from "devextreme-react/data-grid";
@@ -262,7 +262,7 @@ This step's implementation depends on the embedded UI component's API and the li
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDropDownBox from "devextreme-vue/drop-down-box";
         import { DxDataGrid, DxSelection } from "devextreme-vue/data-grid";
@@ -297,7 +297,7 @@ This step's implementation depends on the embedded UI component's API and the li
     ##### React
 
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { DropDownBox } from 'devextreme-react/drop-down-box';
         import { DataGrid, Selection } from "devextreme-react/data-grid";

--- a/concepts/05 UI Components/FileUploader/10 Getting Started with FileUploader/05 Create and Configure FileUploader.md
+++ b/concepts/05 UI Components/FileUploader/10 Getting Started with FileUploader/05 Create and Configure FileUploader.md
@@ -57,7 +57,7 @@
     <script setup lang="ts">
     import { reactive } from 'vue';
     import { DxFileUploader } from 'devextreme-vue/file-uploader';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     </script>
     <template>
         <DxFileUploader />
@@ -70,7 +70,7 @@
     <!-- tab: App.tsx -->
     import React, { JSX } from 'react';
     import { FileUploader } from 'devextreme-react/file-uploader';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     export default function App(): JSX.Element {
         return (

--- a/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/05 Upload Mode.md
+++ b/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/05 Upload Mode.md
@@ -83,7 +83,7 @@ The following examples show how to configure the FileUploader for each upload mo
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';     
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';     
 
         import { 
             DxFileUploader
@@ -106,7 +106,7 @@ The following examples show how to configure the FileUploader for each upload mo
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import FileUploader from 'devextreme-react/file-uploader';
         
@@ -226,7 +226,7 @@ The following examples show how to configure the FileUploader for each upload mo
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';     
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';     
 
         import { 
             DxFileUploader
@@ -249,7 +249,7 @@ The following examples show how to configure the FileUploader for each upload mo
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import FileUploader from 'devextreme-react/file-uploader';
         

--- a/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/07 Chunk Upload.md
+++ b/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/07 Chunk Upload.md
@@ -72,7 +72,7 @@ Chunk upload allows large files to be divided into parts called "chunks" and sen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';     
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';     
 
     import { 
         DxFileUploader
@@ -96,7 +96,7 @@ Chunk upload allows large files to be divided into parts called "chunks" and sen
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileUploader from 'devextreme-react/file-uploader';
     

--- a/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/10 Additional Parameters in a Request.md
+++ b/concepts/05 UI Components/FileUploader/20 Upload Files/05 Client-Side Settings/10 Additional Parameters in a Request.md
@@ -123,7 +123,7 @@ If the [uploadMode](/api-reference/10%20UI%20Components/dxFileUploader/1%20Confi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';     
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';     
 
     import { 
         DxFileUploader
@@ -173,7 +173,7 @@ If the [uploadMode](/api-reference/10%20UI%20Components/dxFileUploader/1%20Confi
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileUploader from 'devextreme-react/file-uploader';
     import NumberBox from 'devextreme-react/number-box';
@@ -370,7 +370,7 @@ When the **uploadMode** is *"useForm"*, define the parameters within hidden inpu
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';     
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';     
 
     import DxFileUploader from 'devextreme-vue/file-uploader';
     import DxNumberBox from 'devextreme-vue/number-box';
@@ -408,7 +408,7 @@ When the **uploadMode** is *"useForm"*, define the parameters within hidden inpu
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileUploader from 'devextreme-react/file-uploader';
     import NumberBox from 'devextreme-react/number-box';

--- a/concepts/05 UI Components/FileUploader/40 File Validation.md
+++ b/concepts/05 UI Components/FileUploader/40 File Validation.md
@@ -46,7 +46,7 @@ The FileUploader allows you to restrict the extension ([allowedFileExtensions](/
         </DxFileUploader>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileManager
@@ -69,7 +69,7 @@ The FileUploader allows you to restrict the extension ([allowedFileExtensions](/
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileUploader from 'devextreme-react/file-uploader';
     

--- a/concepts/05 UI Components/FileUploader/99 How To/10 Specify a Header for the Request.md
+++ b/concepts/05 UI Components/FileUploader/99 How To/10 Specify a Header for the Request.md
@@ -66,7 +66,7 @@ Use the [uploadHeaders](/api-reference/10%20UI%20Components/dxFileUploader/1%20C
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {DxFileUploader} from 'devextreme-vue/file-uploader';
 
@@ -89,7 +89,7 @@ Use the [uploadHeaders](/api-reference/10%20UI%20Components/dxFileUploader/1%20C
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileUploader from 'devextreme-react/file-uploader';
 

--- a/concepts/05 UI Components/FileUploader/99 How To/20 Specify a file's GUID.md
+++ b/concepts/05 UI Components/FileUploader/99 How To/20 Specify a file's GUID.md
@@ -107,7 +107,7 @@ Use the [valueChanged](/api-reference/10%20UI%20Components/dxFileUploader/4%20Ev
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxFileUploader } from "devextreme-vue/file-uploader";
 
@@ -155,7 +155,7 @@ Use the [valueChanged](/api-reference/10%20UI%20Components/dxFileUploader/4%20Ev
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileUploader from "devextreme-react/file-uploader";
 

--- a/concepts/05 UI Components/FileUploader/99 How To/30 Get a file's Guid after uploading in chunks.md
+++ b/concepts/05 UI Components/FileUploader/99 How To/30 Get a file's Guid after uploading in chunks.md
@@ -86,7 +86,7 @@ Follow the steps below to get a file's GUID in 'chunk' [upload mode](/api-refere
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxFileUploader } from "devextreme-vue/file-uploader";
 
@@ -108,7 +108,7 @@ Follow the steps below to get a file's GUID in 'chunk' [upload mode](/api-refere
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileUploader from "devextreme-react/file-uploader";
 

--- a/concepts/05 UI Components/LoadPanel/00 Overview.md
+++ b/concepts/05 UI Components/LoadPanel/00 Overview.md
@@ -68,7 +68,7 @@ The following code adds to your page a simple LoadPanel and a [Button](/api-refe
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLoadPanel } from 'devextreme-vue/load-panel';
     import { DxButton } from 'devextreme-vue/button';
@@ -94,7 +94,7 @@ The following code adds to your page a simple LoadPanel and a [Button](/api-refe
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { LoadPanel } from 'devextreme-react/load-panel';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/LoadPanel/05 Show and Hide Using the API.md
+++ b/concepts/05 UI Components/LoadPanel/05 Show and Hide Using the API.md
@@ -67,7 +67,7 @@ To show or hide the LoadPanel programmatically, bind the [visible](/api-referenc
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLoadPanel } from 'devextreme-vue/load-panel';
     import { DxButton } from 'devextreme-vue/button';
@@ -95,7 +95,7 @@ To show or hide the LoadPanel programmatically, bind the [visible](/api-referenc
 To show or hide the LoadPanel programmatically, bind the [visible](/api-reference/10%20UI%20Components/dxLoadPanel/1%20Configuration/visible.md '/Documentation/ApiReference/UI_Components/dxLoadPanel/Configuration/#visible') property of the LoadPanel UI component to a component property. After that, change this property, and the LoadPanel will appear or disappear.
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { LoadPanel } from 'devextreme-react/load-panel';
     import { Button } from 'devextreme-react/button';
@@ -216,7 +216,7 @@ To execute certain commands before or after the LoadPanel is shown/hidden, handl
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLoadPanel } from 'devextreme-vue/load-panel';
     import { DxButton } from 'devextreme-vue/button';
@@ -247,7 +247,7 @@ To execute certain commands before or after the LoadPanel is shown/hidden, handl
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { LoadPanel } from 'devextreme-react/load-panel';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/LoadPanel/10 Customize the Appearance/20 Change the Text.md
+++ b/concepts/05 UI Components/LoadPanel/10 Customize the Appearance/20 Change the Text.md
@@ -62,7 +62,7 @@ To change the text displayed by the LoadPanel, use the [message](/api-reference/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLoadPanel } from 'devextreme-vue/load-panel';
     import { DxButton } from 'devextreme-vue/button';
@@ -88,7 +88,7 @@ To change the text displayed by the LoadPanel, use the [message](/api-reference/
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { LoadPanel } from 'devextreme-react/load-panel';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/LoadPanel/10 Customize the Appearance/30 Hide the Pane.md
+++ b/concepts/05 UI Components/LoadPanel/10 Customize the Appearance/30 Hide the Pane.md
@@ -66,7 +66,7 @@ The pane is shown by default. To hide it, assign **false** to the [showPane](/ap
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLoadPanel } from 'devextreme-vue/load-panel';
     import { DxButton } from 'devextreme-vue/button';
@@ -92,7 +92,7 @@ The pane is shown by default. To hide it, assign **false** to the [showPane](/ap
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { LoadPanel } from 'devextreme-react/load-panel';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/LoadPanel/10 Customize the Appearance/40 Color the Shading of the Background.md
+++ b/concepts/05 UI Components/LoadPanel/10 Customize the Appearance/40 Color the Shading of the Background.md
@@ -62,7 +62,7 @@ When the LoadPanel is shown, the area beneath it can be shaded. The shading colo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLoadPanel } from 'devextreme-vue/load-panel';
     import { DxButton } from 'devextreme-vue/button';
@@ -88,7 +88,7 @@ When the LoadPanel is shown, the area beneath it can be shaded. The shading colo
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { LoadPanel } from 'devextreme-react/load-panel';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/LoadPanel/15 Resize and Relocate.md
+++ b/concepts/05 UI Components/LoadPanel/15 Resize and Relocate.md
@@ -65,7 +65,7 @@ Specify the **height** and **width** properties to change the LoadPanel's size:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLoadPanel } from 'devextreme-vue/load-panel';
     import { DxButton } from 'devextreme-vue/button';
@@ -91,7 +91,7 @@ Specify the **height** and **width** properties to change the LoadPanel's size:
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { LoadPanel } from 'devextreme-react/load-panel';
     import { Button } from 'devextreme-react/button';
@@ -217,7 +217,7 @@ The [container](/api-reference/10%20UI%20Components/dxLoadPanel/1%20Configuratio
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLoadPanel, DxPosition } from 'devextreme-vue/load-panel';
     import { DxButton } from 'devextreme-vue/button';
@@ -243,7 +243,7 @@ The [container](/api-reference/10%20UI%20Components/dxLoadPanel/1%20Configuratio
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { LoadPanel, Position } from 'devextreme-react/load-panel';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Map/00 Overview.md
+++ b/concepts/05 UI Components/Map/00 Overview.md
@@ -55,7 +55,7 @@ The code below adds the Map UI component to your page. The Map is [centered](/ap
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -74,7 +74,7 @@ The code below adds the Map UI component to your page. The Map is [centered](/ap
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 

--- a/concepts/05 UI Components/Map/05 Zoom and Center the Map.md
+++ b/concepts/05 UI Components/Map/05 Zoom and Center the Map.md
@@ -53,7 +53,7 @@ To zoom the Map, set the [zoom](/api-reference/10%20UI%20Components/dxMap/1%20Co
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -72,7 +72,7 @@ To zoom the Map, set the [zoom](/api-reference/10%20UI%20Components/dxMap/1%20Co
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 
@@ -151,7 +151,7 @@ Note that the UI component can automatically change the **center** and **zoom** 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -174,7 +174,7 @@ Note that the UI component can automatically change the **center** and **zoom** 
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 

--- a/concepts/05 UI Components/Map/10 Specify the Provider and Type.md
+++ b/concepts/05 UI Components/Map/10 Specify the Provider and Type.md
@@ -45,7 +45,7 @@ By default, the Map UI component uses **Google Maps** as a map provider. It can 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -64,7 +64,7 @@ By default, the Map UI component uses **Google Maps** as a map provider. It can 
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 
@@ -145,7 +145,7 @@ When using maps, you should include an API key that authenticates your applicati
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -169,7 +169,7 @@ When using maps, you should include an API key that authenticates your applicati
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 
@@ -249,7 +249,7 @@ The Map UI component supports the following map types: *"hybrid"*, *"satellite"*
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -268,7 +268,7 @@ The Map UI component supports the following map types: *"hybrid"*, *"satellite"*
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 

--- a/concepts/05 UI Components/Map/15 Specify the Size.md
+++ b/concepts/05 UI Components/Map/15 Specify the Size.md
@@ -49,7 +49,7 @@ The default size of the Map UI component is 300x300 pixels. To change it, use to
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -68,7 +68,7 @@ The default size of the Map UI component is 300x300 pixels. To change it, use to
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 
@@ -155,7 +155,7 @@ If you prefer specifying the UI component size using CSS, set the **width** and 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -182,7 +182,7 @@ If you prefer specifying the UI component size using CSS, set the **width** and 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 

--- a/concepts/05 UI Components/Map/20 Configure Markers/05 Add and Remove.md
+++ b/concepts/05 UI Components/Map/20 Configure Markers/05 Add and Remove.md
@@ -51,7 +51,7 @@ To add markers at design-time, pass an array of objects to the [markers](/api-re
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -74,7 +74,7 @@ To add markers at design-time, pass an array of objects to the [markers](/api-re
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 
@@ -219,7 +219,7 @@ To add or remove a marker at runtime, bind the **markers** property of the Map t
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
     import { DxButton } from 'devextreme-vue/button';
@@ -253,7 +253,7 @@ To add or remove a marker at runtime, bind the **markers** property of the Map t
 To add or remove a marker at runtime, bind the **markers** property of the Map to a state property:
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Map/20 Configure Markers/10 Customize.md
+++ b/concepts/05 UI Components/Map/20 Configure Markers/10 Customize.md
@@ -55,7 +55,7 @@ The Map UI component allows you to provide a single icon for all markers. For th
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -79,7 +79,7 @@ The Map UI component allows you to provide a single icon for all markers. For th
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 
@@ -177,7 +177,7 @@ Apart from the icon, you can specify a [tooltip](/api-reference/10%20UI%20Compon
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
     import notify from 'devextreme/ui/notify';
@@ -209,7 +209,7 @@ Apart from the icon, you can specify a [tooltip](/api-reference/10%20UI%20Compon
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
     import notify from 'devextreme/ui/notify';

--- a/concepts/05 UI Components/Map/20 Configure Markers/15 Handle the Related Events.md
+++ b/concepts/05 UI Components/Map/20 Configure Markers/15 Handle the Related Events.md
@@ -67,7 +67,7 @@ To handle them, assign functions to the [onMarkerAdded](/api-reference/10%20UI%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -98,7 +98,7 @@ To handle them, assign functions to the [onMarkerAdded](/api-reference/10%20UI%2
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 

--- a/concepts/05 UI Components/Map/25 Configure Routes/05 Add and Remove.md
+++ b/concepts/05 UI Components/Map/25 Configure Routes/05 Add and Remove.md
@@ -57,7 +57,7 @@ To add routes at design-time, pass an array of objects to the [routes](/api-refe
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -83,7 +83,7 @@ To add routes at design-time, pass an array of objects to the [routes](/api-refe
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 
@@ -223,7 +223,7 @@ To add or remove a route at runtime, bind the **routes** property of the Map to 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
     import { DxButton } from 'devextreme-vue/button';
@@ -266,7 +266,7 @@ To add or remove a route at runtime, bind the **routes** property of the Map to 
 To add or remove a route at runtime, bind the **routes** property of the Map to a state property.
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Map/25 Configure Routes/10 Customize.md
+++ b/concepts/05 UI Components/Map/25 Configure Routes/10 Customize.md
@@ -74,7 +74,7 @@ The [route configuration](/api-reference/10%20UI%20Components/dxMap/1%20Configur
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -108,7 +108,7 @@ The [route configuration](/api-reference/10%20UI%20Components/dxMap/1%20Configur
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 

--- a/concepts/05 UI Components/Map/25 Configure Routes/15 Handle the Related Events.md
+++ b/concepts/05 UI Components/Map/25 Configure Routes/15 Handle the Related Events.md
@@ -67,7 +67,7 @@ To handle them, assign functions to the [onRouteAdded](/api-reference/10%20UI%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxMap } from 'devextreme-vue/map';
 
@@ -98,7 +98,7 @@ To handle them, assign functions to the [onRouteAdded](/api-reference/10%20UI%20
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Map } from 'devextreme-react/map';
 

--- a/concepts/05 UI Components/NumberBox/15 Control the Behavior.md
+++ b/concepts/05 UI Components/NumberBox/15 Control the Behavior.md
@@ -44,7 +44,7 @@ If you need to add spin buttons to the NumberBox, set the [showSpinButtons](/api
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxNumberBox from 'devextreme-vue/number-box';
 
@@ -60,7 +60,7 @@ If you need to add spin buttons to the NumberBox, set the [showSpinButtons](/api
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import NumberBox from 'devextreme-react/number-box';
 
@@ -126,7 +126,7 @@ To specify the step by which the value is changed, use the [step](/api-reference
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxNumberBox from 'devextreme-vue/number-box';
 
@@ -142,7 +142,7 @@ To specify the step by which the value is changed, use the [step](/api-reference
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import NumberBox from 'devextreme-react/number-box';
 

--- a/concepts/05 UI Components/Popover/00 Overview.md
+++ b/concepts/05 UI Components/Popover/00 Overview.md
@@ -66,7 +66,7 @@ The following code creates a simple Popover on your page and attaches it to anot
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopover } from 'devextreme-vue/popover';
 
@@ -80,7 +80,7 @@ The following code creates a simple Popover on your page and attaches it to anot
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popover } from 'devextreme-react/popover';
 

--- a/concepts/05 UI Components/Popover/05 Customize the Appearance/05 Customize the Content/1 Specifying the Content Template.md
+++ b/concepts/05 UI Components/Popover/05 Customize the Appearance/05 Customize the Content/1 Specifying the Content Template.md
@@ -72,7 +72,7 @@ The following code shows how to create a template consisting of static (text) an
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopover } from 'devextreme-vue/popover';
     import { DxSwitch } from 'devextreme-vue/switch';
@@ -88,7 +88,7 @@ The following code shows how to create a template consisting of static (text) an
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popover } from 'devextreme-react/popover';
     import { Switch } from 'devextreme-react/switch';

--- a/concepts/05 UI Components/Popover/05 Customize the Appearance/05 Customize the Content/5 Switching Templates On the Fly.md
+++ b/concepts/05 UI Components/Popover/05 Customize the Appearance/05 Customize the Content/5 Switching Templates On the Fly.md
@@ -108,7 +108,7 @@ If you need to render different templates depending on a specific condition, def
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopover } from 'devextreme-vue/popover';
     import { DxButton } from 'devextreme-vue/button';
@@ -142,7 +142,7 @@ If you need to render different templates depending on a specific condition, def
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { Popover } from 'devextreme-react/popover';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Popover/05 Customize the Appearance/10 Customize the Title.md
+++ b/concepts/05 UI Components/Popover/05 Customize the Appearance/10 Customize the Title.md
@@ -67,7 +67,7 @@ The Popover is displayed without a title by default. To add it, set the [showTit
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopover } from 'devextreme-vue/popover';
 
@@ -81,7 +81,7 @@ The Popover is displayed without a title by default. To add it, set the [showTit
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popover } from 'devextreme-react/popover';
 
@@ -197,7 +197,7 @@ If you need to define the title completely, specify a template for it as shown i
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopover } from 'devextreme-vue/popover';
 
@@ -211,7 +211,7 @@ If you need to define the title completely, specify a template for it as shown i
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popover } from 'devextreme-react/popover';
 

--- a/concepts/05 UI Components/Popover/05 Customize the Appearance/20 Specify Toolbar Items.md
+++ b/concepts/05 UI Components/Popover/05 Customize the Appearance/20 Specify Toolbar Items.md
@@ -100,7 +100,7 @@ The Popover has two toolbars: top and bottom. Items on these toolbars can be pla
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxPopover,
@@ -128,7 +128,7 @@ The Popover has two toolbars: top and bottom. Items on these toolbars can be pla
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popover, ToolbarItem } from 'devextreme-react/popover';
 

--- a/concepts/05 UI Components/Popover/05 Customize the Appearance/30 Color the Shading of the Background.md
+++ b/concepts/05 UI Components/Popover/05 Customize the Appearance/30 Color the Shading of the Background.md
@@ -66,7 +66,7 @@ When the Popover is shown, the area beneath it can be shaded. To enable this beh
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopover } from 'devextreme-vue/popover';
 
@@ -80,7 +80,7 @@ When the Popover is shown, the area beneath it can be shaded. To enable this beh
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popover } from 'devextreme-react/popover';
 

--- a/concepts/05 UI Components/Popover/10 Show and Hide the Popover/01 User Interaction.md
+++ b/concepts/05 UI Components/Popover/10 Show and Hide the Popover/01 User Interaction.md
@@ -60,7 +60,7 @@ To specify when the Popover should be shown and hidden, set the [showEvent](/api
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopover } from 'devextreme-vue/popover';
 
@@ -74,7 +74,7 @@ To specify when the Popover should be shown and hidden, set the [showEvent](/api
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popover } from 'devextreme-react/popover';
 
@@ -186,7 +186,7 @@ The Popover can also be hidden when a user clicks outside it. To control this be
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopover } from 'devextreme-vue/popover';
 
@@ -200,7 +200,7 @@ The Popover can also be hidden when a user clicks outside it. To control this be
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popover } from 'devextreme-react/popover';
 

--- a/concepts/05 UI Components/Popover/10 Show and Hide the Popover/05 API.md
+++ b/concepts/05 UI Components/Popover/10 Show and Hide the Popover/05 API.md
@@ -169,7 +169,7 @@ To show or hide the Popover programmatically, bind the [visible](/api-reference/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopover } from 'devextreme-vue/popover';
     import { DxButton } from 'devextreme-vue/button';
@@ -201,7 +201,7 @@ To show or hide the Popover programmatically, bind the [visible](/api-reference/
 To show or hide the Popover programmatically, bind the [visible](/api-reference/10%20UI%20Components/dxPopup/1%20Configuration/visible.md '/Documentation/ApiReference/UI_Components/dxPopover/Configuration/#visible') property of Popover to a state property. After that, change the latter property, and the Popover will appear or disappear.
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popover } from 'devextreme-react/popover';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Popover/10 Show and Hide the Popover/10 Events.md
+++ b/concepts/05 UI Components/Popover/10 Show and Hide the Popover/10 Events.md
@@ -68,7 +68,7 @@ To execute certain commands before or after the Popover was shown/hidden, handle
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopover } from 'devextreme-vue/popover';
 
@@ -96,7 +96,7 @@ To execute certain commands before or after the Popover was shown/hidden, handle
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popover } from 'devextreme-react/popover';
 

--- a/concepts/05 UI Components/Popover/15 Resize and Relocate.md
+++ b/concepts/05 UI Components/Popover/15 Resize and Relocate.md
@@ -66,7 +66,7 @@ To change the size of the Popover, specify the [height](/api-reference/10%20UI%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopover } from 'devextreme-vue/popover';
 
@@ -80,7 +80,7 @@ To change the size of the Popover, specify the [height](/api-reference/10%20UI%2
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popover } from 'devextreme-react/popover';
 
@@ -188,7 +188,7 @@ If you need to position the Popover against a certain side of the [target elemen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopover } from 'devextreme-vue/popover';
 
@@ -202,7 +202,7 @@ If you need to position the Popover against a certain side of the [target elemen
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popover } from 'devextreme-react/popover';
 

--- a/concepts/05 UI Components/Popup/00 Getting Started with Popup/02 Create a Popup.md
+++ b/concepts/05 UI Components/Popup/00 Getting Started with Popup/02 Create a Popup.md
@@ -89,7 +89,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopup } from 'devextreme-vue/popup';
 
@@ -106,7 +106,7 @@
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Popup

--- a/concepts/05 UI Components/Popup/00 Getting Started with Popup/03 Add Content to the Popup.md
+++ b/concepts/05 UI Components/Popup/00 Getting Started with Popup/03 Add Content to the Popup.md
@@ -91,7 +91,7 @@ You can define content in the Popup's markup or use the [contentTemplate](/api-r
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Popup

--- a/concepts/05 UI Components/Popup/05 Customize the Appearance/05 Customize the Content/1 Specifying the Content Template.md
+++ b/concepts/05 UI Components/Popup/05 Customize the Appearance/05 Customize the Content/1 Specifying the Content Template.md
@@ -73,7 +73,7 @@ The example below shows how to create a template consisting of static (text) and
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopup } from 'devextreme-vue/popup';
     import { DxButton } from 'devextreme-vue/button';
@@ -98,7 +98,7 @@ The example below shows how to create a template consisting of static (text) and
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popup } from 'devextreme-react/popup';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Popup/05 Customize the Appearance/05 Customize the Content/5 Switching Templates On the Fly.md
+++ b/concepts/05 UI Components/Popup/05 Customize the Appearance/05 Customize the Content/5 Switching Templates On the Fly.md
@@ -95,7 +95,7 @@ If you need to render different templates depending on a specific condition, def
 
     <script>
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopup } from 'devextreme-vue/popup';
     import { DxButton } from 'devextreme-vue/button';
@@ -123,7 +123,7 @@ If you need to render different templates depending on a specific condition, def
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { Popup } from 'devextreme-react/popup';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Popup/05 Customize the Appearance/10 Customize the Title.md
+++ b/concepts/05 UI Components/Popup/05 Customize the Appearance/10 Customize the Title.md
@@ -42,7 +42,7 @@ By default, the Popup allocates a part of its area to the title, regardless of w
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopup } from 'devextreme-vue/popup';
 
@@ -61,7 +61,7 @@ By default, the Popup allocates a part of its area to the title, regardless of w
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popup } from 'devextreme-react/popup';
 
@@ -161,7 +161,7 @@ If you need to define the title completely, specify a template for it as shown i
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopup } from 'devextreme-vue/popup';
 
@@ -180,7 +180,7 @@ If you need to define the title completely, specify a template for it as shown i
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popup } from 'devextreme-react/popup';
 

--- a/concepts/05 UI Components/Popup/05 Customize the Appearance/20 Specify Toolbar Items.md
+++ b/concepts/05 UI Components/Popup/05 Customize the Appearance/20 Specify Toolbar Items.md
@@ -89,7 +89,7 @@ The Popup has two toolbars: top and bottom. Items on these toolbars can be plain
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxPopup,
@@ -118,7 +118,7 @@ The Popup has two toolbars: top and bottom. Items on these toolbars can be plain
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popup, ToolbarItem } from 'devextreme-react/popup';
 

--- a/concepts/05 UI Components/Popup/05 Customize the Appearance/30 Color the Shading of the Background.md
+++ b/concepts/05 UI Components/Popup/05 Customize the Appearance/30 Color the Shading of the Background.md
@@ -56,7 +56,7 @@ When the Popup is shown, the area beneath it can be shaded. To enable this behav
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopup } from 'devextreme-vue/popup';
 
@@ -75,7 +75,7 @@ When the Popup is shown, the area beneath it can be shaded. To enable this behav
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popup } from 'devextreme-react/popup';
 

--- a/concepts/05 UI Components/Popup/10 Show and Hide the Popup/01 API.md
+++ b/concepts/05 UI Components/Popup/10 Show and Hide the Popup/01 API.md
@@ -159,7 +159,7 @@ To show or hide the Popup programmatically, bind the [visible](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopup } from 'devextreme-vue/popup';
     import { DxButton } from 'devextreme-vue/button';
@@ -191,7 +191,7 @@ To show or hide the Popup programmatically, bind the [visible](/api-reference/10
 To show or hide the Popup programmatically, bind the [visible](/api-reference/10%20UI%20Components/dxPopup/1%20Configuration/visible.md '/Documentation/ApiReference/UI_Components/dxPopup/Configuration/#visible') property of Popup to a state property. After that, change the latter property, and the Popup will appear or disappear.
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popup } from 'devextreme-react/popup';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Popup/10 Show and Hide the Popup/05 User Interaction.md
+++ b/concepts/05 UI Components/Popup/10 Show and Hide the Popup/05 User Interaction.md
@@ -29,7 +29,7 @@ Enable the [showCloseButton](/api-reference/10%20UI%20Components/dxPopup/1%20Con
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopup } from 'devextreme-vue/popup';
 
@@ -43,7 +43,7 @@ Enable the [showCloseButton](/api-reference/10%20UI%20Components/dxPopup/1%20Con
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popup } from 'devextreme-react/popup';
 
@@ -108,7 +108,7 @@ The Popup can also be hidden when a user clicks outside of it. To control this P
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopup } from 'devextreme-vue/popup';
 
@@ -127,7 +127,7 @@ The Popup can also be hidden when a user clicks outside of it. To control this P
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popup } from 'devextreme-react/popup';
 

--- a/concepts/05 UI Components/Popup/10 Show and Hide the Popup/10 Events.md
+++ b/concepts/05 UI Components/Popup/10 Show and Hide the Popup/10 Events.md
@@ -68,7 +68,7 @@ To execute certain commands before or after the Popup was shown/hidden, handle t
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPopup } from 'devextreme-vue/popup';
 
@@ -96,7 +96,7 @@ To execute certain commands before or after the Popup was shown/hidden, handle t
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Popup } from 'devextreme-react/popup';
 

--- a/concepts/05 UI Components/ProgressBar/00 Overview.md
+++ b/concepts/05 UI Components/ProgressBar/00 Overview.md
@@ -55,7 +55,7 @@ The following code adds a simple ProgressBar to your page. The **value** propert
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxProgressBar } from 'devextreme-vue/progress-bar';
 
@@ -69,7 +69,7 @@ The following code adds a simple ProgressBar to your page. The **value** propert
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ProgressBar } from 'devextreme-react/progress-bar';
 
@@ -149,7 +149,7 @@ When the ProgressBar reaches the [maximum](/api-reference/10%20UI%20Components/d
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxProgressBar } from 'devextreme-vue/progress-bar';
     import { alert } from "devextreme/ui/dialog";
@@ -169,7 +169,7 @@ When the ProgressBar reaches the [maximum](/api-reference/10%20UI%20Components/d
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ProgressBar } from 'devextreme-react/progress-bar';
     import { alert } from "devextreme/ui/dialog";

--- a/concepts/05 UI Components/ProgressBar/05 Progress Status.md
+++ b/concepts/05 UI Components/ProgressBar/05 Progress Status.md
@@ -56,7 +56,7 @@ The progress status displays a numeric value indicating the made progress. Wheth
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxProgressBar } from 'devextreme-vue/progress-bar';
 
@@ -75,7 +75,7 @@ The progress status displays a numeric value indicating the made progress. Wheth
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ProgressBar } from 'devextreme-react/progress-bar';
 

--- a/concepts/05 UI Components/ProgressBar/10 Handle the Value Change Event.md
+++ b/concepts/05 UI Components/ProgressBar/10 Handle the Value Change Event.md
@@ -53,7 +53,7 @@ To process a new ProgressBar value, you need to handle the value change event. I
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxProgressBar } from 'devextreme-vue/progress-bar';
 
@@ -80,7 +80,7 @@ To process a new ProgressBar value, you need to handle the value change event. I
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ProgressBar } from 'devextreme-react/progress-bar';
 

--- a/concepts/05 UI Components/RadioGroup/00 Overview.md
+++ b/concepts/05 UI Components/RadioGroup/00 Overview.md
@@ -52,7 +52,7 @@ The following code adds a simple RadioGroup to your page. Here, the [value](/api
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxRadioGroup } from 'devextreme-vue/radio-group';
 
@@ -71,7 +71,7 @@ The following code adds a simple RadioGroup to your page. Here, the [value](/api
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { RadioGroup } from 'devextreme-react/radio-group';
 
@@ -154,7 +154,7 @@ If your data is an array of objects, bind it to the RadioGroup using the [displa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxRadioGroup } from 'devextreme-vue/radio-group';
 
@@ -181,7 +181,7 @@ If your data is an array of objects, bind it to the RadioGroup using the [displa
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { RadioGroup } from 'devextreme-react/radio-group';
 
@@ -261,7 +261,7 @@ The RadioGroup UI component supports horizontal (default for tablets) and vertic
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxRadioGroup } from 'devextreme-vue/radio-group';
 
@@ -280,7 +280,7 @@ The RadioGroup UI component supports horizontal (default for tablets) and vertic
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { RadioGroup } from 'devextreme-react/radio-group';
 

--- a/concepts/05 UI Components/RadioGroup/05 Handle the Value Change Event.md
+++ b/concepts/05 UI Components/RadioGroup/05 Handle the Value Change Event.md
@@ -56,7 +56,7 @@ To process a new RadioGroup value, you need to handle the value change event. If
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxRadioGroup } from 'devextreme-vue/radio-group';
 
@@ -85,7 +85,7 @@ To process a new RadioGroup value, you need to handle the value change event. If
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { RadioGroup } from 'devextreme-react/radio-group';
 

--- a/concepts/05 UI Components/RadioGroup/10 Customize Item Appearance.md
+++ b/concepts/05 UI Components/RadioGroup/10 Customize Item Appearance.md
@@ -46,7 +46,7 @@ For a minor customization of RadioGroup items, you can define [specific fields](
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxRadioGroup } from 'devextreme-vue/radio-group';
 
@@ -69,7 +69,7 @@ For a minor customization of RadioGroup items, you can define [specific fields](
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { RadioGroup } from 'devextreme-react/radio-group';
 
@@ -154,7 +154,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxRadioGroup } from 'devextreme-vue/radio-group';
 
@@ -173,7 +173,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { RadioGroup } from 'devextreme-react/radio-group';
 

--- a/concepts/05 UI Components/SelectBox/07 Grouping/01 In the Data Source.md
+++ b/concepts/05 UI Components/SelectBox/07 Grouping/01 In the Data Source.md
@@ -79,7 +79,7 @@ Items in the SelectBox can be grouped if they are grouped in the data source. Th
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSelectBox } from 'devextreme-vue/select-box';
 
@@ -114,7 +114,7 @@ Items in the SelectBox can be grouped if they are grouped in the data source. Th
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import SelectBox from 'devextreme-react/select-box';
 
@@ -252,7 +252,7 @@ If objects in your data source miss the **key** and **items** fields, use the [m
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSelectBox } from 'devextreme-vue/select-box';
     import DataSource from "devextreme/data/data_source";
@@ -298,7 +298,7 @@ If objects in your data source miss the **key** and **items** fields, use the [m
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import SelectBox from 'devextreme-react/select-box';
     import DataSource from "devextreme/data/data_source";
@@ -421,7 +421,7 @@ If your data is not grouped, you can group it using the [group](/api-reference/3
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSelectBox } from 'devextreme-vue/select-box';
     import DataSource from "devextreme/data/data_source";
@@ -455,7 +455,7 @@ If your data is not grouped, you can group it using the [group](/api-reference/3
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import SelectBox from 'devextreme-react/select-box';
     import DataSource from "devextreme/data/data_source";

--- a/concepts/05 UI Components/SelectBox/07 Grouping/05 Customize Group Headers.md
+++ b/concepts/05 UI Components/SelectBox/07 Grouping/05 Customize Group Headers.md
@@ -103,7 +103,7 @@ By default, group headers display text of the **key** field in a bold font. If y
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSelectBox } from 'devextreme-vue/select-box';
     import DataSource from "devextreme/data/data_source";
@@ -150,7 +150,7 @@ By default, group headers display text of the **key** field in a bold font. If y
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import SelectBox from 'devextreme-react/select-box';
     import DataSource from "devextreme/data/data_source";

--- a/concepts/05 UI Components/SelectBox/09 Enable Paging.md
+++ b/concepts/05 UI Components/SelectBox/09 Enable Paging.md
@@ -54,7 +54,7 @@ Paging properties are set in the [DataSource](/api-reference/30%20Data%20Layer/D
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSelectBox } from 'devextreme-vue/select-box';
     import DataSource from "devextreme/data/data_source";
@@ -80,7 +80,7 @@ Paging properties are set in the [DataSource](/api-reference/30%20Data%20Layer/D
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import SelectBox from 'devextreme-react/select-box';
     import DataSource from "devextreme/data/data_source";

--- a/concepts/05 UI Components/SelectBox/10 Configure Search Parameters.md
+++ b/concepts/05 UI Components/SelectBox/10 Configure Search Parameters.md
@@ -65,7 +65,7 @@ The SelectBox UI component allows an end user to search through its items. To en
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSelectBox } from 'devextreme-vue/select-box';
 
@@ -90,7 +90,7 @@ The SelectBox UI component allows an end user to search through its items. To en
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import SelectBox from 'devextreme-react/select-box';
 
@@ -189,7 +189,7 @@ When a user types a string in the input field, the SelectBox suggests all items 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSelectBox } from 'devextreme-vue/select-box';
 
@@ -214,7 +214,7 @@ When a user types a string in the input field, the SelectBox suggests all items 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import SelectBox from 'devextreme-react/select-box';
 
@@ -310,7 +310,7 @@ There is a delay between the moment a user finishes typing and the moment the se
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSelectBox } from 'devextreme-vue/select-box';
 
@@ -335,7 +335,7 @@ There is a delay between the moment a user finishes typing and the moment the se
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import SelectBox from 'devextreme-react/select-box';
 
@@ -429,7 +429,7 @@ The SelectBox UI component starts searching after a user types at least one char
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSelectBox } from 'devextreme-vue/select-box';
 
@@ -453,7 +453,7 @@ The SelectBox UI component starts searching after a user types at least one char
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import SelectBox from 'devextreme-react/select-box';
 

--- a/concepts/05 UI Components/SelectBox/15 Create a User-Defined Item.md
+++ b/concepts/05 UI Components/SelectBox/15 Create a User-Defined Item.md
@@ -96,7 +96,7 @@ Note that you should implement the [onCustomItemCreating](/api-reference/10%20UI
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSelectBox } from 'devextreme-vue/select-box';
     import DataSource from "devextreme/data/data_source";
@@ -139,7 +139,7 @@ Note that you should implement the [onCustomItemCreating](/api-reference/10%20UI
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import SelectBox from 'devextreme-react/select-box';
     import DataSource from "devextreme/data/data_source";

--- a/concepts/05 UI Components/Slider/00 Overview.md
+++ b/concepts/05 UI Components/Slider/00 Overview.md
@@ -55,7 +55,7 @@ The following code adds a simple Slider to your page. The **min** and **max** pr
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSlider } from 'devextreme-vue/slider';
 
@@ -74,7 +74,7 @@ The following code adds a simple Slider to your page. The **min** and **max** pr
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Slider } from 'devextreme-react/slider';
 
@@ -166,7 +166,7 @@ In addition, you can specify the step of Slider values using the [step](/api-ref
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSlider } from 'devextreme-vue/slider';
 
@@ -185,7 +185,7 @@ In addition, you can specify the step of Slider values using the [step](/api-ref
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Slider } from 'devextreme-react/slider';
 

--- a/concepts/05 UI Components/Slider/05 Customize Component Appearance.md
+++ b/concepts/05 UI Components/Slider/05 Customize Component Appearance.md
@@ -56,7 +56,7 @@ The Slider can display labels for the [min](/api-reference/10%20UI%20Components/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSlider, DxLabel } from 'devextreme-vue/slider';
 
@@ -76,7 +76,7 @@ The Slider can display labels for the [min](/api-reference/10%20UI%20Components/
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Slider, Label } from 'devextreme-react/slider';
 
@@ -162,7 +162,7 @@ The Slider can also display a tooltip for the slider handle. To configure it, us
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSlider, DxTooltip } from 'devextreme-vue/slider';
 
@@ -182,7 +182,7 @@ The Slider can also display a tooltip for the slider handle. To configure it, us
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Slider, Tooltip } from 'devextreme-react/slider';
 
@@ -251,7 +251,7 @@ To specify whether or not the part of the scale from the beginning to the slider
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSlider } from 'devextreme-vue/slider';
 
@@ -265,7 +265,7 @@ To specify whether or not the part of the scale from the beginning to the slider
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Slider } from 'devextreme-react/slider';
 

--- a/concepts/05 UI Components/Slider/10 Handle the Value Change Event.md
+++ b/concepts/05 UI Components/Slider/10 Handle the Value Change Event.md
@@ -52,7 +52,7 @@ To process a new Slider value, you need to handle the value change event. If the
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxSlider } from 'devextreme-vue/slider';
 
@@ -78,7 +78,7 @@ To process a new Slider value, you need to handle the value change event. If the
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Slider } from 'devextreme-react/slider';
 

--- a/concepts/05 UI Components/TagBox/02 Data Binding/05 Simple Array/05 Array Only.md
+++ b/concepts/05 UI Components/TagBox/02 Data Binding/05 Simple Array/05 Array Only.md
@@ -44,7 +44,7 @@ Bind the TagBox to an array by passing it to the [dataSource](/api-reference/10%
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -63,7 +63,7 @@ Bind the TagBox to an array by passing it to the [dataSource](/api-reference/10%
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 
@@ -140,7 +140,7 @@ Bind the TagBox to an array by passing it to the [dataSource](/api-reference/10%
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -164,7 +164,7 @@ Bind the TagBox to an array by passing it to the [dataSource](/api-reference/10%
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 
@@ -256,7 +256,7 @@ You can create a [Query](/concepts/70%20Data%20Binding/5%20Data%20Layer/6%20Quer
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import query from "devextreme/data/query";
@@ -287,7 +287,7 @@ You can create a [Query](/concepts/70%20Data%20Binding/5%20Data%20Layer/6%20Quer
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import query from "devextreme/data/query";

--- a/concepts/05 UI Components/TagBox/02 Data Binding/05 Simple Array/10 ArrayStore.md
+++ b/concepts/05 UI Components/TagBox/02 Data Binding/05 Simple Array/10 ArrayStore.md
@@ -57,7 +57,7 @@ Extend a JavaScript array's functionality by placing it into an [ArrayStore](/ap
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import ArrayStore from "devextreme/data/array_store";
@@ -84,7 +84,7 @@ Extend a JavaScript array's functionality by placing it into an [ArrayStore](/ap
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import ArrayStore from "devextreme/data/array_store";
@@ -186,7 +186,7 @@ Data kept in the **ArrayStore** can be processed in a [DataSource](/api-referenc
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import DataSource from "devextreme/data/data_source";
@@ -216,7 +216,7 @@ Data kept in the **ArrayStore** can be processed in a [DataSource](/api-referenc
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import DataSource from "devextreme/data/data_source";

--- a/concepts/05 UI Components/TagBox/02 Data Binding/10 JSON Data.md
+++ b/concepts/05 UI Components/TagBox/02 Data Binding/10 JSON Data.md
@@ -45,7 +45,7 @@ Load JSON data by assigning its URL to the [dataSource](/api-reference/10%20UI%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -59,7 +59,7 @@ Load JSON data by assigning its URL to the [dataSource](/api-reference/10%20UI%2
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 
@@ -121,7 +121,7 @@ Note that you can also use a JSONP callback parameter.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -135,7 +135,7 @@ Note that you can also use a JSONP callback parameter.
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 

--- a/concepts/05 UI Components/TagBox/02 Data Binding/15 OData Service.md
+++ b/concepts/05 UI Components/TagBox/02 Data Binding/15 OData Service.md
@@ -51,7 +51,7 @@ Use the [ODataStore](/api-reference/30%20Data%20Layer/ODataStore '/Documentation
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import ODataStore from "devextreme/data/odata/store";
@@ -74,7 +74,7 @@ Use the [ODataStore](/api-reference/30%20Data%20Layer/ODataStore '/Documentation
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import ODataStore from "devextreme/data/odata/store";
@@ -163,7 +163,7 @@ Data kept in the **ODataStore** can be processed in a [DataSource](/api-referenc
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import DataSource from "devextreme/data/data_source";
@@ -190,7 +190,7 @@ Data kept in the **ODataStore** can be processed in a [DataSource](/api-referenc
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import DataSource from "devextreme/data/data_source";

--- a/concepts/05 UI Components/TagBox/02 Data Binding/16 Web API Service.md
+++ b/concepts/05 UI Components/TagBox/02 Data Binding/16 Web API Service.md
@@ -56,7 +56,7 @@ DevExtreme provides the <a href="https://github.com/DevExpress/DevExtreme.AspNet
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import { createStore } from "devextreme-aspnet-data-nojquery";
@@ -82,7 +82,7 @@ DevExtreme provides the <a href="https://github.com/DevExpress/DevExtreme.AspNet
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import { createStore } from "devextreme-aspnet-data-nojquery";

--- a/concepts/05 UI Components/TagBox/02 Data Binding/17 PHP Service.md
+++ b/concepts/05 UI Components/TagBox/02 Data Binding/17 PHP Service.md
@@ -56,7 +56,7 @@ DevExtreme provides the <a href="https://github.com/DevExpress/DevExtreme-PHP-Da
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import { createStore } from "devextreme-aspnet-data-nojquery";
@@ -82,7 +82,7 @@ DevExtreme provides the <a href="https://github.com/DevExpress/DevExtreme-PHP-Da
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import { createStore } from "devextreme-aspnet-data-nojquery";

--- a/concepts/05 UI Components/TagBox/02 Data Binding/18 MongoDB Service.md
+++ b/concepts/05 UI Components/TagBox/02 Data Binding/18 MongoDB Service.md
@@ -56,7 +56,7 @@ Use the third-party <a href="https://github.com/oliversturm/devextreme-query-mon
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import { createStore } from "devextreme-aspnet-data-nojquery";
@@ -82,7 +82,7 @@ Use the third-party <a href="https://github.com/oliversturm/devextreme-query-mon
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import { createStore } from "devextreme-aspnet-data-nojquery";

--- a/concepts/05 UI Components/TagBox/02 Data Binding/30 Access the DataSource.md
+++ b/concepts/05 UI Components/TagBox/02 Data Binding/30 Access the DataSource.md
@@ -37,7 +37,7 @@ Regardless of the data source you use, the TagBox always wraps it in a [DataSour
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -56,7 +56,7 @@ Regardless of the data source you use, the TagBox always wraps it in a [DataSour
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 

--- a/concepts/05 UI Components/TagBox/03 Control the Behavior.md
+++ b/concepts/05 UI Components/TagBox/03 Control the Behavior.md
@@ -56,7 +56,7 @@ By default, the TagBox closes the drop-down list _immediately_ after a user sele
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -80,7 +80,7 @@ By default, the TagBox closes the drop-down list _immediately_ after a user sele
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 
@@ -162,7 +162,7 @@ When selected items overflow the input field, they are arranged in several lines
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -186,7 +186,7 @@ When selected items overflow the input field, they are arranged in several lines
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 
@@ -267,7 +267,7 @@ By default, selected items stay in the drop-down list. If they should be hidden 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -291,7 +291,7 @@ By default, selected items stay in the drop-down list. If they should be hidden 
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 
@@ -372,7 +372,7 @@ The TagBox allows a user to clear selection in one click on the **Clear** button
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -396,7 +396,7 @@ The TagBox allows a user to clear selection in one click on the **Clear** button
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 

--- a/concepts/05 UI Components/TagBox/05 Customize Item Appearance.md
+++ b/concepts/05 UI Components/TagBox/05 Customize Item Appearance.md
@@ -57,7 +57,7 @@ For a minor customization of TagBox items, you can define [specific fields](/api
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -80,7 +80,7 @@ For a minor customization of TagBox items, you can define [specific fields](/api
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 
@@ -198,7 +198,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -225,7 +225,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 
@@ -348,7 +348,7 @@ Using similar techniques, you can also customize tags of the selected items. The
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -370,7 +370,7 @@ Using similar techniques, you can also customize tags of the selected items. The
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 

--- a/concepts/05 UI Components/TagBox/07 Grouping/01 In the Data Source.md
+++ b/concepts/05 UI Components/TagBox/07 Grouping/01 In the Data Source.md
@@ -78,7 +78,7 @@ Items in the TagBox can be grouped if they are grouped in the data source. The T
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -111,7 +111,7 @@ Items in the TagBox can be grouped if they are grouped in the data source. The T
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 
@@ -248,7 +248,7 @@ If objects in your data source miss the **key** and **items** fields, use the [m
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import DataSource from "devextreme/data/data_source";
@@ -292,7 +292,7 @@ If objects in your data source miss the **key** and **items** fields, use the [m
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import DataSource from "devextreme/data/data_source";
@@ -419,7 +419,7 @@ If your data is not grouped at all, you can group it using the [group](/api-refe
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import DataSource from "devextreme/data/data_source";
@@ -451,7 +451,7 @@ If your data is not grouped at all, you can group it using the [group](/api-refe
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import DataSource from "devextreme/data/data_source";

--- a/concepts/05 UI Components/TagBox/07 Grouping/05 Customize Group Headers.md
+++ b/concepts/05 UI Components/TagBox/07 Grouping/05 Customize Group Headers.md
@@ -99,7 +99,7 @@ To customize group headers, specify a [groupTemplate](/api-reference/10%20UI%20C
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import DataSource from "devextreme/data/data_source";
@@ -144,7 +144,7 @@ To customize group headers, specify a [groupTemplate](/api-reference/10%20UI%20C
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import DataSource from "devextreme/data/data_source";

--- a/concepts/05 UI Components/TagBox/09 Enable Paging.md
+++ b/concepts/05 UI Components/TagBox/09 Enable Paging.md
@@ -53,7 +53,7 @@ Paging properties are set in the [DataSource](/api-reference/30%20Data%20Layer/D
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import DataSource from "devextreme/data/data_source";
@@ -77,7 +77,7 @@ Paging properties are set in the [DataSource](/api-reference/30%20Data%20Layer/D
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import DataSource from "devextreme/data/data_source";

--- a/concepts/05 UI Components/TagBox/10 Configure Search Parameters.md
+++ b/concepts/05 UI Components/TagBox/10 Configure Search Parameters.md
@@ -64,7 +64,7 @@ The TagBox UI component allows an end user to search through its items. This fea
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -88,7 +88,7 @@ The TagBox UI component allows an end user to search through its items. This fea
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 
@@ -178,7 +178,7 @@ When a user types a string in the input field, the TagBox suggests all items tha
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -201,7 +201,7 @@ When a user types a string in the input field, the TagBox suggests all items tha
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 
@@ -291,7 +291,7 @@ There is a delay between the moment a user finishes typing and the moment the se
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -314,7 +314,7 @@ There is a delay between the moment a user finishes typing and the moment the se
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 
@@ -403,7 +403,7 @@ The TagBox UI component starts searching after a user has typed at least one cha
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -425,7 +425,7 @@ The TagBox UI component starts searching after a user has typed at least one cha
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 

--- a/concepts/05 UI Components/TagBox/12 Limit the Tag Count/10 Selected Tags.md
+++ b/concepts/05 UI Components/TagBox/12 Limit the Tag Count/10 Selected Tags.md
@@ -108,7 +108,7 @@ The following code shows the [onValueChanged](/api-reference/10%20UI%20Component
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import { DxTooltip } from 'devextreme-vue/tooltip';
@@ -147,7 +147,7 @@ The following code shows the [onValueChanged](/api-reference/10%20UI%20Component
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import { Tooltip } from 'devextreme-react/tooltip';

--- a/concepts/05 UI Components/TagBox/12 Limit the Tag Count/15 Displayed Tags.md
+++ b/concepts/05 UI Components/TagBox/12 Limit the Tag Count/15 Displayed Tags.md
@@ -60,7 +60,7 @@ Specify the [maxDisplayedTags](/api-reference/10%20UI%20Components/dxTagBox/1%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -85,7 +85,7 @@ Specify the [maxDisplayedTags](/api-reference/10%20UI%20Components/dxTagBox/1%20
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 
@@ -186,7 +186,7 @@ You can also customize the multi-tag within the [onMultiTagPreparing](/api-refer
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
 
@@ -223,7 +223,7 @@ You can also customize the multi-tag within the [onMultiTagPreparing](/api-refer
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
 

--- a/concepts/05 UI Components/TagBox/15 Create a User-Defined Item.md
+++ b/concepts/05 UI Components/TagBox/15 Create a User-Defined Item.md
@@ -94,7 +94,7 @@ Note that you need to implement the [onCustomItemCreating](/api-reference/10%20U
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTagBox } from 'devextreme-vue/tag-box';
     import DataSource from "devextreme/data/data_source";
@@ -136,7 +136,7 @@ Note that you need to implement the [onCustomItemCreating](/api-reference/10%20U
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TagBox } from 'devextreme-react/tag-box';
     import DataSource from "devextreme/data/data_source";

--- a/concepts/05 UI Components/TextArea/00 Getting Started with TextArea/05 Create a TextArea.md
+++ b/concepts/05 UI Components/TextArea/00 Getting Started with TextArea/05 Create a TextArea.md
@@ -73,7 +73,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxTextArea } from 'devextreme-vue/text-area';
 
     export default {
@@ -90,7 +90,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TextArea } from 'devextreme-react/text-area';
 

--- a/concepts/05 UI Components/TextArea/13 Handle the Keyboard Events.md
+++ b/concepts/05 UI Components/TextArea/13 Handle the Keyboard Events.md
@@ -63,7 +63,7 @@ The TextArea raises three keyboard events: [keyDown](/api-reference/10%20UI%20Co
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxTextArea } from 'devextreme-vue/text-area';
 
     export default {
@@ -89,7 +89,7 @@ The TextArea raises three keyboard events: [keyDown](/api-reference/10%20UI%20Co
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TextArea } from 'devextreme-react/text-area';
 

--- a/concepts/05 UI Components/TextBox/00 Getting Started with TextBox/05 Create a TextBox.md
+++ b/concepts/05 UI Components/TextBox/00 Getting Started with TextBox/05 Create a TextBox.md
@@ -71,7 +71,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxTextBox } from 'devextreme-vue/text-box';
 
     export default {
@@ -88,7 +88,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TextBox } from 'devextreme-react/text-box';
 

--- a/concepts/05 UI Components/TextBox/10 Handle the Value Change Event.md
+++ b/concepts/05 UI Components/TextBox/10 Handle the Value Change Event.md
@@ -37,7 +37,7 @@ When a user types a value into the TextBox, this value applies when the <a href=
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTextBox } from 'devextreme-vue/text-box';
 
@@ -51,7 +51,7 @@ When a user types a value into the TextBox, this value applies when the <a href=
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TextBox } from 'devextreme-react/text-box';
 
@@ -122,7 +122,7 @@ To process a new TextBox value, you need to handle the value change event. If th
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTextBox } from 'devextreme-vue/text-box';
 
@@ -148,7 +148,7 @@ To process a new TextBox value, you need to handle the value change event. If th
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TextBox } from 'devextreme-react/text-box';
 

--- a/concepts/05 UI Components/TextBox/20 Specify a Mask for the Input.md
+++ b/concepts/05 UI Components/TextBox/20 Specify a Mask for the Input.md
@@ -111,7 +111,7 @@ You can also define custom masking elements using the [maskRules](/api-reference
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTextBox } from 'devextreme-vue/text-box';
 
@@ -144,7 +144,7 @@ You can also define custom masking elements using the [maskRules](/api-reference
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TextBox } from 'devextreme-react/text-box';
 
@@ -237,7 +237,7 @@ By default, the UI component uses underscores to designate blanks in the masked 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTextBox } from 'devextreme-vue/text-box';
 
@@ -251,7 +251,7 @@ By default, the UI component uses underscores to designate blanks in the masked 
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TextBox } from 'devextreme-react/text-box';
 
@@ -314,7 +314,7 @@ If the input value does not match the mask, the TextBox displays an error messag
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTextBox } from 'devextreme-vue/text-box';
 
@@ -328,7 +328,7 @@ If the input value does not match the mask, the TextBox displays an error messag
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TextBox } from 'devextreme-react/text-box';
 

--- a/concepts/05 UI Components/Toast/00 Getting Started with Toast/05 Display a Toast notification/05 Use the 'notify' Method.md
+++ b/concepts/05 UI Components/Toast/00 Getting Started with Toast/05 Display a Toast notification/05 Use the 'notify' Method.md
@@ -170,7 +170,7 @@ If you call the method that allows additional options, you can set the [width](/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxButton } from 'devextreme-vue/button';
     import notify from "devextreme/ui/notify";
 
@@ -220,7 +220,7 @@ If you call the method that allows additional options, you can set the [width](/
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Button } from 'devextreme-react/button';
     import notify from 'devextreme/ui/notify';

--- a/concepts/05 UI Components/Toast/00 Getting Started with Toast/05 Display a Toast notification/10 Show and Hide the Toast.md
+++ b/concepts/05 UI Components/Toast/00 Getting Started with Toast/05 Display a Toast notification/10 Show and Hide the Toast.md
@@ -95,7 +95,7 @@ The example below shows how you can show and hide the Toast component without th
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxButton } from 'devextreme-vue/button';
     import { DxToast, DxPosition } from 'devextreme-vue/toast';
     import notify from "devextreme/ui/notify";
@@ -130,7 +130,7 @@ The example below shows how you can show and hide the Toast component without th
     <!-- tab: App.js -->
     import React, { useState } from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Button } from 'devextreme-react/button';
     import { Toast, Position } from 'devextreme-react/toast';

--- a/concepts/05 UI Components/Toast/00 Getting Started with Toast/10 Customize Toast Content.md
+++ b/concepts/05 UI Components/Toast/00 Getting Started with Toast/10 Customize Toast Content.md
@@ -193,7 +193,7 @@ To customize toast content, either specify a [contentTemplate](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxButton } from 'devextreme-vue/button';
     import { DxToast, DxPosition } from 'devextreme-vue/toast';
     import notify from "devextreme/ui/notify";
@@ -242,7 +242,7 @@ To customize toast content, either specify a [contentTemplate](/api-reference/10
     <!-- tab: App.js -->
     import React, { useState } from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Button } from 'devextreme-react/button';
     import { Toast, Position } from 'devextreme-react/toast';

--- a/concepts/05 UI Components/Toast/05 Show and Hide the Toast/01 API.md
+++ b/concepts/05 UI Components/Toast/05 Show and Hide the Toast/01 API.md
@@ -70,7 +70,7 @@ To show or hide the Toast programmatically, bind the [visible](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxToast } from 'devextreme-vue/toast';
     import { DxButton } from 'devextreme-vue/button';
@@ -98,7 +98,7 @@ To show or hide the Toast programmatically, bind the [visible](/api-reference/10
 To show or hide the Toast programmatically, bind the [visible](/api-reference/10%20UI%20Components/dxOverlay/1%20Configuration/visible.md '/Documentation/ApiReference/UI_Components/dxToast/Configuration/#visible') property of the Toast to a state property. After that, change the latter property, and the Toast will appear or disappear.
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Toast } from 'devextreme-react/toast';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Toast/05 Show and Hide the Toast/10 Events.md
+++ b/concepts/05 UI Components/Toast/05 Show and Hide the Toast/10 Events.md
@@ -69,7 +69,7 @@ To execute certain commands before or after the Toast was shown/hidden, handle t
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxToast } from 'devextreme-vue/toast';
     import { DxButton } from 'devextreme-vue/button';
@@ -99,7 +99,7 @@ To execute certain commands before or after the Toast was shown/hidden, handle t
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Toast } from 'devextreme-react/toast';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Toast/15 Resize and Relocate.md
+++ b/concepts/05 UI Components/Toast/15 Resize and Relocate.md
@@ -71,7 +71,7 @@ To change the size of the Toast, specify the [height](/api-reference/10%20UI%20C
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxToast } from 'devextreme-vue/toast';
     import { DxButton } from 'devextreme-vue/button';
@@ -97,7 +97,7 @@ To change the size of the Toast, specify the [height](/api-reference/10%20UI%20C
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Toast } from 'devextreme-react/toast';
     import { Button } from 'devextreme-react/button';
@@ -230,7 +230,7 @@ If you need to position the Toast against a specific element on your page, set t
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxToast, DxPosition } from 'devextreme-vue/toast';
     import { DxButton } from 'devextreme-vue/button';
@@ -257,7 +257,7 @@ If you need to position the Toast against a specific element on your page, set t
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Toast, Position } from 'devextreme-react/toast';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Tooltip/00 Overview.md
+++ b/concepts/05 UI Components/Tooltip/00 Overview.md
@@ -68,7 +68,7 @@ The following code creates a simple Tooltip on your page and attaches it to anot
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTooltip } from 'devextreme-vue/tooltip';
 
@@ -82,7 +82,7 @@ The following code creates a simple Tooltip on your page and attaches it to anot
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Tooltip } from 'devextreme-react/tooltip';
 

--- a/concepts/05 UI Components/Tooltip/05 Show and Hide the Tooltip/01 User Interaction.md
+++ b/concepts/05 UI Components/Tooltip/05 Show and Hide the Tooltip/01 User Interaction.md
@@ -63,7 +63,7 @@ To specify when the Tooltip should be shown and hidden, set the [showEvent](/api
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTooltip } from 'devextreme-vue/tooltip';
 
@@ -77,7 +77,7 @@ To specify when the Tooltip should be shown and hidden, set the [showEvent](/api
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Tooltip } from 'devextreme-react/tooltip';
 
@@ -188,7 +188,7 @@ The Tooltip can also be hidden when a user clicks outside it. To control this be
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTooltip } from 'devextreme-vue/tooltip';
 
@@ -202,7 +202,7 @@ The Tooltip can also be hidden when a user clicks outside it. To control this be
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Tooltip } from 'devextreme-react/tooltip';
 

--- a/concepts/05 UI Components/Tooltip/05 Show and Hide the Tooltip/05 API.md
+++ b/concepts/05 UI Components/Tooltip/05 Show and Hide the Tooltip/05 API.md
@@ -175,7 +175,7 @@ To show or hide the Tooltip programmatically, bind the [visible](/api-reference/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTooltip } from 'devextreme-vue/tooltip';
     import { DxButton } from 'devextreme-vue/button';
@@ -206,7 +206,7 @@ To show or hide the Tooltip programmatically, bind the [visible](/api-reference/
 To show or hide the Tooltip programmatically, bind the [visible](/api-reference/10%20UI%20Components/dxPopup/1%20Configuration/visible.md '/Documentation/ApiReference/UI_Components/dxTooltip/Configuration/#visible') property of the Tooltip to a state property. After that, change this state property, and the Tooltip will appear or disappear.
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Tooltip } from 'devextreme-react/tooltip';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Tooltip/05 Show and Hide the Tooltip/10 Events.md
+++ b/concepts/05 UI Components/Tooltip/05 Show and Hide the Tooltip/10 Events.md
@@ -68,7 +68,7 @@ To execute certain commands before or after the Tooltip was shown/hidden, handle
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTooltip } from 'devextreme-vue/tooltip';
 
@@ -96,7 +96,7 @@ To execute certain commands before or after the Tooltip was shown/hidden, handle
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Tooltip } from 'devextreme-react/tooltip';
 

--- a/concepts/05 UI Components/Tooltip/10 Customize the Content/1 Specifying the Content Template.md
+++ b/concepts/05 UI Components/Tooltip/10 Customize the Content/1 Specifying the Content Template.md
@@ -72,7 +72,7 @@ The following code shows how to create a template consisting of static (text) an
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTooltip } from 'devextreme-vue/tooltip';
     import { DxSwitch } from 'devextreme-vue/switch';
@@ -88,7 +88,7 @@ The following code shows how to create a template consisting of static (text) an
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Tooltip } from 'devextreme-react/tooltip';
     import { Switch } from 'devextreme-react/switch';

--- a/concepts/05 UI Components/Tooltip/10 Customize the Content/5 Switching Templates On the Fly.md
+++ b/concepts/05 UI Components/Tooltip/10 Customize the Content/5 Switching Templates On the Fly.md
@@ -108,7 +108,7 @@ If you need to render different templates depending on a specific condition, def
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTooltip } from 'devextreme-vue/tooltip';
     import { DxButton } from 'devextreme-vue/button';
@@ -143,7 +143,7 @@ If you need to render different templates depending on a specific condition, def
     <!--tab: App.js-->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { Tooltip } from 'devextreme-react/tooltip';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Tooltip/15 Resize and Relocate.md
+++ b/concepts/05 UI Components/Tooltip/15 Resize and Relocate.md
@@ -71,7 +71,7 @@ To change the size of the Tooltip, specify the [height](/api-reference/10%20UI%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTooltip } from 'devextreme-vue/tooltip';
 
@@ -85,7 +85,7 @@ To change the size of the Tooltip, specify the [height](/api-reference/10%20UI%2
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Tooltip } from 'devextreme-react/tooltip';
 
@@ -201,7 +201,7 @@ If you need to position the Tooltip against a certain side of the [target elemen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTooltip } from 'devextreme-vue/tooltip';
 
@@ -215,7 +215,7 @@ If you need to position the Tooltip against a certain side of the [target elemen
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Tooltip } from 'devextreme-react/tooltip';
 


### PR DESCRIPTION
Replaced mentions of Generic themes with Fluent:
import `'devextreme/dist/css/dx.light.css';` > import `'devextreme/dist/css/dx.fluent.blue.light.css';`

Included files:
```
concepts\05 UI Components\DateBox\**\*.md,
concepts\05 UI Components\TextArea\**\*.md,
concepts\05 UI Components\TextBox\**\*.md,
concepts\05 UI Components\Calendar\**\*.md,
concepts\05 UI Components\RadioGroup\**\*.md,
concepts\05 UI Components\TagBox\**\*.md,
concepts\05 UI Components\SelectBox\**\*.md,
concepts\05 UI Components\ColorBox\**\*.md,
concepts\05 UI Components\FileUploader\**\*.md,
concepts\05 UI Components\NumberBox\**\*.md,
concepts\05 UI Components\ProgressBar\**\*.md,
concepts\05 UI Components\DateRangeBox\**\*.md,
concepts\05 UI Components\Slider\**\*.md,
concepts\05 UI Components\Popup\**\*.md,
concepts\05 UI Components\Popover\**\*.md,
concepts\05 UI Components\Tooltip\**\*.md,
concepts\05 UI Components\Toast\**\*.md,
concepts\05 UI Components\DropDownBox\**\*.md,
concepts\05 UI Components\Map\**\*.md,
concepts\05 UI Components\LoadPanel\**\*.md,
```