### PR TITLE
Update Theme Mentions to Fluent - Remaining Guides (#8607)

### DIFF
--- a/concepts/05 UI Components/Accordion/00 Getting Started with Accordion/05 Create an Accordion.md
+++ b/concepts/05 UI Components/Accordion/00 Getting Started with Accordion/05 Create an Accordion.md
@@ -71,7 +71,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxAccordion } from 'devextreme-vue/accordion';
 
     export default {
@@ -88,7 +88,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Accordion } from 'devextreme-react/accordion';
 

--- a/concepts/05 UI Components/ActionSheet/00 Overview.md
+++ b/concepts/05 UI Components/ActionSheet/00 Overview.md
@@ -93,7 +93,7 @@ The following code adds a simple ActionSheet to your page. The UI component is s
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxActionSheet from 'devextreme-vue/action-sheet';
     import DxButton from 'devextreme-vue/button';
@@ -129,7 +129,7 @@ The following code adds a simple ActionSheet to your page. The UI component is s
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ActionSheet } from 'devextreme-react/action-sheet';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/ActionSheet/05 Customize Item Appearance.md
+++ b/concepts/05 UI Components/ActionSheet/05 Customize Item Appearance.md
@@ -49,7 +49,7 @@ For a minor customization of ActionSheet buttons, you can define [specific field
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxActionSheet from 'devextreme-vue/action-sheet';
 
@@ -72,7 +72,7 @@ For a minor customization of ActionSheet buttons, you can define [specific field
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ActionSheet } from 'devextreme-react/action-sheet';
 
@@ -189,7 +189,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxActionSheet from 'devextreme-vue/action-sheet';
 
@@ -224,7 +224,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ActionSheet } from 'devextreme-react/action-sheet';
 

--- a/concepts/05 UI Components/ActionSheet/10 Specify Display Mode.md
+++ b/concepts/05 UI Components/ActionSheet/10 Specify Display Mode.md
@@ -45,7 +45,7 @@ By default, the ActionSheet comes up from the bottom of the page. If you set the
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxActionSheet } from 'devextreme-vue/action-sheet';
 
@@ -59,7 +59,7 @@ By default, the ActionSheet comes up from the bottom of the page. If you set the
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ActionSheet } from 'devextreme-react/action-sheet';
 

--- a/concepts/05 UI Components/Autocomplete/00 Getting Started with Autocomplete/05 Create Autocomplete and Bind It to Data.md
+++ b/concepts/05 UI Components/Autocomplete/00 Getting Started with Autocomplete/05 Create Autocomplete and Bind It to Data.md
@@ -252,7 +252,7 @@ The code example below specifies the [dataSource](/api-reference/10%20UI%20Compo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxAutocomplete } from 'devextreme-vue/autocomplete';
     import { employeesTasks } from './data.js';
 
@@ -341,7 +341,7 @@ The code example below specifies the [dataSource](/api-reference/10%20UI%20Compo
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { employeesTasks } from './data';
     import { Autocomplete } from 'devextreme-react';
 

--- a/concepts/05 UI Components/Autocomplete/10 Configure Search Parameters.md
+++ b/concepts/05 UI Components/Autocomplete/10 Configure Search Parameters.md
@@ -56,7 +56,7 @@ The AutoComplete can provide suggestions in two different modes: *'contains'* (b
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxAutocomplete } from 'devextreme-vue/autocomplete';
 
@@ -79,7 +79,7 @@ The AutoComplete can provide suggestions in two different modes: *'contains'* (b
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Autocomplete } from 'devextreme-react/autocomplete';
 
@@ -145,7 +145,7 @@ By default, the AutoComplete UI component starts providing suggestions once an e
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxAutocomplete } from 'devextreme-vue/autocomplete';
 
@@ -159,7 +159,7 @@ By default, the AutoComplete UI component starts providing suggestions once an e
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Autocomplete } from 'devextreme-react/autocomplete';
 
@@ -215,7 +215,7 @@ You can also specify the time interval the UI component should wait before provi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxAutocomplete } from 'devextreme-vue/autocomplete';
 
@@ -229,7 +229,7 @@ You can also specify the time interval the UI component should wait before provi
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Autocomplete } from 'devextreme-react/autocomplete';
 

--- a/concepts/05 UI Components/Box/00 Overview.md
+++ b/concepts/05 UI Components/Box/00 Overview.md
@@ -97,7 +97,7 @@ The following code adds a simple Box containing three items to your page. These 
         </DxBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxBox, DxItem } from 'devextreme-vue/box';
 
@@ -124,7 +124,7 @@ The following code adds a simple Box containing three items to your page. These 
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Box, { Item } from 'devextreme-react/box';
 

--- a/concepts/05 UI Components/Box/05 Specify an Item Size.md
+++ b/concepts/05 UI Components/Box/05 Specify an Item Size.md
@@ -99,7 +99,7 @@ The unoccupied area can be distributed among the items according to **ratio**s. 
         </DxBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxBox, DxItem } from 'devextreme-vue/box';
 
@@ -126,7 +126,7 @@ The unoccupied area can be distributed among the items according to **ratio**s. 
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Box, { Item } from 'devextreme-react/box';
 
@@ -262,7 +262,7 @@ If **ratio** applies when there is an available space, **shrink** applies when s
         </DxBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxBox, DxItem } from 'devextreme-vue/box';
 
@@ -289,7 +289,7 @@ If **ratio** applies when there is an available space, **shrink** applies when s
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Box, { Item } from 'devextreme-react/box';
 
@@ -421,7 +421,7 @@ The result is different if *Item 2*'s **shrink** value is more than the other it
         </DxBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxBox, DxItem } from 'devextreme-vue/box';
 
@@ -448,7 +448,7 @@ The result is different if *Item 2*'s **shrink** value is more than the other it
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Box, { Item } from 'devextreme-react/box';
 

--- a/concepts/05 UI Components/Box/10 Arrange and Align Items.md
+++ b/concepts/05 UI Components/Box/10 Arrange and Align Items.md
@@ -49,7 +49,7 @@ Items can be arranged in a row or in a column depending on the value of the [dir
         </DxBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxBox } from 'devextreme-vue/box';
 
@@ -64,7 +64,7 @@ Items can be arranged in a row or in a column depending on the value of the [dir
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Box from 'devextreme-react/box';
 
@@ -154,7 +154,7 @@ If the Box items do not occupy the entire Box, you can align them along and cros
         </DxBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxBox } from 'devextreme-vue/box';
 
@@ -169,7 +169,7 @@ If the Box items do not occupy the entire Box, you can align them along and cros
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Box from 'devextreme-react/box';
 

--- a/concepts/05 UI Components/Box/15 Nest One Box Into Another.md
+++ b/concepts/05 UI Components/Box/15 Nest One Box Into Another.md
@@ -120,7 +120,7 @@ A nested Box is configured similarly to an ordinary Box. To nest one Box into an
         </DxBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxBox, DxItem } from 'devextreme-vue/box';
 
@@ -147,7 +147,7 @@ A nested Box is configured similarly to an ordinary Box. To nest one Box into an
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Box, { Item } from 'devextreme-react/box';
 

--- a/concepts/05 UI Components/Button/00 Getting Started with Button/02 Create a Button.md
+++ b/concepts/05 UI Components/Button/00 Getting Started with Button/02 Create a Button.md
@@ -91,7 +91,7 @@
 [Add DevExtreme to your React application](/concepts/50%20React%20Components/05%20Add%20DevExtreme%20to%20a%20React%20Application/00%20Add%20DevExtreme%20to%20a%20React%20Application.md '/Documentation/Guide/React_Components/Add_DevExtreme_to_a_React_Application/') and use the following code to create a Button:
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { Button } from 'devextreme-react/button';
 
     function App() {

--- a/concepts/05 UI Components/ButtonGroup/00 Getting Started with ButtonGroup/1 Create the ButtonGroup.md
+++ b/concepts/05 UI Components/ButtonGroup/00 Getting Started with ButtonGroup/1 Create the ButtonGroup.md
@@ -74,7 +74,7 @@ You can use the following code to create the ButtonGroup:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxButtonGroup } from 'devextreme-vue/button-group';
 
@@ -89,7 +89,7 @@ You can use the following code to create the ButtonGroup:
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ButtonGroup } from 'devextreme-react/button-group';
 

--- a/concepts/05 UI Components/Chart/00 Getting Started with Chart/05 Create a Chart.md
+++ b/concepts/05 UI Components/Chart/00 Getting Started with Chart/05 Create a Chart.md
@@ -81,7 +81,7 @@
     </template>
 
     <script setup lang="ts">
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxChart from 'devextreme-vue/chart';
     </script>
 
@@ -91,7 +91,7 @@
 
     <!-- tab: App.tsx -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Chart from 'devextreme-react/chart';
 
     function App() {

--- a/concepts/05 UI Components/Chat/05 Getting Started with Chat/05 Create a Chat.md
+++ b/concepts/05 UI Components/Chat/05 Getting Started with Chat/05 Create a Chat.md
@@ -71,7 +71,7 @@
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxChat } from 'devextreme-vue/chat';
     </script>
 
@@ -82,7 +82,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Chat } from 'devextreme-react/chat';
 

--- a/concepts/05 UI Components/CheckBox/00 Getting Started with CheckBox/05 Create a CheckBox.md
+++ b/concepts/05 UI Components/CheckBox/00 Getting Started with CheckBox/05 Create a CheckBox.md
@@ -71,7 +71,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxCheckBox } from 'devextreme-vue/check-box';
 
     export default {
@@ -88,7 +88,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { CheckBox } from 'devextreme-react/check-box';
 

--- a/concepts/05 UI Components/ContextMenu/00 Overview.md
+++ b/concepts/05 UI Components/ContextMenu/00 Overview.md
@@ -103,7 +103,7 @@ The following code adds the ContextMenu UI component to your page and binds it t
         </div>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxContextMenu from 'devextreme-vue/context-menu';
 
@@ -143,7 +143,7 @@ The following code adds the ContextMenu UI component to your page and binds it t
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ContextMenu } from 'devextreme-react/context-menu';
 

--- a/concepts/05 UI Components/ContextMenu/03 Access the Clicked Item.md
+++ b/concepts/05 UI Components/ContextMenu/03 Access the Clicked Item.md
@@ -50,7 +50,7 @@ To access the clicked item, handle the [itemClick](/api-reference/10%20UI%20Comp
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxContextMenu from 'devextreme-vue/context-menu';
 
@@ -71,7 +71,7 @@ To access the clicked item, handle the [itemClick](/api-reference/10%20UI%20Comp
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ContextMenu } from 'devextreme-react/context-menu';
 

--- a/concepts/05 UI Components/ContextMenu/05 Customize Item Appearance.md
+++ b/concepts/05 UI Components/ContextMenu/05 Customize Item Appearance.md
@@ -57,7 +57,7 @@ For a minor customization of ContextMenu items, you can define [specific fields]
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxContextMenu from 'devextreme-vue/context-menu';
 
@@ -81,7 +81,7 @@ For a minor customization of ContextMenu items, you can define [specific fields]
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ContextMenu } from 'devextreme-react/context-menu';
 
@@ -183,7 +183,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
         </DxContextMenu>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxContextMenu from 'devextreme-vue/context-menu';
 
@@ -207,7 +207,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ContextMenu } from 'devextreme-react/context-menu';
 

--- a/concepts/05 UI Components/ContextMenu/10 Open and Close the Context Menu/05 User Interaction.md
+++ b/concepts/05 UI Components/ContextMenu/10 Open and Close the Context Menu/05 User Interaction.md
@@ -57,7 +57,7 @@ By default, the ContextMenu appears when a user right-clicks the [target element
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxContextMenu from 'devextreme-vue/context-menu';
 
@@ -81,7 +81,7 @@ By default, the ContextMenu appears when a user right-clicks the [target element
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ContextMenu } from 'devextreme-react/context-menu';
 
@@ -171,7 +171,7 @@ The ContextMenu is hidden when a user clicks anywhere outside it. You can redefi
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxContextMenu from 'devextreme-vue/context-menu';
 
@@ -200,7 +200,7 @@ The ContextMenu is hidden when a user clicks anywhere outside it. You can redefi
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ContextMenu } from 'devextreme-react/context-menu';
 

--- a/concepts/05 UI Components/ContextMenu/10 Open and Close the Context Menu/10 API.md
+++ b/concepts/05 UI Components/ContextMenu/10 Open and Close the Context Menu/10 API.md
@@ -82,7 +82,7 @@ To open or close the ContextMenu from code, bind the [visible](/api-reference/10
         </div>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxButton from 'devextreme-vue/button';
     import DxContextMenu from 'devextreme-vue/context-menu';
@@ -116,7 +116,7 @@ To open or close the ContextMenu from code, bind the [visible](/api-reference/10
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Button } from 'devextreme-react/button';
     import { ContextMenu } from 'devextreme-react/context-menu';
@@ -226,7 +226,7 @@ When invoking the context menu from code, you may want to specify its [position]
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxContextMenu from 'devextreme-vue/context-menu';
 
@@ -249,7 +249,7 @@ When invoking the context menu from code, you may want to specify its [position]
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ContextMenu } from 'devextreme-react/context-menu';
 

--- a/concepts/05 UI Components/ContextMenu/10 Open and Close the Context Menu/30 Events.md
+++ b/concepts/05 UI Components/ContextMenu/10 Open and Close the Context Menu/30 Events.md
@@ -70,7 +70,7 @@ To execute certain commands before or after the ContextMenu was opened/closed, h
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxContextMenu from 'devextreme-vue/context-menu';
 
@@ -99,7 +99,7 @@ To execute certain commands before or after the ContextMenu was opened/closed, h
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ContextMenu } from 'devextreme-react/context-menu';
 

--- a/concepts/05 UI Components/Drawer/00 Getting Started with Navigation Drawer/00 Create the Drawer.md
+++ b/concepts/05 UI Components/Drawer/00 Getting Started with Navigation Drawer/00 Create the Drawer.md
@@ -182,7 +182,7 @@ You can also specify the [minSize](/api-reference/10%20UI%20Components/dxDrawer/
     }
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import './App.css';
     import NavigationDrawer from "./components/NavigationDrawer";
 

--- a/concepts/05 UI Components/Drawer/00 Getting Started with Navigation Drawer/15 Implement Navigation.md
+++ b/concepts/05 UI Components/Drawer/00 Getting Started with Navigation Drawer/15 Implement Navigation.md
@@ -325,7 +325,7 @@ Each list item should navigate to a different view. To implement this, follow th
     <!-- tab: main.js -->
     import { createApp, h } from 'vue';
     import { createRouter, createWebHashHistory } from 'vue-router';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import App from './App.vue';
     import InboxItemComponent from "./components/InboxItem.vue";
     import SentMailComponent from "./components/SentMail.vue";

--- a/concepts/05 UI Components/DropDownButton/00 Getting Started with DropDownButton/10 Create a DropDownButton.md
+++ b/concepts/05 UI Components/DropDownButton/00 Getting Started with DropDownButton/10 Create a DropDownButton.md
@@ -74,7 +74,7 @@ You can use the following code to create a DropDownButton:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDropDownButton from 'devextreme-vue/drop-down-button';
 
@@ -90,7 +90,7 @@ You can use the following code to create a DropDownButton:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DropDownButton from 'devextreme-react/drop-down-button';
 

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/10 Create a Form.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/10 Create a Form.md
@@ -92,7 +92,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm } from 'devextreme-vue/form';
 
@@ -115,7 +115,7 @@
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Form

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/20 Populate the Form Fields.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/20 Populate the Form Fields.md
@@ -69,7 +69,7 @@ The Form chooses default editors based on value types: [TextBox](/api-reference/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm } from 'devextreme-vue/form';
 
@@ -95,7 +95,7 @@ The Form chooses default editors based on value types: [TextBox](/api-reference/
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Form

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/30 Configure Simple Items.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/30 Configure Simple Items.md
@@ -89,7 +89,7 @@ Use the [items[]](/Documentation/ApiReference/UI_Components/dxForm/Configuration
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem } from 'devextreme-vue/form';
     
@@ -121,7 +121,7 @@ Use the [items[]](/Documentation/ApiReference/UI_Components/dxForm/Configuration
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Form,

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/10 In Columns.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/10 In Columns.md
@@ -96,7 +96,7 @@ An item can span multiple columns. The example below sets the [colSpan](/api-ref
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem } from 'devextreme-vue/form';
     
@@ -125,7 +125,7 @@ An item can span multiple columns. The example below sets the [colSpan](/api-ref
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Form,

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/20 In Groups.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/20 In Groups.md
@@ -116,7 +116,7 @@ The following code creates two groups, each occupies a separate column. The resu
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem, DxGroupItem } from 'devextreme-vue/form';
     
@@ -148,7 +148,7 @@ The following code creates two groups, each occupies a separate column. The resu
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Form,

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/30 In Tabs.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/30 In Tabs.md
@@ -153,7 +153,7 @@ The code also shows how to configure the tab panel's [height](/api-reference/10%
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { 
         DxForm, 
@@ -195,7 +195,7 @@ The code also shows how to configure the tab panel's [height](/api-reference/10%
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Form,

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/40 Add an Empty Space.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/40 Organize the Form Items/40 Add an Empty Space.md
@@ -95,7 +95,7 @@ In the following example, the empty item [spans](/api-reference/10%20UI%20Compon
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem, DxEmptyItem } from 'devextreme-vue/form';
     
@@ -121,7 +121,7 @@ In the following example, the empty item [spans](/api-reference/10%20UI%20Compon
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Form,

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/50 Configure Item Labels.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/50 Configure Item Labels.md
@@ -106,7 +106,7 @@ The following code shows how to configure the **labelLocation** property to plac
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem, DxLabel } from 'devextreme-vue/form';
     
@@ -132,7 +132,7 @@ The following code shows how to configure the **labelLocation** property to plac
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Form,

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/60 Modify the Form at Runtime.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/60 Modify the Form at Runtime.md
@@ -96,7 +96,7 @@ You can change any properties of the form, its items or editors at runtime. To u
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, 
         // ... 
@@ -130,7 +130,7 @@ You can change any properties of the form, its items or editors at runtime. To u
 
     <!-- tab: App.js -->
     import React, {useState, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Form,

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/70 Validate the Form Data.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/70 Validate the Form Data.md
@@ -101,7 +101,7 @@ The following example sets the **isRequired** property for the `Name` item. It a
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { 
         DxForm, 
@@ -133,7 +133,7 @@ The following example sets the **isRequired** property for the `Name` item. It a
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Form,

--- a/concepts/05 UI Components/Form/01 Getting Started with Form/80 Submit the Form.md
+++ b/concepts/05 UI Components/Form/01 Getting Started with Form/80 Submit the Form.md
@@ -156,7 +156,7 @@ The code below shows how to add a submit button, but does not show how to implem
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { 
         DxForm, 
@@ -207,7 +207,7 @@ The code below shows how to add a submit button, but does not show how to implem
 
     <!-- tab: App.js -->
     import React, { useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Form,
@@ -338,7 +338,7 @@ Alternatively, if you want to implement custom validation logic, handle the Butt
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { 
         DxForm, 
@@ -373,7 +373,7 @@ Alternatively, if you want to implement custom validation logic, handle the Butt
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         Form,

--- a/concepts/05 UI Components/Form/05 Configure Simple Items/01 Create a Simple Item.md
+++ b/concepts/05 UI Components/Form/05 Configure Simple Items/01 Create a Simple Item.md
@@ -54,7 +54,7 @@ By default, the Form generates a simple item for each field of the [formData](/a
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxForm from 'devextreme-vue/form';
 
@@ -80,7 +80,7 @@ By default, the Form generates a simple item for each field of the [formData](/a
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Form from 'devextreme-react/form';
 
@@ -193,7 +193,7 @@ The editor that will be used in a particular simple item depends on the type of 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxForm, {
         DxSimpleItem
@@ -227,7 +227,7 @@ The editor that will be used in a particular simple item depends on the type of 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Form, {
         SimpleItem

--- a/concepts/05 UI Components/Form/05 Configure Simple Items/05 Customize a Simple Item.md
+++ b/concepts/05 UI Components/Form/05 Configure Simple Items/05 Customize a Simple Item.md
@@ -102,7 +102,7 @@ If none of the available editors suit your requirements, you can define a custom
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxForm, {
         DxSimpleItem
@@ -132,7 +132,7 @@ If none of the available editors suit your requirements, you can define a custom
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Form, {
         SimpleItem
@@ -265,7 +265,7 @@ A simple item can be accompanied by a line of text that gives a hint, for exampl
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxForm, {
         DxSimpleItem
@@ -292,7 +292,7 @@ A simple item can be accompanied by a line of text that gives a hint, for exampl
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Form, {
         SimpleItem
@@ -405,7 +405,7 @@ You can modify automatically generated items using the [customizeItem](/api-refe
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxForm from 'devextreme-vue/form';
 
@@ -446,7 +446,7 @@ You can modify automatically generated items using the [customizeItem](/api-refe
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Form from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/05 Configure Simple Items/10 Create an Unbound Simple Item.md
+++ b/concepts/05 UI Components/Form/05 Configure Simple Items/10 Create an Unbound Simple Item.md
@@ -128,7 +128,7 @@ In the following example, the `order` item contains the [DataGrid](/concepts/05%
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxForm, {
         DxSimpleItem,
@@ -171,7 +171,7 @@ In the following example, the `order` item contains the [DataGrid](/concepts/05%
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Form, {
         SimpleItem,

--- a/concepts/05 UI Components/Form/10 Organize Simple Items/05 In Groups/01 Create a Group.md
+++ b/concepts/05 UI Components/Form/10 Organize Simple Items/05 In Groups/01 Create a Group.md
@@ -82,7 +82,7 @@ In the context of the Form UI component, a group is called ["group item"](/api-r
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxGroupItem, DxSimpleItem } from 'devextreme-vue/form';
 
@@ -111,7 +111,7 @@ In the context of the Form UI component, a group is called ["group item"](/api-r
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, GroupItem, SimpleItem } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/10 Organize Simple Items/05 In Groups/05 Columns within a Group.md
+++ b/concepts/05 UI Components/Form/10 Organize Simple Items/05 In Groups/05 Columns within a Group.md
@@ -96,7 +96,7 @@ Items within a group can be organized in several columns. To specify the number 
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxGroupItem, DxSimpleItem } from 'devextreme-vue/form';
 
@@ -125,7 +125,7 @@ Items within a group can be organized in several columns. To specify the number 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, GroupItem, SimpleItem } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/10 Organize Simple Items/05 In Groups/10 Custom Content within a Group.md
+++ b/concepts/05 UI Components/Form/10 Organize Simple Items/05 In Groups/10 Custom Content within a Group.md
@@ -82,7 +82,7 @@ The Form UI component allows you to place custom content, for example, an image,
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxGroupItem, DxSimpleItem } from 'devextreme-vue/form';
 
@@ -109,7 +109,7 @@ The Form UI component allows you to place custom content, for example, an image,
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, GroupItem, SimpleItem } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/10 Organize Simple Items/10 In Tabs/01 Create a Tab.md
+++ b/concepts/05 UI Components/Form/10 Organize Simple Items/10 In Tabs/01 Create a Tab.md
@@ -87,7 +87,7 @@ The Form UI component allows you to organize items in tabs. In the context of th
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem, DxTabbedItem, DxTab } from 'devextreme-vue/form';
 
@@ -117,7 +117,7 @@ The Form UI component allows you to organize items in tabs. In the context of th
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem, TabbedItem, Tab } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/10 Organize Simple Items/10 In Tabs/05 Columns within a Tab.md
+++ b/concepts/05 UI Components/Form/10 Organize Simple Items/10 In Tabs/05 Columns within a Tab.md
@@ -104,7 +104,7 @@ The content of a tab can be organized in columns. The [colCount](/api-reference/
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem, DxTabbedItem, DxTab } from 'devextreme-vue/form';
 
@@ -134,7 +134,7 @@ The content of a tab can be organized in columns. The [colCount](/api-reference/
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem, TabbedItem, Tab } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/10 Organize Simple Items/10 In Tabs/10 Custom Content within a Tab.md
+++ b/concepts/05 UI Components/Form/10 Organize Simple Items/10 In Tabs/10 Custom Content within a Tab.md
@@ -129,7 +129,7 @@ The Form UI component allows you to specify custom templates for an individual t
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem, DxTabbedItem, DxTab } from 'devextreme-vue/form';
 
@@ -161,7 +161,7 @@ The Form UI component allows you to specify custom templates for an individual t
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem, TabbedItem, Tab } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/10 Organize Simple Items/10 In Tabs/20 Configure the Tab Panel.md
+++ b/concepts/05 UI Components/Form/10 Organize Simple Items/10 In Tabs/20 Configure the Tab Panel.md
@@ -81,7 +81,7 @@ For displaying tabs, the Form uses the [TabPanel](/api-reference/10%20UI%20Compo
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem, DxTabbedItem, DxTab, DxTabPanelOptions } from 'devextreme-vue/form';
 
@@ -116,7 +116,7 @@ For displaying tabs, the Form uses the [TabPanel](/api-reference/10%20UI%20Compo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem, TabbedItem, Tab, TabPanelOptions } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/10 Organize Simple Items/15 In Columns/05 Fixed and Floating Number of Columns.md
+++ b/concepts/05 UI Components/Form/10 Organize Simple Items/15 In Columns/05 Fixed and Floating Number of Columns.md
@@ -55,7 +55,7 @@ The Form UI component can have a fixed number of columns in the layout...
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem } from 'devextreme-vue/form';
 
@@ -81,7 +81,7 @@ The Form UI component can have a fixed number of columns in the layout...
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem } from 'devextreme-react/form';
 
@@ -215,7 +215,7 @@ The Form UI component can have a fixed number of columns in the layout...
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxTabbedItem, DxSimpleItem, DxTab } from 'devextreme-vue/form';
 
@@ -246,7 +246,7 @@ The Form UI component can have a fixed number of columns in the layout...
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem, TabbedItem, Tab }  from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/10 Organize Simple Items/15 In Columns/10 Span Columns.md
+++ b/concepts/05 UI Components/Form/10 Organize Simple Items/15 In Columns/10 Span Columns.md
@@ -85,7 +85,7 @@ If an item should span more than one column, assign the required number to the [
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem, DxTabbedItem, DxTab } from 'devextreme-vue/form';
 
@@ -112,7 +112,7 @@ If an item should span more than one column, assign the required number to the [
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem, TabbedItem, Tab } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/10 Organize Simple Items/15 In Columns/15 Layout Depending on the Screen Width.md
+++ b/concepts/05 UI Components/Form/10 Organize Simple Items/15 In Columns/15 Layout Depending on the Screen Width.md
@@ -69,7 +69,7 @@ The Form UI component supports different layouts for different screen widths. Us
             :screen-by-width="screenByWidth" />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxForm from 'devextreme-vue/form';
 
@@ -115,7 +115,7 @@ The Form UI component supports different layouts for different screen widths. Us
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Form from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/10 Organize Simple Items/20 Add an Empty Space.md
+++ b/concepts/05 UI Components/Form/10 Organize Simple Items/20 Add an Empty Space.md
@@ -68,7 +68,7 @@ If you need to add an empty space between neighboring items, use an [empty item]
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxEmptyItem, DxSimpleItem } from 'devextreme-vue/form';
 
@@ -93,7 +93,7 @@ If you need to add an empty space between neighboring items, use an [empty item]
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, EmptyItem, SimpleItem } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/10 Organize Simple Items/25 Add a Button.md
+++ b/concepts/05 UI Components/Form/10 Organize Simple Items/25 Add a Button.md
@@ -87,7 +87,7 @@ You can add a button that performs a custom action using a [button item](/api-re
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxEmptyItem, DxSimpleItem, DxButtonItem, DxButtonOptions } from 'devextreme-vue/form';
 
@@ -116,7 +116,7 @@ You can add a button that performs a custom action using a [button item](/api-re
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, EmptyItem, SimpleItem, ButtonItem, ButtonOptions } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/15 Configure Item Labels/05 Location and Alignment/05 Align Labels Relatively to Editors.md
+++ b/concepts/05 UI Components/Form/15 Configure Item Labels/05 Location and Alignment/05 Align Labels Relatively to Editors.md
@@ -73,7 +73,7 @@ The Form UI component displays labels on the left side of their editors and alig
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem, DxLabel } from 'devextreme-vue/form';
 
@@ -100,7 +100,7 @@ The Form UI component displays labels on the left side of their editors and alig
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem, Label } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/15 Configure Item Labels/05 Location and Alignment/10 Align Editors Relatively to Each Other.md
+++ b/concepts/05 UI Components/Form/15 Configure Item Labels/05 Location and Alignment/10 Align Editors Relatively to Each Other.md
@@ -98,7 +98,7 @@ By default, the UI component aligns all editors of all simple items in straight 
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem, DxGroupItem } from 'devextreme-vue/form';
 
@@ -129,7 +129,7 @@ By default, the UI component aligns all editors of all simple items in straight 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem, GroupItem } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/15 Configure Item Labels/10 Additional Marks.md
+++ b/concepts/05 UI Components/Form/15 Configure Item Labels/10 Additional Marks.md
@@ -70,7 +70,7 @@ To specify the mark or text for required and optional items, use the [requiredMa
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem } from 'devextreme-vue/form';
 
@@ -97,7 +97,7 @@ To specify the mark or text for required and optional items, use the [requiredMa
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem } from 'devextreme-react/form';
 
@@ -193,7 +193,7 @@ Each label ends with a colon. To hide it, assign **false** to the [showColonAfte
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem, DxLabel } from 'devextreme-vue/form';
 
@@ -220,7 +220,7 @@ Each label ends with a colon. To hide it, assign **false** to the [showColonAfte
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem, Label } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/20 Change Properties at Runtime/05 Form Properties.md
+++ b/concepts/05 UI Components/Form/20 Change Properties at Runtime/05 Form Properties.md
@@ -74,7 +74,7 @@ To change the [Form configuration](/api-reference/10%20UI%20Components/dxForm/1%
         </div>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm } from 'devextreme-vue/form';
     import { DxCheckBox } from 'devextreme-vue/check-box';
@@ -106,7 +106,7 @@ To change the [Form configuration](/api-reference/10%20UI%20Components/dxForm/1%
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form } from 'devextreme-react/form';
     import { CheckBox } from 'devextreme-react/check-box';

--- a/concepts/05 UI Components/Form/20 Change Properties at Runtime/10 Item Properties.md
+++ b/concepts/05 UI Components/Form/20 Change Properties at Runtime/10 Item Properties.md
@@ -106,7 +106,7 @@ To change an item property at runtime, bind the property that should be changed 
         </div>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem, DxGroupItem } from 'devextreme-vue/form';
     import { DxCheckBox } from 'devextreme-vue/check-box';
@@ -138,7 +138,7 @@ To change an item property at runtime, bind the property that should be changed 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem, GroupItem } from 'devextreme-react/form';
     import { CheckBox } from 'devextreme-react/check-box';

--- a/concepts/05 UI Components/Form/20 Change Properties at Runtime/15 Editor Properties.md
+++ b/concepts/05 UI Components/Form/20 Change Properties at Runtime/15 Editor Properties.md
@@ -109,7 +109,7 @@ To change the properties of an editor, bind the property that should be changed 
         </div>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem } from 'devextreme-vue/form';
     import { DxCheckBox } from 'devextreme-vue/check-box';
@@ -148,7 +148,7 @@ To change the properties of an editor, bind the property that should be changed 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem } from 'devextreme-react/form';
     import { CheckBox } from 'devextreme-react/check-box';

--- a/concepts/05 UI Components/Form/25 Handle the Value Change Event.md
+++ b/concepts/05 UI Components/Form/25 Handle the Value Change Event.md
@@ -49,7 +49,7 @@ To process a new form item value, you need to handle the [fieldDataChanged](/api
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm } from 'devextreme-vue/form';
 
@@ -77,7 +77,7 @@ To process a new form item value, you need to handle the [fieldDataChanged](/api
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Form/30 Update Form Data Using the API.md
+++ b/concepts/05 UI Components/Form/30 Update Form Data Using the API.md
@@ -108,7 +108,7 @@ If you need to update form data at runtime, use two-way binding to bind the [for
         </div>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm } from 'devextreme-vue/form';
     import { DxButton } from 'devextreme-vue/button';
@@ -143,7 +143,7 @@ If you need to update form data at runtime, bind the [formData](/api-reference/1
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form } from 'devextreme-react/form';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Form/35 Generate a Data Object from Form Items.md
+++ b/concepts/05 UI Components/Form/35 Generate a Data Object from Form Items.md
@@ -62,7 +62,7 @@ Not only you can bind the Form to an existing data object, but you can also gene
         </DxForm>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxForm, DxSimpleItem } from 'devextreme-vue/form';
 
@@ -90,7 +90,7 @@ Not only you can bind the Form to an existing data object, but you can also gene
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Form, SimpleItem } from 'devextreme-react/form';
 

--- a/concepts/05 UI Components/Gallery/00 Overview.md
+++ b/concepts/05 UI Components/Gallery/00 Overview.md
@@ -61,7 +61,7 @@ The following code adds the Gallery UI component to your page. The simplest conf
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 
@@ -85,7 +85,7 @@ The following code adds the Gallery UI component to your page. The simplest conf
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
 

--- a/concepts/05 UI Components/Gallery/05 Switch Between Images/05 User Interaction.md
+++ b/concepts/05 UI Components/Gallery/05 Switch Between Images/05 User Interaction.md
@@ -55,7 +55,7 @@ To switch between images on touch-enabled devices, the user can perform the swip
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 
@@ -77,7 +77,7 @@ To switch between images on touch-enabled devices, the user can perform the swip
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
 
@@ -159,7 +159,7 @@ With the buttons and swipe gesture, the user switches images in a particular ord
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 
@@ -182,7 +182,7 @@ With the buttons and swipe gesture, the user switches images in a particular ord
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
 
@@ -262,7 +262,7 @@ Below the current image, the Gallery shows navigation bullets that allow the use
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 
@@ -284,7 +284,7 @@ Below the current image, the Gallery shows navigation bullets that allow the use
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
 

--- a/concepts/05 UI Components/Gallery/05 Switch Between Images/10 API.md
+++ b/concepts/05 UI Components/Gallery/05 Switch Between Images/10 API.md
@@ -99,7 +99,7 @@ To switch the Gallery to the next or previous image, call the [nextItem(animatio
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
     import { DxButton } from 'devextreme-vue/button';
@@ -133,7 +133,7 @@ To switch the Gallery to the next or previous image, call the [nextItem(animatio
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
     import { Button } from 'devextreme-react/button';
@@ -227,7 +227,7 @@ To navigate to a specific image, call the [goToItem(itemIndex, animation)](/api-
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 

--- a/concepts/05 UI Components/Gallery/10 Set the Initial Image.md
+++ b/concepts/05 UI Components/Gallery/10 Set the Initial Image.md
@@ -54,7 +54,7 @@ By default, the image that the Gallery UI component displays initially is the fi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 
@@ -77,7 +77,7 @@ By default, the image that the Gallery UI component displays initially is the fi
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
 
@@ -172,7 +172,7 @@ As an alternative, you can specify the initial image using its data source objec
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 
@@ -201,7 +201,7 @@ As an alternative, you can specify the initial image using its data source objec
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
 

--- a/concepts/05 UI Components/Gallery/15 Enable the Slideshow.md
+++ b/concepts/05 UI Components/Gallery/15 Enable the Slideshow.md
@@ -54,7 +54,7 @@ The Gallery UI component supports the display of images in a slideshow. To speci
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 
@@ -77,7 +77,7 @@ The Gallery UI component supports the display of images in a slideshow. To speci
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
 

--- a/concepts/05 UI Components/Gallery/20 Animate the Image Change.md
+++ b/concepts/05 UI Components/Gallery/20 Animate the Image Change.md
@@ -57,7 +57,7 @@ By default, the change of the image is animated. You can specify how long the an
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 
@@ -80,7 +80,7 @@ By default, the change of the image is animated. You can specify how long the an
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
 

--- a/concepts/05 UI Components/Gallery/25 Transform and Combine Images.md
+++ b/concepts/05 UI Components/Gallery/25 Transform and Combine Images.md
@@ -59,7 +59,7 @@ By default, the Gallery UI component displays one image at a time. To fit more i
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 
@@ -83,7 +83,7 @@ By default, the Gallery UI component displays one image at a time. To fit more i
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
 
@@ -175,7 +175,7 @@ When distributing images along the total width, the Gallery may add margins betw
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 
@@ -199,7 +199,7 @@ When distributing images along the total width, the Gallery may add margins betw
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
 
@@ -294,7 +294,7 @@ The Gallery UI component allows you to display not only the current image, but a
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 
@@ -318,7 +318,7 @@ The Gallery UI component allows you to display not only the current image, but a
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
 

--- a/concepts/05 UI Components/Gallery/30 Customize Item Appearance.md
+++ b/concepts/05 UI Components/Gallery/30 Customize Item Appearance.md
@@ -55,7 +55,7 @@ Gallery items are not sctrictly images. They can contain text or other elements 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 
@@ -80,7 +80,7 @@ Gallery items are not sctrictly images. They can contain text or other elements 
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
 
@@ -173,7 +173,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxGallery } from 'devextreme-vue/gallery';
 
@@ -196,7 +196,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Gallery } from 'devextreme-react/gallery';
 

--- a/concepts/05 UI Components/HtmlEditor/00 Getting Started with HtmlEditor/02 Create an HtmlEditor.md
+++ b/concepts/05 UI Components/HtmlEditor/00 Getting Started with HtmlEditor/02 Create an HtmlEditor.md
@@ -83,7 +83,7 @@ The HTML Editor uses the <a href="https://github.com/DevExpress/devextreme-quill
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxHtmlEditor } from 'devextreme-vue/html-editor';
 
     export default {
@@ -101,7 +101,7 @@ The HTML Editor uses the <a href="https://github.com/DevExpress/devextreme-quill
     <!-- tab: App.js -->
     import React from 'react';
     import './App.css';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { HtmlEditor } from 'devextreme-react/html-editor';
 
     const App = () => {

--- a/concepts/05 UI Components/HtmlEditor/10 Formats/60 Customize Built-In Formats and Modules/20 Extend.md
+++ b/concepts/05 UI Components/HtmlEditor/10 Formats/60 Customize Built-In Formats and Modules/20 Extend.md
@@ -69,7 +69,7 @@ In the following code, the `strike` format is extended so that the strikethrough
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxHtmlEditor } from 'devextreme-vue/html-editor';
 
@@ -102,7 +102,7 @@ In the following code, the `strike` format is extended so that the strikethrough
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { HtmlEditor } from 'devextreme-react/html-editor';
 

--- a/concepts/05 UI Components/HtmlEditor/20 Toolbar/00 Predefined Items/00 Predefined Items.md
+++ b/concepts/05 UI Components/HtmlEditor/20 Toolbar/00 Predefined Items/00 Predefined Items.md
@@ -268,7 +268,7 @@ To add a button to the toolbar, add its [name](/concepts/05%20UI%20Components/Ht
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxHtmlEditor,
@@ -288,7 +288,7 @@ To add a button to the toolbar, add its [name](/concepts/05%20UI%20Components/Ht
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { HtmlEditor, Toolbar, Item } from 'devextreme-react/html-editor';
 
@@ -395,7 +395,7 @@ To add a select box, specify the [name](/api-reference/_hidden/dxHtmlEditorToolb
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxHtmlEditor,
@@ -421,7 +421,7 @@ To add a select box, specify the [name](/api-reference/_hidden/dxHtmlEditorToolb
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { HtmlEditor, Toolbar, Item } from 'devextreme-react/html-editor';
 

--- a/concepts/05 UI Components/HtmlEditor/20 Toolbar/00 Predefined Items/10 Customize Predefined Items.md
+++ b/concepts/05 UI Components/HtmlEditor/20 Toolbar/00 Predefined Items/10 Customize Predefined Items.md
@@ -56,7 +56,7 @@ To customize a button, assign its [name](/concepts/05%20UI%20Components/HtmlEdit
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxHtmlEditor,
@@ -81,7 +81,7 @@ To customize a button, assign its [name](/concepts/05%20UI%20Components/HtmlEdit
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { HtmlEditor, Toolbar, Item } from 'devextreme-react/html-editor';
 
@@ -185,7 +185,7 @@ To customize a select box, specify [select box properties](/api-reference/10%20U
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxHtmlEditor,
@@ -211,7 +211,7 @@ To customize a select box, specify [select box properties](/api-reference/10%20U
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { HtmlEditor, Toolbar, Item } from 'devextreme-react/html-editor';
 

--- a/concepts/05 UI Components/HtmlEditor/20 Toolbar/30 Relocate an Item.md
+++ b/concepts/05 UI Components/HtmlEditor/20 Toolbar/30 Relocate an Item.md
@@ -76,7 +76,7 @@ This property accepts the *"before"*, *"center"*, and *"after"* values that spec
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxHtmlEditor,
@@ -96,7 +96,7 @@ This property accepts the *"before"*, *"center"*, and *"after"* values that spec
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { HtmlEditor, Toolbar, Item } from 'devextreme-react/html-editor';
 
@@ -194,7 +194,7 @@ If the toolbar cannot fit all the items, some of them are collected in the overf
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxHtmlEditor,
@@ -214,7 +214,7 @@ If the toolbar cannot fit all the items, some of them are collected in the overf
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { HtmlEditor, Toolbar, Item } from 'devextreme-react/html-editor';
 

--- a/concepts/05 UI Components/HtmlEditor/20 Toolbar/35 Relocate the Toolbar.md
+++ b/concepts/05 UI Components/HtmlEditor/20 Toolbar/35 Relocate the Toolbar.md
@@ -56,7 +56,7 @@ In the following code, the toolbar is placed in a separate `<div>` under the HTM
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxHtmlEditor,
@@ -74,7 +74,7 @@ In the following code, the toolbar is placed in a separate `<div>` under the HTM
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { HtmlEditor, Toolbar } from 'devextreme-react/html-editor';
 

--- a/concepts/05 UI Components/List/00 Getting Started with List/02 Create a List.md
+++ b/concepts/05 UI Components/List/00 Getting Started with List/02 Create a List.md
@@ -87,7 +87,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxList } from 'devextreme-vue/list';
 
@@ -104,7 +104,7 @@
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         List

--- a/concepts/05 UI Components/List/00 Getting Started with List/03 Bind the List to Data.md
+++ b/concepts/05 UI Components/List/00 Getting Started with List/03 Bind the List to Data.md
@@ -335,7 +335,7 @@ The List can load data from different data source types. To use a local array, a
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         List

--- a/concepts/05 UI Components/List/00 Getting Started with List/04 Select Items.md
+++ b/concepts/05 UI Components/List/00 Getting Started with List/04 Select Items.md
@@ -37,7 +37,7 @@ The List supports *"single"*, *"multiple"*, and *"all"* item selection modes. To
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     function App() {
         return (

--- a/concepts/05 UI Components/List/00 Getting Started with List/05 Group Items.md
+++ b/concepts/05 UI Components/List/00 Getting Started with List/05 Group Items.md
@@ -82,7 +82,7 @@ You can also display a hierarchy in a list bound to a flat array. In this case, 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     // ...    
     import { products } from './products';

--- a/concepts/05 UI Components/List/00 Getting Started with List/06 Search Items.md
+++ b/concepts/05 UI Components/List/00 Getting Started with List/06 Search Items.md
@@ -40,7 +40,7 @@ To add a search bar to the List, set the [searchEnabled](/api-reference/10%20UI%
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     function App() {
         return (

--- a/concepts/05 UI Components/List/00 Getting Started with List/08 Delete Items.md
+++ b/concepts/05 UI Components/List/00 Getting Started with List/08 Delete Items.md
@@ -37,7 +37,7 @@ To allow users to delete items from the List, set the [allowItemDeleting](/api-r
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     function App() {
         return (

--- a/concepts/05 UI Components/List/05 Customize Item Appearance.md
+++ b/concepts/05 UI Components/List/05 Customize Item Appearance.md
@@ -50,7 +50,7 @@ For a minor customization of List items, you can define [specific fields](/api-r
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxList from 'devextreme-vue/list';
 
@@ -76,7 +76,7 @@ For a minor customization of List items, you can define [specific fields](/api-r
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
 
@@ -172,7 +172,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxList from 'devextreme-vue/list';
 
@@ -200,7 +200,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
 

--- a/concepts/05 UI Components/List/08 Paging.md
+++ b/concepts/05 UI Components/List/08 Paging.md
@@ -50,7 +50,7 @@ Paging properties are set in the [DataSource](/api-reference/30%20Data%20Layer/D
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxList from 'devextreme-vue/list';
     import DataSource from 'devextreme/data/data_source';
@@ -77,7 +77,7 @@ Paging properties are set in the [DataSource](/api-reference/30%20Data%20Layer/D
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
     import DataSource from 'devextreme/data/data_source';

--- a/concepts/05 UI Components/List/14 Grouping/01 In the Data Source.md
+++ b/concepts/05 UI Components/List/14 Grouping/01 In the Data Source.md
@@ -85,7 +85,7 @@ Items in the List are grouped if they are grouped in the data source. The List r
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxList from 'devextreme-vue/list';
 
@@ -121,7 +121,7 @@ Items in the List are grouped if they are grouped in the data source. The List r
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
 
@@ -270,7 +270,7 @@ If objects in your data source miss the **key** and **items** fields, use the [m
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxList from 'devextreme-vue/list';
     import DataSource from 'devextreme/data/data_source';
@@ -317,7 +317,7 @@ If objects in your data source miss the **key** and **items** fields, use the [m
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
     import DataSource from 'devextreme/data/data_source';
@@ -447,7 +447,7 @@ If your data is not grouped at all, you can group it using the [group](/api-refe
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxList from 'devextreme-vue/list';
     import DataSource from 'devextreme/data/data_source';
@@ -482,7 +482,7 @@ If your data is not grouped at all, you can group it using the [group](/api-refe
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
     import DataSource from 'devextreme/data/data_source';

--- a/concepts/05 UI Components/List/14 Grouping/05 Customize Group Headers.md
+++ b/concepts/05 UI Components/List/14 Grouping/05 Customize Group Headers.md
@@ -119,7 +119,7 @@ You can define a [groupTemplate](/api-reference/10%20UI%20Components/dxList/1%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxList from 'devextreme-vue/list';
     import DataSource from 'devextreme/data/data_source';
@@ -167,7 +167,7 @@ You can define a [groupTemplate](/api-reference/10%20UI%20Components/dxList/1%20
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
     import DataSource from 'devextreme/data/data_source';

--- a/concepts/05 UI Components/List/14 Grouping/10 Expand and Collapse a Group.md
+++ b/concepts/05 UI Components/List/14 Grouping/10 Expand and Collapse a Group.md
@@ -66,7 +66,7 @@ If the user should be able to collapse or expand a group in the List, set the [c
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxList from 'devextreme-vue/list';
 
@@ -97,7 +97,7 @@ If the user should be able to collapse or expand a group in the List, set the [c
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
 
@@ -173,7 +173,7 @@ To collapse or expand a specific group programmatically, call the [collapseGroup
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxList from 'devextreme-vue/list';
 
@@ -209,7 +209,7 @@ To collapse or expand a specific group programmatically, call the [collapseGroup
 
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
     // ...

--- a/concepts/05 UI Components/List/20 Scrolling/01 User Interaction.md
+++ b/concepts/05 UI Components/List/20 Scrolling/01 User Interaction.md
@@ -45,7 +45,7 @@ An end user can scroll the List with a swipe gesture and with the scrollbar. Alt
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -60,7 +60,7 @@ An end user can scroll the List with a swipe gesture and with the scrollbar. Alt
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     export default function App() {
@@ -118,7 +118,7 @@ The List employs native scrolling on most platforms, except non-Mac desktops and
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -133,7 +133,7 @@ The List employs native scrolling on most platforms, except non-Mac desktops and
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     export default function App() {
@@ -193,7 +193,7 @@ If simulated scrolling is used, you can specify when to show the scrollbar. For 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -208,7 +208,7 @@ If simulated scrolling is used, you can specify when to show the scrollbar. For 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     export default function App() {
@@ -266,7 +266,7 @@ On mobile devices, the user can pull the List to scroll it slightly further than
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -281,7 +281,7 @@ On mobile devices, the user can pull the List to scroll it slightly further than
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     export default function App() {
@@ -338,7 +338,7 @@ If you want to disable scrolling completely, assign **false** to the [scrollingE
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -353,7 +353,7 @@ If you want to disable scrolling completely, assign **false** to the [scrollingE
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     export default function App() {

--- a/concepts/05 UI Components/List/20 Scrolling/05 API.md
+++ b/concepts/05 UI Components/List/20 Scrolling/05 API.md
@@ -128,7 +128,7 @@ The following examples shows how to call these methods.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     const listRefKey = "my-list";
@@ -188,7 +188,7 @@ The following examples shows how to call these methods.
 
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
     // ...

--- a/concepts/05 UI Components/List/20 Scrolling/10 Events.md
+++ b/concepts/05 UI Components/List/20 Scrolling/10 Events.md
@@ -51,7 +51,7 @@ To execute certain commands when the List is scrolled, handle the [scroll](/api-
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -74,7 +74,7 @@ To execute certain commands when the List is scrolled, handle the [scroll](/api-
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     const onListScroll = (e) => {

--- a/concepts/05 UI Components/List/25 Selection/01 User Interaction.md
+++ b/concepts/05 UI Components/List/25 Selection/01 User Interaction.md
@@ -41,7 +41,7 @@ To enable selection in the List component, use the [selectionMode](/api-referenc
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -56,7 +56,7 @@ To enable selection in the List component, use the [selectionMode](/api-referenc
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     export default function App() {
@@ -114,7 +114,7 @@ If you want users to select List items only by checking checkboxes, assign `fals
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -129,7 +129,7 @@ If you want users to select List items only by checking checkboxes, assign `fals
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     export default function App() {
@@ -185,7 +185,7 @@ When data in the List is [paginated](/concepts/05%20UI%20Components/List/08%20Pa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -200,7 +200,7 @@ When data in the List is [paginated](/concepts/05%20UI%20Components/List/08%20Pa
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     export default function App() {

--- a/concepts/05 UI Components/List/25 Selection/05 API.md
+++ b/concepts/05 UI Components/List/25 Selection/05 API.md
@@ -74,7 +74,7 @@ To configure the initial selection or access selected item keys, use the [select
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -105,7 +105,7 @@ To configure the initial selection or access selected item keys, use the [select
 
     <!-- tab: App.js -->
     import React, { useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
 

--- a/concepts/05 UI Components/List/25 Selection/10 Events.md
+++ b/concepts/05 UI Components/List/25 Selection/10 Events.md
@@ -59,7 +59,7 @@ The List UI component fires the [selectionChanged](/api-reference/10%20UI%20Comp
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -85,7 +85,7 @@ The List UI component fires the [selectionChanged](/api-reference/10%20UI%20Comp
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
 

--- a/concepts/05 UI Components/List/27 Searching.md
+++ b/concepts/05 UI Components/List/27 Searching.md
@@ -70,7 +70,7 @@ Searching is disabled in the List UI component by default. Assign **true** to th
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     const listData = [
@@ -95,7 +95,7 @@ Searching is disabled in the List UI component by default. Assign **true** to th
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     const listData = [
@@ -213,7 +213,7 @@ You can customize the search panel by specifying the [searchEditorOptions](/api-
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList, {
         DxSearchEditorOptions
     } from 'devextreme-vue/list';
@@ -231,7 +231,7 @@ You can customize the search panel by specifying the [searchEditorOptions](/api-
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List, {
         SearchEditorOptions
     } from 'devextreme-react/list';

--- a/concepts/05 UI Components/List/30 Item Reordering/01 User Interaction.md
+++ b/concepts/05 UI Components/List/30 Item Reordering/01 User Interaction.md
@@ -48,7 +48,7 @@ If you want to allow the user to reorder items on the List, define the [itemDrag
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList, {
         DxItemDragging
     } from 'devextreme-vue/list';
@@ -66,7 +66,7 @@ If you want to allow the user to reorder items on the List, define the [itemDrag
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List, {
         ItemDragging
     } from 'devextreme-react/list';

--- a/concepts/05 UI Components/List/30 Item Reordering/05 API.md
+++ b/concepts/05 UI Components/List/30 Item Reordering/05 API.md
@@ -59,7 +59,7 @@ Pass the index to the [reorderItem(itemIndex, toItemIndex)](/api-reference/10%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     const listRefKey = "my-list";
@@ -100,7 +100,7 @@ Pass the index to the [reorderItem(itemIndex, toItemIndex)](/api-reference/10%20
 
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
     // ...

--- a/concepts/05 UI Components/List/30 Item Reordering/10 Events.md
+++ b/concepts/05 UI Components/List/30 Item Reordering/10 Events.md
@@ -57,7 +57,7 @@ To execute certain commands when an item changes its position, handle the [itemR
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -81,7 +81,7 @@ To execute certain commands when an item changes its position, handle the [itemR
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     const onItemReordered = (e) => {

--- a/concepts/05 UI Components/List/35 Item Deletion/01 User Interaction.md
+++ b/concepts/05 UI Components/List/35 Item Deletion/01 User Interaction.md
@@ -45,7 +45,7 @@ To allow the user to delete items from the List, set the [allowItemDeleting](/ap
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -60,7 +60,7 @@ To allow the user to delete items from the List, set the [allowItemDeleting](/ap
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     export default function App() {

--- a/concepts/05 UI Components/List/35 Item Deletion/05 API.md
+++ b/concepts/05 UI Components/List/35 Item Deletion/05 API.md
@@ -46,7 +46,7 @@ You can delete a list item by its index. Pass the index to the [deleteItem(itemI
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     const listRefKey = "my-list";
@@ -82,7 +82,7 @@ You can delete a list item by its index. Pass the index to the [deleteItem(itemI
 
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
     // ...

--- a/concepts/05 UI Components/List/35 Item Deletion/10 Events.md
+++ b/concepts/05 UI Components/List/35 Item Deletion/10 Events.md
@@ -66,7 +66,7 @@ To execute certain commands before or after an item is deleted from the List, ha
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     export default {
@@ -95,7 +95,7 @@ To execute certain commands before or after an item is deleted from the List, ha
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     const onItemDeleting = (e) => {

--- a/concepts/05 UI Components/List/40 Item Context Menu.md
+++ b/concepts/05 UI Components/List/40 Item Context Menu.md
@@ -113,7 +113,7 @@ If you want to offer the user a set of commands related to a List item, you can 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList, {
         DxMenuItem
     } from 'devextreme-vue/list';
@@ -154,7 +154,7 @@ If you want to offer the user a set of commands related to a List item, you can 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List, {
         MenuItem
     } from 'devextreme-react/list';

--- a/concepts/05 UI Components/List/45 End-User Interaction/01 Touch-Screen Gestures.md
+++ b/concepts/05 UI Components/List/45 End-User Interaction/01 Touch-Screen Gestures.md
@@ -62,7 +62,7 @@ Swipe can be used to [delete an item](/concepts/05%20UI%20Components/List/35%20I
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import DxList from 'devextreme-vue/list';
 
         export default {
@@ -82,7 +82,7 @@ Swipe can be used to [delete an item](/concepts/05%20UI%20Components/List/35%20I
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import List from 'devextreme-react/list';
 
         const onItemSwipe = (e) => {
@@ -146,7 +146,7 @@ Long tap can be used to access the commands of the [context menu](/concepts/05%2
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import DxList from 'devextreme-vue/list';
 
         export default {
@@ -161,7 +161,7 @@ Long tap can be used to access the commands of the [context menu](/concepts/05%2
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import List from 'devextreme-react/list';
 
         export default function App() {
@@ -219,7 +219,7 @@ This gesture refreshes data in the List. To enable it, assign **true** to the [p
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import DxList from 'devextreme-vue/list';
 
         export default {
@@ -234,7 +234,7 @@ This gesture refreshes data in the List. To enable it, assign **true** to the [p
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import List from 'devextreme-react/list';
 
         export default function App() {

--- a/concepts/05 UI Components/List/45 End-User Interaction/05 Universal Actions.md
+++ b/concepts/05 UI Components/List/45 End-User Interaction/05 Universal Actions.md
@@ -61,7 +61,7 @@ Universal actions are those actions that raise the same event despite being perf
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import DxList from 'devextreme-vue/list';
 
         export default {
@@ -81,7 +81,7 @@ Universal actions are those actions that raise the same event despite being perf
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import List from 'devextreme-react/list';
 
     const onItemClick = (e) => {

--- a/concepts/05 UI Components/LoadIndicator/00 Overview.md
+++ b/concepts/05 UI Components/LoadIndicator/00 Overview.md
@@ -55,7 +55,7 @@ The following code adds a simple LoadIndicator to your page. You can change the 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLoadIndicator } from 'devextreme-vue/load-indicator';
 
@@ -74,7 +74,7 @@ The following code adds a simple LoadIndicator to your page. You can change the 
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { LoadIndicator } from 'devextreme-react/load-indicator';
 
@@ -147,7 +147,7 @@ If you need to use a custom image in the LoadIndicator, assign its URL to the [i
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLoadIndicator } from 'devextreme-vue/load-indicator';
 
@@ -167,7 +167,7 @@ If you need to use a custom image in the LoadIndicator, assign its URL to the [i
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { LoadIndicator } from 'devextreme-react/load-indicator';
 

--- a/concepts/05 UI Components/LoadIndicator/05 Show and Hide Using the API.md
+++ b/concepts/05 UI Components/LoadIndicator/05 Show and Hide Using the API.md
@@ -66,7 +66,7 @@ To specify whether the LoadIndicator is shown, change the [visible](/api-referen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLoadIndicator } from 'devextreme-vue/load-indicator';
     import { DxButton } from 'devextreme-vue/button';
@@ -92,7 +92,7 @@ To specify whether the LoadIndicator is shown, change the [visible](/api-referen
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { LoadIndicator } from 'devextreme-react/load-indicator';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/Lookup/00 Getting Started with Lookup/05 Create a Lookup Component.md
+++ b/concepts/05 UI Components/Lookup/00 Getting Started with Lookup/05 Create a Lookup Component.md
@@ -73,7 +73,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxLookup } from 'devextreme-vue/lookup';
 
     export default {
@@ -90,7 +90,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
 

--- a/concepts/05 UI Components/Lookup/03 Data Binding/05 Simple Array/05 Array Only.md
+++ b/concepts/05 UI Components/Lookup/03 Data Binding/05 Simple Array/05 Array Only.md
@@ -39,7 +39,7 @@ Bind the Lookup to an array by passing it to the [dataSource](/api-reference/10%
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
 
@@ -58,7 +58,7 @@ Bind the Lookup to an array by passing it to the [dataSource](/api-reference/10%
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
 
@@ -135,7 +135,7 @@ Bind the Lookup to an array by passing it to the [dataSource](/api-reference/10%
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
 
@@ -159,7 +159,7 @@ Bind the Lookup to an array by passing it to the [dataSource](/api-reference/10%
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
 
@@ -249,7 +249,7 @@ You can create a [Query](/concepts/70%20Data%20Binding/5%20Data%20Layer/6%20Quer
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
     import query from "devextreme/data/query";
@@ -279,7 +279,7 @@ You can create a [Query](/concepts/70%20Data%20Binding/5%20Data%20Layer/6%20Quer
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
     import query from "devextreme/data/query";

--- a/concepts/05 UI Components/Lookup/03 Data Binding/05 Simple Array/10 ArrayStore.md
+++ b/concepts/05 UI Components/Lookup/03 Data Binding/05 Simple Array/10 ArrayStore.md
@@ -57,7 +57,7 @@ Extend a JavaScript array's functionality by placing it into an [ArrayStore](/ap
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
     import ArrayStore from "devextreme/data/array_store";
@@ -84,7 +84,7 @@ Extend a JavaScript array's functionality by placing it into an [ArrayStore](/ap
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
     import ArrayStore from "devextreme/data/array_store";
@@ -181,7 +181,7 @@ Data kept in the **ArrayStore** can be processed in a [DataSource](/api-referenc
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
     import DataSource from "devextreme/data/data_source";
@@ -206,7 +206,7 @@ Data kept in the **ArrayStore** can be processed in a [DataSource](/api-referenc
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
     import DataSource from "devextreme/data/data_source";

--- a/concepts/05 UI Components/Lookup/03 Data Binding/10 JSON Data.md
+++ b/concepts/05 UI Components/Lookup/03 Data Binding/10 JSON Data.md
@@ -45,7 +45,7 @@ Load JSON data by assigning its URL to the [dataSource](/api-reference/10%20UI%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
 
@@ -59,7 +59,7 @@ Load JSON data by assigning its URL to the [dataSource](/api-reference/10%20UI%2
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
 
@@ -121,7 +121,7 @@ Note that you can also use a JSONP callback parameter.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
 
@@ -135,7 +135,7 @@ Note that you can also use a JSONP callback parameter.
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
 

--- a/concepts/05 UI Components/Lookup/03 Data Binding/15 OData Service.md
+++ b/concepts/05 UI Components/Lookup/03 Data Binding/15 OData Service.md
@@ -52,7 +52,7 @@ Use the [ODataStore](/api-reference/30%20Data%20Layer/ODataStore '/Documentation
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
     import ODataStore from "devextreme/data/odata/store";
@@ -75,7 +75,7 @@ Use the [ODataStore](/api-reference/30%20Data%20Layer/ODataStore '/Documentation
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
     import ODataStore from "devextreme/data/odata/store";
@@ -168,7 +168,7 @@ Data kept in the **ODataStore** can be processed in a [DataSource](/api-referenc
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
     import DataSource from "devextreme/data/data_source";
@@ -195,7 +195,7 @@ Data kept in the **ODataStore** can be processed in a [DataSource](/api-referenc
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
     import DataSource from "devextreme/data/data_source";

--- a/concepts/05 UI Components/Lookup/03 Data Binding/16 Web API Service.md
+++ b/concepts/05 UI Components/Lookup/03 Data Binding/16 Web API Service.md
@@ -54,7 +54,7 @@ DevExtreme provides the <a href="https://github.com/DevExpress/DevExtreme.AspNet
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
     import { createStore } from "devextreme-aspnet-data-nojquery";
@@ -79,7 +79,7 @@ DevExtreme provides the <a href="https://github.com/DevExpress/DevExtreme.AspNet
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
     import { createStore } from "devextreme-aspnet-data-nojquery";

--- a/concepts/05 UI Components/Lookup/03 Data Binding/17 PHP Service.md
+++ b/concepts/05 UI Components/Lookup/03 Data Binding/17 PHP Service.md
@@ -54,7 +54,7 @@ DevExtreme provides the <a href="https://github.com/DevExpress/DevExtreme-PHP-Da
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
     import { createStore } from "devextreme-aspnet-data-nojquery";
@@ -79,7 +79,7 @@ DevExtreme provides the <a href="https://github.com/DevExpress/DevExtreme-PHP-Da
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
     import { createStore } from "devextreme-aspnet-data-nojquery";

--- a/concepts/05 UI Components/Lookup/03 Data Binding/18 MongoDB Service.md
+++ b/concepts/05 UI Components/Lookup/03 Data Binding/18 MongoDB Service.md
@@ -54,7 +54,7 @@ Use the third-party <a href="https://github.com/oliversturm/devextreme-query-mon
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
     import { createStore } from "devextreme-aspnet-data-nojquery";
@@ -79,7 +79,7 @@ Use the third-party <a href="https://github.com/oliversturm/devextreme-query-mon
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
     import { createStore } from "devextreme-aspnet-data-nojquery";

--- a/concepts/05 UI Components/Lookup/03 Data Binding/30 Access the DataSource.md
+++ b/concepts/05 UI Components/Lookup/03 Data Binding/30 Access the DataSource.md
@@ -33,7 +33,7 @@ Regardless of the data source you use, the Lookup always wraps it in a [DataSour
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
 
@@ -52,7 +52,7 @@ Regardless of the data source you use, the Lookup always wraps it in a [DataSour
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
 

--- a/concepts/05 UI Components/Lookup/10 Enable Grouping.md
+++ b/concepts/05 UI Components/Lookup/10 Enable Grouping.md
@@ -59,7 +59,7 @@ The Lookup can organize items in groups. If you use a simple array as a data sou
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
 
@@ -85,7 +85,7 @@ The Lookup can organize items in groups. If you use a simple array as a data sou
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
 
@@ -190,7 +190,7 @@ If you use the [DevExtreme DataSource](/api-reference/30%20Data%20Layer/DataSour
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
     import DataSource from "devextreme/data/data_source";
@@ -222,7 +222,7 @@ If you use the [DevExtreme DataSource](/api-reference/30%20Data%20Layer/DataSour
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
     import DataSource from "devextreme/data/data_source";
@@ -335,7 +335,7 @@ To customize group headers, specify a [groupTemplate](/api-reference/10%20UI%20C
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
 
@@ -361,7 +361,7 @@ To customize group headers, specify a [groupTemplate](/api-reference/10%20UI%20C
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
     import DataSource from "devextreme/data/data_source";

--- a/concepts/05 UI Components/Lookup/20 Customize the Appearance/05 Customize Item Appearance.md
+++ b/concepts/05 UI Components/Lookup/20 Customize the Appearance/05 Customize Item Appearance.md
@@ -54,7 +54,7 @@ For a minor customization of Lookup items, you can define [specific fields](/api
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
 
@@ -77,7 +77,7 @@ For a minor customization of Lookup items, you can define [specific fields](/api
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
 
@@ -198,7 +198,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
 
@@ -227,7 +227,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
 
@@ -361,7 +361,7 @@ Using similar techniques, you can customize the input field of the Lookup. The t
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup } from 'devextreme-vue/lookup';
 
@@ -390,7 +390,7 @@ Using similar techniques, you can customize the input field of the Lookup. The t
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup } from 'devextreme-react/lookup';
 

--- a/concepts/05 UI Components/Lookup/20 Customize the Appearance/08 Customize the Drop-Down Menu.md
+++ b/concepts/05 UI Components/Lookup/20 Customize the Appearance/08 Customize the Drop-Down Menu.md
@@ -62,7 +62,7 @@ To customize the Popup or Popover, use the [dropDownOptions](/api-reference/10%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup, DxDropDownOptions } from 'devextreme-vue/lookup';
 
@@ -87,7 +87,7 @@ To customize the Popup or Popover, use the [dropDownOptions](/api-reference/10%2
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup, DropDownOptions } from 'devextreme-react/lookup';
 
@@ -194,7 +194,7 @@ To change the size of the drop-down menu and position it against a specific elem
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup, DxDropDownOptions, DxPosition } from 'devextreme-vue/lookup';
 
@@ -220,7 +220,7 @@ To change the size of the drop-down menu and position it against a specific elem
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup, DropDownOptions, Position } from 'devextreme-react/lookup';
 
@@ -326,7 +326,7 @@ The drop-down menu can have a title. Use the **dropDownOptions**.[title](/api-re
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxLookup, DxDropDownOptions } from 'devextreme-vue/lookup';
 
@@ -351,7 +351,7 @@ The drop-down menu can have a title. Use the **dropDownOptions**.[title](/api-re
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Lookup, DropDownOptions } from 'devextreme-react/lookup';
 

--- a/concepts/05 UI Components/Menu/00 Getting Started with Menu/05 Create Base Menu Level.md
+++ b/concepts/05 UI Components/Menu/00 Getting Started with Menu/05 Create Base Menu Level.md
@@ -134,7 +134,7 @@ To create a base Menu level, define the component in the markup and populate it 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Menu, { Item } from 'devextreme-react/menu';
 

--- a/concepts/05 UI Components/Menu/00 Getting Started with Menu/20 Enable Menu Adaptivity.md
+++ b/concepts/05 UI Components/Menu/00 Getting Started with Menu/20 Enable Menu Adaptivity.md
@@ -153,7 +153,7 @@ In the code below, the [CheckBox](/api-reference/10%20UI%20Components/dxCheckBox
     <!-- tab: App.js -->
     import React, { useState, useCallback } from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Menu, { Item } from 'devextreme-react/menu';
     import CheckBox from 'devextreme-react/check-box';

--- a/concepts/05 UI Components/Menu/03 Access the Clicked Item.md
+++ b/concepts/05 UI Components/Menu/03 Access the Clicked Item.md
@@ -48,7 +48,7 @@ To access the clicked item, handle the [itemClick](/api-reference/10%20UI%20Comp
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMenu from 'devextreme-vue/menu';
 
@@ -69,7 +69,7 @@ To access the clicked item, handle the [itemClick](/api-reference/10%20UI%20Comp
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Menu } from 'devextreme-react/menu';
 

--- a/concepts/05 UI Components/Menu/05 Customize Item Appearance.md
+++ b/concepts/05 UI Components/Menu/05 Customize Item Appearance.md
@@ -70,7 +70,7 @@ For a minor customization of Menu items, you can define [specific fields](/api-r
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMenu from 'devextreme-vue/menu';
 
@@ -102,7 +102,7 @@ For a minor customization of Menu items, you can define [specific fields](/api-r
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Menu } from 'devextreme-react/menu';
 
@@ -216,7 +216,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
         </DxMenu>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMenu from 'devextreme-vue/menu';
 
@@ -248,7 +248,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Menu } from 'devextreme-react/menu';
 

--- a/concepts/05 UI Components/Menu/10 Change the Orientation.md
+++ b/concepts/05 UI Components/Menu/10 Change the Orientation.md
@@ -44,7 +44,7 @@ To arrange items on the menu panel in a row (horizontally) or in a column (verti
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMenu from 'devextreme-vue/menu';
 
@@ -59,7 +59,7 @@ To arrange items on the menu panel in a row (horizontally) or in a column (verti
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Menu } from 'devextreme-react/menu';
 
@@ -129,7 +129,7 @@ When the UI component is positioned at the bottom or at the left side, you may w
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMenu from 'devextreme-vue/menu';
 
@@ -144,7 +144,7 @@ When the UI component is positioned at the bottom or at the left side, you may w
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Menu } from 'devextreme-react/menu';
 

--- a/concepts/05 UI Components/MultiView/00 Overview.md
+++ b/concepts/05 UI Components/MultiView/00 Overview.md
@@ -60,7 +60,7 @@ In the most simple case, the MultiView UI component requires only the [dataSourc
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMultiView from 'devextreme-vue/multi-view';
 
@@ -84,7 +84,7 @@ In the most simple case, the MultiView UI component requires only the [dataSourc
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { MultiView } from 'devextreme-react/multi-view';
 

--- a/concepts/05 UI Components/MultiView/05 Customize Item Appearance.md
+++ b/concepts/05 UI Components/MultiView/05 Customize Item Appearance.md
@@ -93,7 +93,7 @@ To customize views in the MultiView, define an [itemTemplate](/api-reference/10%
         </DxMultiView>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMultiView from 'devextreme-vue/multi-view';
 
@@ -124,7 +124,7 @@ To customize views in the MultiView, define an [itemTemplate](/api-reference/10%
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { MultiView } from 'devextreme-react/multi-view';
 
@@ -211,7 +211,7 @@ You can also customize individual views. Declare them using the [dxItem](/api-re
         </DxMultiView>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMultiView, { DxItem } from 'devextreme-vue/multi-view';
 
@@ -229,7 +229,7 @@ You can also customize individual views. Declare them using the [dxItem](/api-re
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { MultiView, Item } from 'devextreme-react/multi-view';
 

--- a/concepts/05 UI Components/MultiView/10 Switch Between Views.md
+++ b/concepts/05 UI Components/MultiView/10 Switch Between Views.md
@@ -45,7 +45,7 @@ By default, an end user can switch between views by swiping. Assign **false** to
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMultiView from 'devextreme-vue/multi-view';
 
@@ -60,7 +60,7 @@ By default, an end user can switch between views by swiping. Assign **false** to
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { MultiView } from 'devextreme-react/multi-view';
 
@@ -137,7 +137,7 @@ You can switch the views from code by changing the [selectedIndex](/api-referenc
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMultiView from 'devextreme-vue/multi-view';
 
@@ -166,7 +166,7 @@ You can switch the views from code by changing the [selectedIndex](/api-referenc
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { MultiView } from 'devextreme-react/multi-view';
 
@@ -257,7 +257,7 @@ By default, the MultiView UI component animates switching between views. You can
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMultiView from 'devextreme-vue/multi-view';
 
@@ -272,7 +272,7 @@ By default, the MultiView UI component animates switching between views. You can
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { MultiView } from 'devextreme-react/multi-view';
 

--- a/concepts/05 UI Components/MultiView/15 Loop the Views.md
+++ b/concepts/05 UI Components/MultiView/15 Loop the Views.md
@@ -53,7 +53,7 @@ The MultiView UI component can display views in a loop. The loop mode enables an
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMultiView from 'devextreme-vue/multi-view';
 
@@ -76,7 +76,7 @@ The MultiView UI component can display views in a loop. The loop mode enables an
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { MultiView } from 'devextreme-react/multi-view';
 

--- a/concepts/05 UI Components/PieChart/00 Getting Started with PieChart/05 Create a PieChart.md
+++ b/concepts/05 UI Components/PieChart/00 Getting Started with PieChart/05 Create a PieChart.md
@@ -79,7 +79,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxPieChart } from 'devextreme-vue/pie-chart';
 
     export default {
@@ -96,7 +96,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { PieChart } from 'devextreme-react/pie-chart';
 

--- a/concepts/05 UI Components/RangeSlider/00 Overview.md
+++ b/concepts/05 UI Components/RangeSlider/00 Overview.md
@@ -57,7 +57,7 @@ The following code adds a simple RangeSlider to your page. The **start** and **e
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxRangeSlider } from 'devextreme-vue/range-slider';
 
@@ -77,7 +77,7 @@ The following code adds a simple RangeSlider to your page. The **start** and **e
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { RangeSlider } from 'devextreme-react/range-slider';
 
@@ -174,7 +174,7 @@ In addition, you can specify the step of RangeSlider values using the [step](/ap
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxRangeSlider } from 'devextreme-vue/range-slider';
 
@@ -194,7 +194,7 @@ In addition, you can specify the step of RangeSlider values using the [step](/ap
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { RangeSlider } from 'devextreme-react/range-slider';
 

--- a/concepts/05 UI Components/RangeSlider/05 Customize Component Appearance.md
+++ b/concepts/05 UI Components/RangeSlider/05 Customize Component Appearance.md
@@ -56,7 +56,7 @@ The RangeSlider can display labels for the [min](/api-reference/10%20UI%20Compon
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxRangeSlider, DxLabel } from 'devextreme-vue/range-slider';
 
@@ -76,7 +76,7 @@ The RangeSlider can display labels for the [min](/api-reference/10%20UI%20Compon
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { RangeSlider, Label } from 'devextreme-react/range-slider';
 
@@ -162,7 +162,7 @@ The RangeSlider can also display a tooltip for the slider handles. To configure 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxRangeSlider, DxTooltip } from 'devextreme-vue/range-slider';
 
@@ -182,7 +182,7 @@ The RangeSlider can also display a tooltip for the slider handles. To configure 
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { RangeSlider, Tooltip } from 'devextreme-react/range-slider';
 
@@ -249,7 +249,7 @@ To specify whether or not the selected range should be highlighted, use the **sh
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxRangeSlider } from 'devextreme-vue/range-slider';
 
@@ -263,7 +263,7 @@ To specify whether or not the selected range should be highlighted, use the **sh
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { RangeSlider } from 'devextreme-react/range-slider';
 

--- a/concepts/05 UI Components/RangeSlider/10 Handle the Value Change Event.md
+++ b/concepts/05 UI Components/RangeSlider/10 Handle the Value Change Event.md
@@ -55,7 +55,7 @@ To process new RangeSlider values, you need to handle the value change event. If
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxRangeSlider } from 'devextreme-vue/range-slider';
 
@@ -82,7 +82,7 @@ To process new RangeSlider values, you need to handle the value change event. If
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { RangeSlider } from 'devextreme-react/range-slider';
 

--- a/concepts/05 UI Components/ResponsiveBox/00 Overview.md
+++ b/concepts/05 UI Components/ResponsiveBox/00 Overview.md
@@ -202,7 +202,7 @@ The following code creates a simple ResponsiveBox. The UI component defines an o
         </DxResponsiveBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxResponsiveBox, DxItem, DxLocation, DxCol, DxRow } from 'devextreme-vue/responsive-box';
 
@@ -234,7 +234,7 @@ The following code creates a simple ResponsiveBox. The UI component defines an o
 
     <!--HTML-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import ResponsiveBox, { Row, Col, Item, Location } from 'devextreme-react/responsive-box';
 

--- a/concepts/05 UI Components/ResponsiveBox/05 Size Qualifiers.md
+++ b/concepts/05 UI Components/ResponsiveBox/05 Size Qualifiers.md
@@ -91,7 +91,7 @@ If a size qualifier should be identified with other screen width values, use the
         </DxResponsiveBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxResponsiveBox } from 'devextreme-vue/responsive-box';
 
@@ -121,7 +121,7 @@ If a size qualifier should be identified with other screen width values, use the
 
     <!--HTML-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import ResponsiveBox from 'devextreme-react/responsive-box';
 

--- a/concepts/05 UI Components/ResponsiveBox/10 Create the Layout Grid.md
+++ b/concepts/05 UI Components/ResponsiveBox/10 Create the Layout Grid.md
@@ -68,7 +68,7 @@ All ResponsiveBox elements are arranged in a layout grid according to the [rows]
         </DxResponsiveBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxResponsiveBox, DxCol, DxRow } from 'devextreme-vue/responsive-box';
 
@@ -88,7 +88,7 @@ All ResponsiveBox elements are arranged in a layout grid according to the [rows]
 
     <!--HTML-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import ResponsiveBox, { Row, Col } from 'devextreme-react/responsive-box';
 
@@ -211,7 +211,7 @@ The collections of rows and columns may differ depending on the screen's [size q
         </DxResponsiveBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxResponsiveBox, DxCol, DxRow } from 'devextreme-vue/responsive-box';
 
@@ -231,7 +231,7 @@ The collections of rows and columns may differ depending on the screen's [size q
 
     <!--HTML-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import ResponsiveBox, { Row, Col } from 'devextreme-react/responsive-box';
 

--- a/concepts/05 UI Components/ResponsiveBox/15 Arrange Layout Elements.md
+++ b/concepts/05 UI Components/ResponsiveBox/15 Arrange Layout Elements.md
@@ -66,7 +66,7 @@ All layout elements are arranged against a [layout grid](/concepts/05%20UI%20Com
         </DxResponsiveBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxResponsiveBox, DxCol, DxRow } from 'devextreme-vue/responsive-box';
 
@@ -86,7 +86,7 @@ All layout elements are arranged against a [layout grid](/concepts/05%20UI%20Com
 
     <!--HTML-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import ResponsiveBox, { Row, Col } from 'devextreme-react/responsive-box';
 
@@ -284,7 +284,7 @@ Every layout element has the [location](/api-reference/_hidden/dxResponsiveBoxIt
         </DxResponsiveBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxResponsiveBox, DxItem, DxLocation, DxCol, DxRow } from 'devextreme-vue/responsive-box';
 
@@ -316,7 +316,7 @@ Every layout element has the [location](/api-reference/_hidden/dxResponsiveBoxIt
 
     <!--HTML-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import ResponsiveBox, { Row, Col, Item, Location } from 'devextreme-react/responsive-box';
 
@@ -448,7 +448,7 @@ If on some screens, all elements should be arranged in a single column, assign t
         </DxResponsiveBox>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxResponsiveBox, DxCol, DxRow } from 'devextreme-vue/responsive-box';
 
@@ -468,7 +468,7 @@ If on some screens, all elements should be arranged in a single column, assign t
 
     <!--HTML-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import ResponsiveBox, { Row, Col } from 'devextreme-react/responsive-box';
 

--- a/concepts/05 UI Components/Scheduler/00 Getting Started with Scheduler/02 Create a Scheduler.md
+++ b/concepts/05 UI Components/Scheduler/00 Getting Started with Scheduler/02 Create a Scheduler.md
@@ -87,7 +87,7 @@
     </template> 
 
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import { DxScheduler } from 'devextreme-vue/scheduler'; 
 
@@ -109,7 +109,7 @@
 [Add DevExtreme to your React application](/concepts/50%20React%20Components/05%20Add%20DevExtreme%20to%20a%20React%20Application/00%20Add%20DevExtreme%20to%20a%20React%20Application.md '/Documentation/Guide/React_Components/Add_DevExtreme_to_a_React_Application/') and use the following code to create a Scheduler:
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import './App.css';
 
     import { Scheduler } from 'devextreme-react/scheduler';

--- a/concepts/05 UI Components/Scheduler/030 Appointments/015 Appointment Types/020 All-Day Appointments.md
+++ b/concepts/05 UI Components/Scheduler/030 Appointments/015 Appointment Types/020 All-Day Appointments.md
@@ -68,7 +68,7 @@ If your appointment data objects contain a different field that performs the fun
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler from 'devextreme-vue/scheduler';
 
@@ -95,7 +95,7 @@ If your appointment data objects contain a different field that performs the fun
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
     

--- a/concepts/05 UI Components/Scheduler/030 Appointments/015 Appointment Types/030 Recurring Appointments.md
+++ b/concepts/05 UI Components/Scheduler/030 Appointments/015 Appointment Types/030 Recurring Appointments.md
@@ -73,7 +73,7 @@ If your appointment data objects contain different fields that perform the funct
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler from 'devextreme-vue/scheduler';
 
@@ -100,7 +100,7 @@ If your appointment data objects contain different fields that perform the funct
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
     

--- a/concepts/05 UI Components/Scheduler/030 Appointments/020 Add Appointments/010 User Interaction.md
+++ b/concepts/05 UI Components/Scheduler/030 Appointments/020 Add Appointments/010 User Interaction.md
@@ -55,7 +55,7 @@ To prevent an end user from adding an appointment, set the **editing**.[allowAdd
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler, { DxEditing } from 'devextreme-vue/scheduler';
 
@@ -77,7 +77,7 @@ To prevent an end user from adding an appointment, set the **editing**.[allowAdd
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler, { Editing } from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/Scheduler/030 Appointments/020 Add Appointments/020 API.md
+++ b/concepts/05 UI Components/Scheduler/030 Appointments/020 Add Appointments/020 API.md
@@ -94,7 +94,7 @@ To add an appointment to the [data source](/api-reference/10%20UI%20Components/d
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler from 'devextreme-vue/scheduler';
     import DxButton from 'devextreme-vue/button';
@@ -141,7 +141,7 @@ To add an appointment to the [data source](/api-reference/10%20UI%20Components/d
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
     import Button from 'devextreme-react/button';

--- a/concepts/05 UI Components/Scheduler/030 Appointments/020 Add Appointments/030 Events.md
+++ b/concepts/05 UI Components/Scheduler/030 Appointments/020 Add Appointments/030 Events.md
@@ -55,7 +55,7 @@ To execute certain commands before or after an appointment was added, handle the
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler from 'devextreme-vue/scheduler';
 
@@ -84,7 +84,7 @@ To execute certain commands before or after an appointment was added, handle the
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/Scheduler/030 Appointments/030 Update Appointments/010 User Interaction.md
+++ b/concepts/05 UI Components/Scheduler/030 Appointments/030 Update Appointments/010 User Interaction.md
@@ -54,7 +54,7 @@ If a user updates a [recurring appointment](/concepts/05%20UI%20Components/Sched
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler } from 'devextreme-vue/scheduler';
 
@@ -68,7 +68,7 @@ If a user updates a [recurring appointment](/concepts/05%20UI%20Components/Sched
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Scheduler } from 'devextreme-react/scheduler';
 
@@ -130,7 +130,7 @@ To prevent a user from updating an appointment, set the **editing**.[allowUpdati
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler, DxEditing } from 'devextreme-vue/scheduler';
 
@@ -144,7 +144,7 @@ To prevent a user from updating an appointment, set the **editing**.[allowUpdati
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Scheduler, Editing } from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/Scheduler/030 Appointments/030 Update Appointments/020 API.md
+++ b/concepts/05 UI Components/Scheduler/030 Appointments/030 Update Appointments/020 API.md
@@ -88,7 +88,7 @@ To update an appointment, call the **updateAppointment(target, appointment)** me
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler from 'devextreme-vue/scheduler';
     import DxButton from 'devextreme-vue/button';
@@ -123,7 +123,7 @@ To update an appointment, call the **updateAppointment(target, appointment)** me
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
     import Button from 'devextreme-react/button';

--- a/concepts/05 UI Components/Scheduler/030 Appointments/030 Update Appointments/030 Events.md
+++ b/concepts/05 UI Components/Scheduler/030 Appointments/030 Update Appointments/030 Events.md
@@ -55,7 +55,7 @@ To execute certain commands before or after an appointment was updated, handle t
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler from 'devextreme-vue/scheduler';
 
@@ -84,7 +84,7 @@ To execute certain commands before or after an appointment was updated, handle t
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/Scheduler/030 Appointments/040 Delete Appointments/010 User Interaction.md
+++ b/concepts/05 UI Components/Scheduler/030 Appointments/040 Delete Appointments/010 User Interaction.md
@@ -51,7 +51,7 @@ If a user deletes a [recurring appointment](/concepts/05%20UI%20Components/Sched
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler from 'devextreme-vue/scheduler';
 
@@ -67,7 +67,7 @@ If a user deletes a [recurring appointment](/concepts/05%20UI%20Components/Sched
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
 
@@ -127,7 +127,7 @@ To prevent a user from deleting an appointment, set the **editing**.[allowDeleti
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler, { DxEditing } from 'devextreme-vue/scheduler';
 
@@ -149,7 +149,7 @@ To prevent a user from deleting an appointment, set the **editing**.[allowDeleti
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler, { Editing } from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/Scheduler/030 Appointments/040 Delete Appointments/020 API.md
+++ b/concepts/05 UI Components/Scheduler/030 Appointments/040 Delete Appointments/020 API.md
@@ -89,7 +89,7 @@ To delete an appointment, call the **deleteAppointment(appointment)** method. Th
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler from 'devextreme-vue/scheduler';
     import DxButton from 'devextreme-vue/button';
@@ -132,7 +132,7 @@ To delete an appointment, call the **deleteAppointment(appointment)** method. Th
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
     import Button from 'devextreme-react/button';

--- a/concepts/05 UI Components/Scheduler/030 Appointments/040 Delete Appointments/030 Events.md
+++ b/concepts/05 UI Components/Scheduler/030 Appointments/040 Delete Appointments/030 Events.md
@@ -55,7 +55,7 @@ To execute certain commands before or after an appointment was deleted, handle t
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler from 'devextreme-vue/scheduler';
 
@@ -84,7 +84,7 @@ To execute certain commands before or after an appointment was deleted, handle t
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/Scheduler/030 Appointments/050 Customize Appointment.md
+++ b/concepts/05 UI Components/Scheduler/030 Appointments/050 Customize Appointment.md
@@ -80,7 +80,7 @@ For a minor customization of Scheduler appointments, you can define [specific fi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler from 'devextreme-vue/scheduler';
 
@@ -118,7 +118,7 @@ For a minor customization of Scheduler appointments, you can define [specific fi
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
 
@@ -263,7 +263,7 @@ If you need a more flexible solution, define a custom template. The following co
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler from 'devextreme-vue/scheduler';
 
@@ -299,7 +299,7 @@ If you need a more flexible solution, define a rendering function. The following
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/Scheduler/030 Appointments/060 Customize Appointment Tooltip.md
+++ b/concepts/05 UI Components/Scheduler/030 Appointments/060 Customize Appointment Tooltip.md
@@ -281,7 +281,7 @@ When a user clicks an appointment, the Scheduler shows a tooltip that can be cus
     import Scheduler from 'devextreme-react/scheduler';
     import Tooltip from './Tooltip.js';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     const App = () => {
         const schedulerRef = useRef(null);

--- a/concepts/05 UI Components/Scheduler/040 Resources/020 Assign Appointments to Resources/010 API.md
+++ b/concepts/05 UI Components/Scheduler/040 Resources/020 Assign Appointments to Resources/010 API.md
@@ -119,7 +119,7 @@ Each resource kind has the [fieldExpr](/api-reference/10%20UI%20Components/dxSch
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler, DxResource } from 'devextreme-vue/scheduler';
 
@@ -161,7 +161,7 @@ Each resource kind has the [fieldExpr](/api-reference/10%20UI%20Components/dxSch
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Scheduler, Resource } from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/Scheduler/040 Resources/020 Assign Appointments to Resources/Assign Appointments to Resources.md
+++ b/concepts/05 UI Components/Scheduler/040 Resources/020 Assign Appointments to Resources/Assign Appointments to Resources.md
@@ -156,7 +156,7 @@ To define resource kinds, assign an array of objects specifying them to the [res
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataSource from 'devextreme/data/data_source';
     import { DxScheduler, DxResource } from 'devextreme-vue/scheduler';
@@ -207,7 +207,7 @@ To define resource kinds, assign an array of objects specifying them to the [res
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataSource from 'devextreme/data/data_source';
     import { Scheduler, Resource } from 'devextreme-react/scheduler';

--- a/concepts/05 UI Components/Scheduler/040 Resources/030 Group Appointments by Resources.md
+++ b/concepts/05 UI Components/Scheduler/040 Resources/030 Group Appointments by Resources.md
@@ -101,7 +101,7 @@ To group appointments by resources, assign an array to the [groups](/api-referen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler, { DxResource } from 'devextreme-vue/scheduler';
 
@@ -146,7 +146,7 @@ To group appointments by resources, assign an array to the [groups](/api-referen
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler, { Resource } from 'devextreme-react/scheduler';
 
@@ -252,7 +252,7 @@ You can change resource headers orientation in an individual view using the **vi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler, { DxView } from 'devextreme-vue/scheduler';
 
@@ -274,7 +274,7 @@ You can change resource headers orientation in an individual view using the **vi
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler, { View } from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/Scheduler/040 Resources/040 Customize Resource Headers.md
+++ b/concepts/05 UI Components/Scheduler/040 Resources/040 Customize Resource Headers.md
@@ -98,7 +98,7 @@ Implement a Vue template and assign it to the [resourceCellTemplate](/api-refere
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler, { DxResource } from 'devextreme-vue/scheduler';
 
@@ -135,7 +135,7 @@ Implement a callback function with custom template and assign it to the [resourc
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler, { Resource } from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/Scheduler/050 Timetable.md
+++ b/concepts/05 UI Components/Scheduler/050 Timetable.md
@@ -78,7 +78,7 @@ The Scheduler UI component allows you to customize its timetable. You can specif
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler } from 'devextreme-vue/scheduler';
 
@@ -109,7 +109,7 @@ The Scheduler UI component allows you to customize its timetable. You can specif
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Scheduler } from 'devextreme-react/scheduler';
 
@@ -277,7 +277,7 @@ For a more detailed customization, define custom templates for cells, time scale
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler } from 'devextreme-vue/scheduler';
 
@@ -304,7 +304,7 @@ For a more detailed customization, define custom rendering functions for cells, 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Scheduler } from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/Scheduler/055 Date Navigator.md
+++ b/concepts/05 UI Components/Scheduler/055 Date Navigator.md
@@ -67,7 +67,7 @@ You can specify the range of available dates in the [min](/api-reference/10%20UI
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler } from 'devextreme-vue/scheduler';
 
@@ -89,7 +89,7 @@ You can specify the range of available dates in the [min](/api-reference/10%20UI
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
     

--- a/concepts/05 UI Components/Scheduler/060 Views/010 View Types/050 Agenda View.md
+++ b/concepts/05 UI Components/Scheduler/060 Views/010 View Types/050 Agenda View.md
@@ -60,7 +60,7 @@ By default, the **agenda** view displays appointments for seven dates at a time 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler, DxView } from 'devextreme-vue/scheduler';
 
@@ -79,7 +79,7 @@ By default, the **agenda** view displays appointments for seven dates at a time 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Scheduler, View } from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/Scheduler/060 Views/010 View Types/View Types.md
+++ b/concepts/05 UI Components/Scheduler/060 Views/010 View Types/View Types.md
@@ -48,7 +48,7 @@ A user switches between views with the [View Switcher](/concepts/05%20UI%20Compo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxScheduler from 'devextreme-vue/scheduler';
 
@@ -71,7 +71,7 @@ A user switches between views with the [View Switcher](/concepts/05%20UI%20Compo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Scheduler from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/Scheduler/060 Views/020 Customize Individual Views.md
+++ b/concepts/05 UI Components/Scheduler/060 Views/020 Customize Individual Views.md
@@ -90,7 +90,7 @@ The following code snippet customizes the *"day"* and *"workWeek"* views. This e
 
     <script>
     import { DxScheduler, DxResource, DxView } from 'devextreme-vue/scheduler';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     </script>
 
@@ -112,7 +112,7 @@ The following code snippet customizes the *"day"* and *"workWeek"* views. This e
 
     <!-- tab: App.tsx -->
     import { Scheduler, Resource, View } from 'devextreme-react/scheduler';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     function renderTimeCell(data: {text: string}): JSX.Element {
         return (

--- a/concepts/05 UI Components/Scheduler/075 Current Time Indication.md
+++ b/concepts/05 UI Components/Scheduler/075 Current Time Indication.md
@@ -45,7 +45,7 @@ Use the [showCurrentTimeIndicator](/api-reference/10%20UI%20Components/dxSchedul
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler } from 'devextreme-vue/scheduler';
 
@@ -60,7 +60,7 @@ Use the [showCurrentTimeIndicator](/api-reference/10%20UI%20Components/dxSchedul
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Scheduler } from 'devextreme-react/scheduler';
 
@@ -124,7 +124,7 @@ Additionally, you can apply shading to cover the timetable up to the current tim
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScheduler } from 'devextreme-vue/scheduler';
 
@@ -139,7 +139,7 @@ Additionally, you can apply shading to cover the timetable up to the current tim
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Scheduler } from 'devextreme-react/scheduler';
 

--- a/concepts/05 UI Components/ScrollView/00 Overview.md
+++ b/concepts/05 UI Components/ScrollView/00 Overview.md
@@ -60,7 +60,7 @@ The following code adds a simple ScrollView to your page. The [width](/api-refer
         </DxScrollView>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScrollView } from 'devextreme-vue/scroll-view';
 
@@ -75,7 +75,7 @@ The following code adds a simple ScrollView to your page. The [width](/api-refer
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ScrollView } from 'devextreme-react/scroll-view';
 
@@ -142,7 +142,7 @@ The ScrollView employs native scrolling on most platforms, except desktops. To e
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScrollView } from 'devextreme-vue/scroll-view';
 
@@ -157,7 +157,7 @@ The ScrollView employs native scrolling on most platforms, except desktops. To e
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ScrollView } from 'devextreme-react/scroll-view';
 
@@ -224,7 +224,7 @@ If simulated scrolling is used, you can specify when to show the scrollbar. For 
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScrollView } from 'devextreme-vue/scroll-view';
 
@@ -239,7 +239,7 @@ If simulated scrolling is used, you can specify when to show the scrollbar. For 
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ScrollView } from 'devextreme-react/scroll-view';
 

--- a/concepts/05 UI Components/ScrollView/05 Scroll the Content/10 User Interaction.md
+++ b/concepts/05 UI Components/ScrollView/05 Scroll the Content/10 User Interaction.md
@@ -47,7 +47,7 @@ An end user can scroll the ScrollView content with the swipe gesture or with the
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScrollView } from 'devextreme-vue/scroll-view';
 
@@ -62,7 +62,7 @@ An end user can scroll the ScrollView content with the swipe gesture or with the
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ScrollView } from 'devextreme-react/scroll-view';
 

--- a/concepts/05 UI Components/ScrollView/05 Scroll the Content/20 API.md
+++ b/concepts/05 UI Components/ScrollView/05 Scroll the Content/20 API.md
@@ -94,7 +94,7 @@ To scroll through ScrollView content by a specified distance, call the [scrollBy
         </div>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxButton } from 'devextreme-vue';
     import { DxScrollView } from 'devextreme-vue/scroll-view';
@@ -131,7 +131,7 @@ To scroll through ScrollView content by a specified distance, call the [scrollBy
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Button } from 'devextreme-react';
     import { ScrollView } from 'devextreme-react/scroll-view';
@@ -261,7 +261,7 @@ To scroll content vertically and horizontally, call the [scrollBy(distance)](/ap
         </div>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxButton } from 'devextreme-vue';
     import { DxScrollView } from 'devextreme-vue/scroll-view';
@@ -295,7 +295,7 @@ To scroll content vertically and horizontally, call the [scrollBy(distance)](/ap
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Button } from 'devextreme-react';
     import { ScrollView } from 'devextreme-react/scroll-view';
@@ -417,7 +417,7 @@ To scroll the content to a specific position, call the [scrollTo(targetLocation)
         </div>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxButton } from 'devextreme-vue';
     import { DxScrollView } from 'devextreme-vue/scroll-view';
@@ -451,7 +451,7 @@ To scroll the content to a specific position, call the [scrollTo(targetLocation)
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Button } from 'devextreme-react';
     import { ScrollView } from 'devextreme-react/scroll-view';
@@ -580,7 +580,7 @@ To scroll content to a specific element, call the [scrollToElement(element)](/ap
         </div>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxButton } from 'devextreme-vue';
     import { DxScrollView } from 'devextreme-vue/scroll-view';
@@ -615,7 +615,7 @@ To scroll content to a specific element, call the [scrollToElement(element)](/ap
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Button } from 'devextreme-react';
     import { ScrollView } from 'devextreme-react/scroll-view';

--- a/concepts/05 UI Components/ScrollView/10 Handle Scroll Gestures.md
+++ b/concepts/05 UI Components/ScrollView/10 Handle Scroll Gestures.md
@@ -56,7 +56,7 @@ The ScrollView raises the [pullDown](/api-reference/10%20UI%20Components/dxScrol
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScrollView } from 'devextreme-vue/scroll-view';
 
@@ -77,7 +77,7 @@ The ScrollView raises the [pullDown](/api-reference/10%20UI%20Components/dxScrol
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ScrollView } from 'devextreme-react/scroll-view';
 
@@ -159,7 +159,7 @@ If an end user scrolls the content down to the bottom, the ScrollView raises the
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScrollView } from 'devextreme-vue/scroll-view';
 
@@ -180,7 +180,7 @@ If an end user scrolls the content down to the bottom, the ScrollView raises the
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ScrollView } from 'devextreme-react/scroll-view';
 
@@ -263,7 +263,7 @@ If you want to process each scroll gesture performed by a user, handle the [scro
         </DxScrollView>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxScrollView } from 'devextreme-vue/scroll-view';
 
@@ -286,7 +286,7 @@ If you want to process each scroll gesture performed by a user, handle the [scro
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ScrollView } from 'devextreme-react/scroll-view';
 

--- a/concepts/05 UI Components/Splitter/00 Getting Started with Splitter/05 Build a Layout.md
+++ b/concepts/05 UI Components/Splitter/00 Getting Started with Splitter/05 Build a Layout.md
@@ -105,7 +105,7 @@ Once you set up pane layout, the Splitter displays separator bars between panes.
     </template>
 
     <script setup>  
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import { DxSplitter, DxItem } from 'devextreme-vue/splitter';
     </script>
 
@@ -114,7 +114,7 @@ Once you set up pane layout, the Splitter displays separator bars between panes.
     <!-- tab: App.js -->
     import React from 'react';
     import Splitter, { Item } from 'devextreme-react/splitter';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     const App = () => (
     <React.Fragment>

--- a/concepts/05 UI Components/Splitter/00 Getting Started with Splitter/10 Configure Panes.md
+++ b/concepts/05 UI Components/Splitter/00 Getting Started with Splitter/10 Configure Panes.md
@@ -107,7 +107,7 @@ This tutorial explicitly specifies the following properties: **size**, **minSize
     <!-- tab: App.js -->
     import React from 'react';
     import Splitter, { Item } from 'devextreme-react/splitter';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     const App = () => (
     <React.Fragment>

--- a/concepts/05 UI Components/Splitter/00 Getting Started with Splitter/15 Fill Panes with Content.md
+++ b/concepts/05 UI Components/Splitter/00 Getting Started with Splitter/15 Fill Panes with Content.md
@@ -218,7 +218,7 @@ This tutorial uses **templates** to define components inside panes:
 
     <script setup>  
         import { ref } from 'vue';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import DxForm from 'devextreme-vue/form';
         import DxButton from 'devextreme-vue/button';
         import { DxSplitter, DxItem } from 'devextreme-vue/splitter';
@@ -259,7 +259,7 @@ This tutorial uses **templates** to define components inside panes:
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { useState } from 'react';
     import Form from 'devextreme-react/form';
     import Button from 'devextreme-react/button';

--- a/concepts/05 UI Components/Stepper/05 Getting Started with Stepper/05 Create Stepper.md
+++ b/concepts/05 UI Components/Stepper/05 Getting Started with Stepper/05 Create Stepper.md
@@ -79,7 +79,7 @@
     <script setup lang="ts">
         import { reactive } from 'vue';
         import { DxStepper, DxItem, DxStepperTypes } from 'devextreme-vue/stepper';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         const items: DxStepperTypes.Item[] = reactive([
             {}
@@ -101,7 +101,7 @@
     <!-- tab: App.tsx -->
     import React, { JSX, useState } from 'react';
     import { Stepper, Item, StepperTypes } from 'devextreme-react/stepper';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     export default function App(): JSX.Element {
         const [steps, setSteps] = useState<any[]>([

--- a/concepts/05 UI Components/Switch/10 Handle the Value Change Event.md
+++ b/concepts/05 UI Components/Switch/10 Handle the Value Change Event.md
@@ -71,7 +71,7 @@ To process a new Switch value, you need to handle the value change event. If the
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxSwitch from 'devextreme-vue/switch';
 
@@ -97,7 +97,7 @@ To process a new Switch value, you need to handle the value change event. If the
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Switch from 'devextreme-react/switch';
 

--- a/concepts/05 UI Components/TabPanel/01 Getting Started with TabPanel/10 Create the TabPanel.md
+++ b/concepts/05 UI Components/TabPanel/01 Getting Started with TabPanel/10 Create the TabPanel.md
@@ -92,7 +92,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTabPanel } from 'devextreme-vue/tab-panel';
 
@@ -116,7 +116,7 @@
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TabPanel from 'devextreme-react/tab-panel';
 

--- a/concepts/05 UI Components/TabPanel/01 Getting Started with TabPanel/20 Create Tabs.md
+++ b/concepts/05 UI Components/TabPanel/01 Getting Started with TabPanel/20 Create Tabs.md
@@ -58,7 +58,7 @@ Specify a tab's [title](/api-reference/_hidden/dxTabPanelItem/title.md '/Documen
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTabPanel, { DxItem } from "devextreme-vue/tab-panel";
 
@@ -74,7 +74,7 @@ Specify a tab's [title](/api-reference/_hidden/dxTabPanelItem/title.md '/Documen
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TabPanel, { Item } from "devextreme-react/tab-panel";
 

--- a/concepts/05 UI Components/TabPanel/01 Getting Started with TabPanel/30 Specify View Content.md
+++ b/concepts/05 UI Components/TabPanel/01 Getting Started with TabPanel/30 Specify View Content.md
@@ -233,7 +233,7 @@ This tutorial demonstrates the use of the **items[]**.**template** property. Thi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTabPanel, { DxItem } from "devextreme-vue/tab-panel";
     import DxForm, { DxSimpleItem, DxLabel } from "devextreme-vue/form";
@@ -270,7 +270,7 @@ This tutorial demonstrates the use of the **items[]**.**template** property. Thi
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TabPanel, { Item } from "devextreme-react/tab-panel";
     import Form, { SimpleItem, Label } from "devextreme-react/form";

--- a/concepts/05 UI Components/Tabs/00 Getting Started with Tabs/05 Create Predefined Tabs.md
+++ b/concepts/05 UI Components/Tabs/00 Getting Started with Tabs/05 Create Predefined Tabs.md
@@ -107,7 +107,7 @@ You can use predefined item features to customize the items. The code below crea
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTabs, { DxItem } from 'devextreme-vue/tabs';
 
     export default {
@@ -132,7 +132,7 @@ You can use predefined item features to customize the items. The code below crea
     import React from 'react';
     import Tabs, { Item } from 'devextreme-react/tabs';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     function App() {
         return (

--- a/concepts/05 UI Components/Tabs/00 Getting Started with Tabs/20 Handle Tab Click.md
+++ b/concepts/05 UI Components/Tabs/00 Getting Started with Tabs/20 Handle Tab Click.md
@@ -70,7 +70,7 @@ Use the [onItemClick](/api-reference/10%20UI%20Components/dxTabs/1%20Configurati
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxTabs, { DxItem } from 'devextreme-vue/tabs';
     import notify from "devextreme/ui/notify";
 
@@ -109,7 +109,7 @@ Use the [onItemClick](/api-reference/10%20UI%20Components/dxTabs/1%20Configurati
     import Tabs, { Item } from 'devextreme-react/tabs';
     import notify from 'devextreme/ui/notify';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     const showMessage = (id) => {
         notify(

--- a/concepts/05 UI Components/TileView/00 Overview.md
+++ b/concepts/05 UI Components/TileView/00 Overview.md
@@ -55,7 +55,7 @@ The following code adds a primitive TileView to your page.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTileView } from 'devextreme-vue/tile-view';
 
@@ -79,7 +79,7 @@ The following code adds a primitive TileView to your page.
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TileView } from 'devextreme-react/tile-view';
 
@@ -144,7 +144,7 @@ By default, the UI component is oriented horizontally, but you can orient it ver
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTileView } from 'devextreme-vue/tile-view';
 
@@ -158,7 +158,7 @@ By default, the UI component is oriented horizontally, but you can orient it ver
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TileView } from 'devextreme-react/tile-view';
 

--- a/concepts/05 UI Components/TileView/03 Specify the Size of Tiles.md
+++ b/concepts/05 UI Components/TileView/03 Specify the Size of Tiles.md
@@ -62,7 +62,7 @@ For example, the following code makes the *"Massachusetts"* tile twice bigger th
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTileView } from 'devextreme-vue/tile-view';
 
@@ -86,7 +86,7 @@ For example, the following code makes the *"Massachusetts"* tile twice bigger th
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TileView } from 'devextreme-react/tile-view';
 

--- a/concepts/05 UI Components/TileView/05 Customize Tile Appearance.md
+++ b/concepts/05 UI Components/TileView/05 Customize Tile Appearance.md
@@ -45,7 +45,7 @@ For a minor customization of tiles, you can define [specific fields](/api-refere
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTileView } from 'devextreme-vue/tile-view';
 
@@ -68,7 +68,7 @@ For a minor customization of tiles, you can define [specific fields](/api-refere
 ##### React
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TileView } from 'devextreme-react/tile-view';
 
@@ -184,7 +184,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTileView from "devextreme-vue/tile-view";
 
@@ -218,7 +218,7 @@ If you need a more flexible solution, define an [itemTemplate](/api-reference/10
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { TileView } from 'devextreme-react/tile-view';
 
@@ -329,7 +329,7 @@ You can also customize individual tiles. Declare them using the [dxItem](/api-re
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTileView, { DxItem } from "devextreme-vue/tile-view";
 
@@ -346,7 +346,7 @@ You can also customize individual tiles. Declare them using the [dxItem](/api-re
 You can also customize individual tiles. Declare them using the [dxItem](/api-reference/10%20UI%20Components/Markup%20Components/dxItem '/Documentation/ApiReference/UI_Components/Markup_Components/dxItem/') component.
 
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TileView, Item } from 'devextreme-react/tile-view';
 

--- a/concepts/05 UI Components/Toolbar/00 Getting Started with Toolbar/05 Create a Toolbar and its Items.md
+++ b/concepts/05 UI Components/Toolbar/00 Getting Started with Toolbar/05 Create a Toolbar and its Items.md
@@ -178,7 +178,7 @@ The following code creates a Toolbar and adds a [dxTextBox](/api-reference/10%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxToolbar, { DxItem } from 'devextreme-vue/toolbar';
     import notify from "devextreme/ui/notify";
     import 'devextreme/ui/text_box';
@@ -225,7 +225,7 @@ The following code creates a Toolbar and adds a [dxTextBox](/api-reference/10%20
     import notify from 'devextreme/ui/notify';
     import 'devextreme/ui/text_box';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     const showMessage = (name) => {
         notify(

--- a/concepts/05 UI Components/TreeView/00 Getting Started with TreeView/02 Create a TreeView.md
+++ b/concepts/05 UI Components/TreeView/00 Getting Started with TreeView/02 Create a TreeView.md
@@ -83,7 +83,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -106,7 +106,7 @@
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TreeView } from 'devextreme-react/tree-view';
 

--- a/concepts/05 UI Components/TreeView/00 Getting Started with TreeView/05 Bind the TreeView to Data.md
+++ b/concepts/05 UI Components/TreeView/00 Getting Started with TreeView/05 Bind the TreeView to Data.md
@@ -386,7 +386,7 @@ The TreeView supports plain and hierarchical data structures. To use plain data,
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeView from 'devextreme-react/tree-view';
     import products from './products';

--- a/concepts/05 UI Components/TreeView/05 Use Hierarchical Data.md
+++ b/concepts/05 UI Components/TreeView/05 Use Hierarchical Data.md
@@ -99,7 +99,7 @@ As you can see, all items in a hierarchical data source have the **id** and **te
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -136,7 +136,7 @@ As you can see, all items in a hierarchical data source have the **id** and **te
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeView from 'devextreme-react/tree-view';
 
@@ -244,7 +244,7 @@ Frequently, the **id** of an item is also its **text**. In this case, set both t
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -279,7 +279,7 @@ Frequently, the **id** of an item is also its **text**. In this case, set both t
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeView from 'devextreme-react/tree-view';
 

--- a/concepts/05 UI Components/TreeView/07 Use Plain Data.md
+++ b/concepts/05 UI Components/TreeView/07 Use Plain Data.md
@@ -57,7 +57,7 @@ If you use plain data in the TreeView, set the [dataStructure](/api-reference/10
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -87,7 +87,7 @@ If you use plain data in the TreeView, set the [dataStructure](/api-reference/10
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeView from 'devextreme-react/tree-view';
 
@@ -182,7 +182,7 @@ As you can see, all items in a plain data source have the **id** and **text** fi
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -211,7 +211,7 @@ As you can see, all items in a plain data source have the **id** and **text** fi
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeView from 'devextreme-react/tree-view';
 
@@ -306,7 +306,7 @@ Frequently, the **id** of an item is also its **text**. In this case, set both t
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -336,7 +336,7 @@ Frequently, the **id** of an item is also its **text**. In this case, set both t
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeView from 'devextreme-react/tree-view';
 

--- a/concepts/05 UI Components/TreeView/10 Access a Node/05 Within Event Handlers.md
+++ b/concepts/05 UI Components/TreeView/10 Access a Node/05 Within Event Handlers.md
@@ -48,7 +48,7 @@ Usually, you need to access a TreeView node when an action was made on it, for e
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
         
     import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -77,7 +77,7 @@ Usually, you need to access a TreeView node when an action was made on it, for e
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
         
     import TreeView from 'devextreme-react/tree-view';
 

--- a/concepts/05 UI Components/TreeView/10 Access a Node/10 Using a Method.md
+++ b/concepts/05 UI Components/TreeView/10 Access a Node/10 Using a Method.md
@@ -38,7 +38,7 @@ Call the [getNodes()](/api-reference/10%20UI%20Components/dxTreeView/3%20Methods
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
         
     import { DxTreeView } from 'devextreme-vue/tree-view';
     const treeViewRef = 'treeView';
@@ -71,7 +71,7 @@ Call the [getNodes()](/api-reference/10%20UI%20Components/dxTreeView/3%20Methods
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import TreeView from 'devextreme-react/tree-view';
 

--- a/concepts/05 UI Components/TreeView/15 Search Nodes.md
+++ b/concepts/05 UI Components/TreeView/15 Search Nodes.md
@@ -74,7 +74,7 @@ Searching is disabled in the TreeView UI component by default. Assign **true** t
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -105,7 +105,7 @@ Searching is disabled in the TreeView UI component by default. Assign **true** t
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeView from 'devextreme-react/tree-view';
 
@@ -210,7 +210,7 @@ When a user types a string in the input field, the TreeView suggests all nodes t
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -241,7 +241,7 @@ When a user types a string in the input field, the TreeView suggests all nodes t
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeView from 'devextreme-react/tree-view';
 
@@ -351,7 +351,7 @@ You can customize the search panel by specifying the [searchEditorOptions](/api-
         </DxTreeView>    
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeView, {
         DxSearchEditorOptions
@@ -384,7 +384,7 @@ You can customize the search panel by specifying the [searchEditorOptions](/api-
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TreeView, SearchEditorOptions } from 'devextreme-react/tree-view';
 

--- a/concepts/05 UI Components/TreeView/20 Expand and Collapse Nodes/01 Initially.md
+++ b/concepts/05 UI Components/TreeView/20 Expand and Collapse Nodes/01 Initially.md
@@ -77,7 +77,7 @@ If a node is supposed to be expanded initially, set its [expanded](/api-referenc
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -116,7 +116,7 @@ If a node is supposed to be expanded initially, set its [expanded](/api-referenc
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import TreeView from 'devextreme-react/tree-view';
 

--- a/concepts/05 UI Components/TreeView/20 Expand and Collapse Nodes/05 Using the API.md
+++ b/concepts/05 UI Components/TreeView/20 Expand and Collapse Nodes/05 Using the API.md
@@ -44,7 +44,7 @@ You can use the [expandAll()](/api-reference/10%20UI%20Components/dxTreeView/3%2
             />
         </template>
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -82,7 +82,7 @@ You can use the [expandAll()](/api-reference/10%20UI%20Components/dxTreeView/3%2
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import TreeView from 'devextreme-react/tree-view';
 
@@ -161,7 +161,7 @@ Call the [expandItem(key)](/api-reference/10%20UI%20Components/dxTreeView/3%20Me
             />
         </template>
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -199,7 +199,7 @@ Call the [expandItem(key)](/api-reference/10%20UI%20Components/dxTreeView/3%20Me
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import TreeView from 'devextreme-react/tree-view';
         const data = [ ... ];

--- a/concepts/05 UI Components/TreeView/20 Expand and Collapse Nodes/10 Events.md
+++ b/concepts/05 UI Components/TreeView/20 Expand and Collapse Nodes/10 Events.md
@@ -52,7 +52,7 @@ To execute certain commands when a node is expanded or collapsed, handle the [it
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -83,7 +83,7 @@ To execute certain commands when a node is expanded or collapsed, handle the [it
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import TreeView from 'devextreme-react/tree-view';
 

--- a/concepts/05 UI Components/TreeView/32 Enhance Performance on Large Datasets.md
+++ b/concepts/05 UI Components/TreeView/32 Enhance Performance on Large Datasets.md
@@ -69,7 +69,7 @@ To enable the Virtual Mode, set the [virtualModeEnabled](/api-reference/10%20UI%
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeView } from 'devextreme-vue/tree-view';
 
@@ -99,7 +99,7 @@ To enable the Virtual Mode, set the [virtualModeEnabled](/api-reference/10%20UI%
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeView from 'devextreme-react/tree-view';
 
@@ -195,7 +195,7 @@ If the Virtual Mode does not meet your requirements, you can get full control ov
         />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTreeView } from 'devextreme-vue/tree-view';
     import 'whatwg-fetch';
@@ -221,7 +221,7 @@ If the Virtual Mode does not meet your requirements, you can get full control ov
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeView from 'devextreme-react/tree-view';
     import 'whatwg-fetch';

--- a/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/10 Validate an Editor Value.md
+++ b/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/10 Validate an Editor Value.md
@@ -82,7 +82,7 @@ Associate a DevExtreme editor with the [Validator](/api-reference/10%20UI%20Comp
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTextBox from 'devextreme-vue/text-box';
     import DxValidator, {
@@ -110,7 +110,7 @@ Associate a DevExtreme editor with the [Validator](/api-reference/10%20UI%20Comp
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TextBox from 'devextreme-react/text-box';
     import Validator, {

--- a/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/20 Validate Several Editor Values/1 Group the Editors.md
+++ b/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/20 Validate Several Editor Values/1 Group the Editors.md
@@ -94,7 +94,7 @@ Editors belonging to a single **Validation Group** can be validated together. Al
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTextBox from 'devextreme-vue/text-box';
     import DxValidator, {
@@ -125,7 +125,7 @@ Editors belonging to a single **Validation Group** can be validated together. Al
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TextBox from 'devextreme-react/text-box';
     import Validator, { 

--- a/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/20 Validate Several Editor Values/2 Validate the Group.md
+++ b/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/20 Validate Several Editor Values/2 Validate the Group.md
@@ -122,7 +122,7 @@ Call a group's [validate()](/api-reference/10%20UI%20Components/dxValidator/3%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTextBox from 'devextreme-vue/text-box';
     import DxValidator, {
@@ -163,7 +163,7 @@ Call a group's [validate()](/api-reference/10%20UI%20Components/dxValidator/3%20
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TextBox from 'devextreme-react/text-box';
     import Validator, { 
@@ -362,7 +362,7 @@ Alternatively, you can get a group's instance and call its [validate](/api-refer
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTextBox from 'devextreme-vue/text-box';
     import DxValidator, { DxRequiredRule } from 'devextreme-vue/validator';
@@ -400,7 +400,7 @@ Alternatively, you can get a group's instance and call its [validate](/api-refer
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TextBox } from 'devextreme-react/text-box';
     import { Button } from 'devextreme-react/button';

--- a/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/20 Validate Several Editor Values/3 Display Validation Errors.md
+++ b/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/20 Validate Several Editor Values/3 Display Validation Errors.md
@@ -78,7 +78,7 @@ All group validation errors can be displayed in the [ValidationSummary](/api-ref
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     // ...
     // import ValidationGroup from 'devextreme-react/validation-group';

--- a/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/30 Disable Validation Dynamically.md
+++ b/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/30 Disable Validation Dynamically.md
@@ -163,7 +163,7 @@ The following example illustrates this case. A page contains two [TextBoxes](/ap
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTextBox, DxButton, DxCheckBox } from 'devextreme-vue';
     import {
@@ -206,7 +206,7 @@ The following example illustrates this case. A page contains two [TextBoxes](/ap
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { 
         CheckBox, 

--- a/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/60 Validate a Custom Value.md
+++ b/concepts/05 UI Components/zz Common/05 UI Widgets/20 Data Validation/60 Validate a Custom Value.md
@@ -175,7 +175,7 @@ You can use the DevExtreme validation engine to validate a custom value, for exa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTextBox from "devextreme-vue/text-box";
     import DxValidator, { DxRequiredRule } from "devextreme-vue/validator";
@@ -230,7 +230,7 @@ You can use the DevExtreme validation engine to validate a custom value, for exa
     <!-- tab: App.js -->
     import { useState, useCallback } from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { TextBox } from 'devextreme-react/text-box';
     import { Button } from 'devextreme-react/button';
     import { Validator, RequiredRule } from 'devextreme-react/validator';

--- a/concepts/05 UI Components/zz Common/30 Templates/05 Default Templates.md
+++ b/concepts/05 UI Components/zz Common/30 Templates/05 Default Templates.md
@@ -70,7 +70,7 @@ You can achieve the same in the markup using the [dxItem](/api-reference/10%20UI
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxList, {
         DxItem
@@ -89,7 +89,7 @@ You can achieve the same in the markup using the [dxItem](/api-reference/10%20UI
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List, { Item } from 'devextreme-react/list';
 


### PR DESCRIPTION
Replaced mentions of Generic themes with Fluent:
import `'devextreme/dist/css/dx.light.css';` > import `'devextreme/dist/css/dx.fluent.blue.light.css';`

Included files:
```
concepts\05 UI Components\**\*.md
```