### PR TITLE
Update Theme Mentions to Fluent - Remaining API

### DIFF
--- a/api-reference/10 UI Components/BaseChart/1 Configuration/animation/animation.md
+++ b/api-reference/10 UI Components/BaseChart/1 Configuration/animation/animation.md
@@ -83,7 +83,7 @@ The UI component animates its elements at the beginning of its lifetime and when
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxAnimation
@@ -103,7 +103,7 @@ The UI component animates its elements at the beginning of its lifetime and when
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Animation 

--- a/api-reference/10 UI Components/BaseGauge/1 Configuration/animation/animation.md
+++ b/api-reference/10 UI Components/BaseGauge/1 Configuration/animation/animation.md
@@ -79,7 +79,7 @@ To make your gauge "live", enable animation for it by setting the **enabled** pr
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxAnimation
@@ -99,7 +99,7 @@ To make your gauge "live", enable animation for it by setting the **enabled** pr
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Animation 

--- a/api-reference/10 UI Components/BaseWidget/1 Configuration/margin/margin.md
+++ b/api-reference/10 UI Components/BaseWidget/1 Configuration/margin/margin.md
@@ -85,7 +85,7 @@ Generates space around the UI component.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxMargin 
@@ -105,7 +105,7 @@ Generates space around the UI component.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Margin 

--- a/api-reference/10 UI Components/Component/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/Component/1 Configuration/onOptionChanged.md
@@ -97,7 +97,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -121,7 +121,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/Editor/1 Configuration/isDirty.md
+++ b/api-reference/10 UI Components/Editor/1 Configuration/isDirty.md
@@ -75,7 +75,7 @@ This property is a read-only flag. You can use it to check if the editor value c
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
     import DxButton from 'devextreme-vue/button';
     import notify from 'devextreme/ui/notify';
@@ -114,7 +114,7 @@ This property is a read-only flag. You can use it to check if the editor value c
     import React, { useRef } from 'react';
     import {WidgetName} from 'devextreme-react/{widget-name}';
     import Button from 'devextreme-react/button';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     const App = () => {
         const {widgetName}Ref = useRef(null);

--- a/api-reference/10 UI Components/GridBase/1 Configuration/columnChooser/container.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/columnChooser/container.md
@@ -42,7 +42,7 @@ Use this property if you need to change the element in which the column chooser 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumnChooser
         // ... 
@@ -64,7 +64,7 @@ Use this property if you need to change the element in which the column chooser 
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumnChooser
         // ... 
@@ -77,7 +77,7 @@ Use this property if you need to change the element in which the column chooser 
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName}, {
         ColumnChooser 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/columnChooser/position.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/columnChooser/position.md
@@ -88,7 +88,7 @@ You can specify the [my](/api-reference/50%20Common/Object%20Structures/position
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumnChooser, 
         DxPosition
@@ -118,7 +118,7 @@ You can specify the [my](/api-reference/50%20Common/Object%20Structures/position
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumnChooser, 
         DxPosition
@@ -132,7 +132,7 @@ You can specify the [my](/api-reference/50%20Common/Object%20Structures/position
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName}, {
         ColumnChooser, 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/columnChooser/search/editorOptions.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/columnChooser/search/editorOptions.md
@@ -99,7 +99,7 @@ See the [TextBox Configuration](/Documentation/ApiReference/UI_Components/dxText
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumnChooser, 
         DxColumnChooserSearch,
@@ -140,7 +140,7 @@ See the [TextBox Configuration](/Documentation/ApiReference/UI_Components/dxText
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumnChooser, 
         DxColumnChooserSearch,
@@ -162,7 +162,7 @@ See the [TextBox Configuration](/Documentation/ApiReference/UI_Components/dxText
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName}, {
         ColumnChooser, 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/columnChooser/search/search.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/columnChooser/search/search.md
@@ -99,7 +99,7 @@ Configures the column chooser's search functionality.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumnChooser, 
         DxColumnChooserSearch,
@@ -137,7 +137,7 @@ Configures the column chooser's search functionality.
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumnChooser, 
         DxColumnChooserSearch,
@@ -156,7 +156,7 @@ Configures the column chooser's search functionality.
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName}, {
         ColumnChooser, 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/editing/form.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/editing/form.md
@@ -177,7 +177,7 @@ Default form editors depend on the [columns' configuration](/api-reference/10%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, { DxColumn, DxEditing, DxForm } from 'devextreme-vue/{widget-name}';
     import { DxItem } from 'devextreme-vue/form';
@@ -202,7 +202,7 @@ Default form editors depend on the [columns' configuration](/api-reference/10%20
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column,

--- a/api-reference/10 UI Components/GridBase/1 Configuration/editing/texts/texts.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/editing/texts/texts.md
@@ -83,7 +83,7 @@ The following code shows the **editing**.**texts** declaration syntax:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxEditing,
@@ -107,7 +107,7 @@ The following code shows the **editing**.**texts** declaration syntax:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Editing,

--- a/api-reference/10 UI Components/GridBase/1 Configuration/filterRow/operationDescriptions/operationDescriptions.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/filterRow/operationDescriptions/operationDescriptions.md
@@ -70,7 +70,7 @@ The following code sample illustrates how to set this property:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxFilterRow,
@@ -90,7 +90,7 @@ The following code sample illustrates how to set this property:
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         FilterRow,

--- a/api-reference/10 UI Components/GridBase/1 Configuration/filterValue.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/filterValue.md
@@ -65,7 +65,7 @@ The filter expression can contain the following operations: *"="*, *"<>"*, *"<"*
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxHeaderFilter,
@@ -91,7 +91,7 @@ The filter expression can contain the following operations: *"="*, *"<>"*, *"<"*
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         HeaderFilter,
@@ -195,7 +195,7 @@ If a column's [groupInterval](/api-reference/40%20Common%20Types/15%20grids/Colu
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn,
@@ -225,7 +225,7 @@ If a column's [groupInterval](/api-reference/40%20Common%20Types/15%20grids/Colu
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column,

--- a/api-reference/10 UI Components/GridBase/1 Configuration/onAdaptiveDetailRowPreparing.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/onAdaptiveDetailRowPreparing.md
@@ -89,7 +89,7 @@ The following Form properties cannot be specified using **formOptions**:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-vue/{widget-name}';
   
@@ -117,7 +117,7 @@ The following Form properties cannot be specified using **formOptions**:
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-vue/{widget-name}';
     
@@ -135,7 +135,7 @@ The following Form properties cannot be specified using **formOptions**:
     <!-- tab: App.js -->
     import { useCallback } from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/onInitNewRow.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/onInitNewRow.md
@@ -151,7 +151,7 @@ In the following code, the **onInitNewRow** function is used to provide default 
         </Dx{WidgetName}>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName}, DxColumn } from 'devextreme-vue/{widget-name}';
     import 'whatwg-fetch';
@@ -197,7 +197,7 @@ In the following code, the **onInitNewRow** function is used to provide default 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName}, Column } from 'devextreme-react/{widget-name}';
     import 'whatwg-fetch';

--- a/api-reference/10 UI Components/GridBase/1 Configuration/onKeyDown.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/onKeyDown.md
@@ -97,7 +97,7 @@ The following code shows how to handle a key combination:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -120,7 +120,7 @@ The following code shows how to handle a key combination:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/onRowRemoving.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/onRowRemoving.md
@@ -147,7 +147,7 @@ This function allows you to intercept row removal and perform additional actions
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import {WidgetName}, { ... } from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/GridBase/1 Configuration/onRowValidating.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/onRowValidating.md
@@ -144,7 +144,7 @@ The following code illustrates how to validate an email address on the server an
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
     import 'whatwg-fetch';
@@ -178,7 +178,7 @@ The following code illustrates how to validate an email address on the server an
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
     import 'whatwg-fetch';

--- a/api-reference/10 UI Components/GridBase/1 Configuration/stateStoring/customSave.md
+++ b/api-reference/10 UI Components/GridBase/1 Configuration/stateStoring/customSave.md
@@ -124,7 +124,7 @@ If you need to save and load the state from a remote storage, use the following 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxStateStoring
@@ -167,7 +167,7 @@ If you need to save and load the state from a remote storage, use the following 
 
     <!-- tab: App.js -->
     import React, { useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         StateStoring

--- a/api-reference/10 UI Components/GridBase/3 Methods/cellValue(rowIndex_dataField_value).md
+++ b/api-reference/10 UI Components/GridBase/3 Methods/cellValue(rowIndex_dataField_value).md
@@ -60,7 +60,7 @@ Call [saveEditData()](/api-reference/10%20UI%20Components/GridBase/3%20Methods/s
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName} } from 'devextreme-vue/{widget-name}';
 
@@ -93,7 +93,7 @@ Call [saveEditData()](/api-reference/10%20UI%20Components/GridBase/3%20Methods/s
     
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/GridBase/3 Methods/cellValue(rowIndex_visibleColumnIndex_value).md
+++ b/api-reference/10 UI Components/GridBase/3 Methods/cellValue(rowIndex_visibleColumnIndex_value).md
@@ -58,7 +58,7 @@ Call [saveEditData()](/api-reference/10%20UI%20Components/GridBase/3%20Methods/s
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName} } from 'devextreme-vue/{widget-name}';
 
@@ -91,7 +91,7 @@ Call [saveEditData()](/api-reference/10%20UI%20Components/GridBase/3%20Methods/s
     
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/GridBase/3 Methods/refresh().md
+++ b/api-reference/10 UI Components/GridBase/3 Methods/refresh().md
@@ -69,7 +69,7 @@ The following code snippet shows how to call **refresh()**:
         </Dx{WidgetName}>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName}, /* ... */ } from 'devextreme-vue/{widget-name}';
 
@@ -109,7 +109,7 @@ The following code snippet shows how to call **refresh()**:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName}, /* ... */ } from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/GridBase/3 Methods/state().md
+++ b/api-reference/10 UI Components/GridBase/3 Methods/state().md
@@ -99,7 +99,7 @@ The following example shows how to save the UI component state in the local stor
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         // ...
@@ -142,7 +142,7 @@ The following example shows how to save the UI component state in the local stor
 
     <!-- tab: App.js -->
     import React, { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         // ...

--- a/api-reference/10 UI Components/UI Events/dxhold.md
+++ b/api-reference/10 UI Components/UI Events/dxhold.md
@@ -148,7 +148,7 @@ If you need to subscribe to **dxhold** for two elements that are in the parent-c
     import { on } from 'devextreme/events';
     import 'devextreme/events/hold';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     let parentStyle = {
         backgroundColor: "aquamarine",

--- a/api-reference/10 UI Components/dxAccordion/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxAccordion/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxActionSheet/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxActionSheet/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxAutocomplete/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxAutocomplete/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxBarGauge/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxBarGauge/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxBox/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxBox/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxBullet/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxBullet/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxButton/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxButton/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxButtonGroup/1 Configuration/buttonTemplate.md
+++ b/api-reference/10 UI Components/dxButtonGroup/1 Configuration/buttonTemplate.md
@@ -77,7 +77,7 @@ A template name or container.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxButtonGroup } from 'devextreme-vue';
 
@@ -98,7 +98,7 @@ A template name or container.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { ButtonGroup } from 'devextreme-react';
 

--- a/api-reference/10 UI Components/dxButtonGroup/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxButtonGroup/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxCalendar/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxCalendar/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxCardView/1 Configuration/onContextMenuPreparing.md
+++ b/api-reference/10 UI Components/dxCardView/1 Configuration/onContextMenuPreparing.md
@@ -105,7 +105,7 @@ In the following code, the **onContextMenuPreparing** function adds a custom ite
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -129,7 +129,7 @@ In the following code, the **onContextMenuPreparing** function adds a custom ite
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import {WidgetName} from 'devextreme-react/{widget-name}';
 
     const App = () => {

--- a/api-reference/10 UI Components/dxCardView/1 Configuration/pager.md
+++ b/api-reference/10 UI Components/dxCardView/1 Configuration/pager.md
@@ -62,7 +62,7 @@ The pager is an element that allows users to navigate through pages and change t
 
     <!-- tab: App.tsx -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import CardView, { Paging, Pager } from 'devextreme-react/card-view';
 
     function App() {

--- a/api-reference/10 UI Components/dxCardView/9 Types/ColumnProperties/calculateDisplayValue.md
+++ b/api-reference/10 UI Components/dxCardView/9 Types/ColumnProperties/calculateDisplayValue.md
@@ -71,7 +71,7 @@ This property accepts the name of the [data source field](/api-reference/10%20UI
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn 
@@ -95,7 +95,7 @@ This property accepts the name of the [data source field](/api-reference/10%20UI
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column

--- a/api-reference/10 UI Components/dxCardView/9 Types/ColumnProperties/customizeText.md
+++ b/api-reference/10 UI Components/dxCardView/9 Types/ColumnProperties/customizeText.md
@@ -82,7 +82,7 @@ The [formatted](/api-reference/10%20UI%20Components/dxCardView/9%20Types/ColumnP
     </template>
 
     <script setup lang="ts">
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { Dx{WidgetName}, DxColumn } from "devextreme-vue/{widget-name}";
 
     function customizeText(fieldInfo) {
@@ -94,7 +94,7 @@ The [formatted](/api-reference/10%20UI%20Components/dxCardView/9%20Types/ColumnP
 
     <!-- tab: App.tsx -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import {WidgetName}, { Column } from "devextreme-react/{widget-name}";
     
     const customizeText = (fieldInfo) => {

--- a/api-reference/10 UI Components/dxCardView/9 Types/ColumnProperties/setFieldValue.md
+++ b/api-reference/10 UI Components/dxCardView/9 Types/ColumnProperties/setFieldValue.md
@@ -86,7 +86,7 @@ This function allows you to process user input before it is saved to the data so
         </Dx{WidgetName}>
     </template>
     <script setup lang="ts">
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { Dx{WidgetName}, DxColumn } from 'devextreme-vue/{widget-name}';
 
     const setFieldValue = (newData, value, currentCardData) => {
@@ -99,7 +99,7 @@ This function allows you to process user input before it is saved to the data so
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { {WidgetName}, Column } from 'devextreme-react/{widget-name}';
 
     const App = () => {

--- a/api-reference/10 UI Components/dxCardView/9 Types/dxCardViewEditing/form.md
+++ b/api-reference/10 UI Components/dxCardView/9 Types/dxCardViewEditing/form.md
@@ -103,7 +103,7 @@ Default form editors depend on the [columns' configuration](/api-reference/10%20
     </template>
 
     <script setup lang="ts">
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, { DxColumn, DxEditing, DxForm } from 'devextreme-vue/{widget-name}';
     import { DxItem } from 'devextreme-vue/form';
     </script>
@@ -113,7 +113,7 @@ Default form editors depend on the [columns' configuration](/api-reference/10%20
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column,

--- a/api-reference/10 UI Components/dxChart/1 Configuration/dataPrepareSettings/dataPrepareSettings.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/dataPrepareSettings/dataPrepareSettings.md
@@ -75,7 +75,7 @@ The following code shows the **dataPrepareSettings** declaration syntax:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxChart, {
         DxDataPrepareSettings 
@@ -98,7 +98,7 @@ The following code shows the **dataPrepareSettings** declaration syntax:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Chart, {
         DataPrepareSettings 

--- a/api-reference/10 UI Components/dxChart/1 Configuration/dataPrepareSettings/sortingMethod.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/dataPrepareSettings/sortingMethod.md
@@ -79,7 +79,7 @@ The following code sorts string arguments in alphabetical order:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxChart, {
         DxDataPrepareSettings

--- a/api-reference/10 UI Components/dxChart/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxChart/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxChat/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxChat/1 Configuration/onOptionChanged.md
@@ -101,7 +101,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -125,7 +125,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxCheckBox/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxCheckBox/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxCircularGauge/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxCircularGauge/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxColorBox/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxColorBox/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxContextMenu/1 Configuration/hideOnOutsideClick.md
+++ b/api-reference/10 UI Components/dxContextMenu/1 Configuration/hideOnOutsideClick.md
@@ -63,7 +63,7 @@ The function passed to this property enables you to specify a custom condition f
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -83,7 +83,7 @@ The function passed to this property enables you to specify a custom condition f
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxContextMenu/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxContextMenu/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/customizeColumns.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/customizeColumns.md
@@ -60,7 +60,7 @@ Use this function to make minor adjustments to automatically generated columns. 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         // ... 
@@ -84,7 +84,7 @@ Use this function to make minor adjustments to automatically generated columns. 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         // ...

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/editing/allowDeleting.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/editing/allowDeleting.md
@@ -72,7 +72,7 @@ The following code allows a user to delete only odd data rows:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxEditing
@@ -96,7 +96,7 @@ The following code allows a user to delete only odd data rows:
 
     <!-- tab: App.js -->
     import React, { useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Editing

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/export/export.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/export/export.md
@@ -156,7 +156,7 @@ The following instructions show how to enable and configure client-side export:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { DxDataGrid, 
             DxExport,
@@ -176,7 +176,7 @@ The following instructions show how to enable and configure client-side export:
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DataGrid, {
             Export,
@@ -303,7 +303,7 @@ The following instructions show how to enable and configure client-side export:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { DxDataGrid, DxExport } from 'devextreme-vue/data-grid';
         import { exportDataGrid } from 'devextreme/excel_exporter';
@@ -341,7 +341,7 @@ The following instructions show how to enable and configure client-side export:
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { Workbook } from 'devextreme-exceljs-fork';
         import saveAs from 'file-saver';
@@ -475,7 +475,7 @@ The following instructions show how to enable and configure client-side export:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDataGrid from 'devextreme-vue/data-grid';
         import DxButton from 'devextreme-vue/button';
@@ -515,7 +515,7 @@ The following instructions show how to enable and configure client-side export:
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DataGrid from 'devextreme-react/data-grid';
         import Button from 'devextreme-react/button';

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/export/formats.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/export/formats.md
@@ -128,7 +128,7 @@ Since the **formats** property accepts an array, you can specify multiple format
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxDataGrid, DxExport } from 'devextreme-vue/data-grid';
     import { jsPDF } from 'jspdf';
     import { exportDataGrid as exportDataGridToPdf} from 'devextreme/pdf_exporter';
@@ -178,7 +178,7 @@ Since the **formats** property accepts an array, you can specify multiple format
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DataGrid, { Export } from 'devextreme-react/data-grid';
     import { jsPDF } from 'jspdf';
     import { exportDataGrid as exportDataGridToPdf} from 'devextreme/pdf_exporter';
@@ -342,7 +342,7 @@ The example below shows how to export DataGrid to CSV format.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxDataGrid, DxExport } from 'devextreme-vue/data-grid';
     import { Workbook } from 'devextreme-exceljs-fork';
     import { saveAs } from 'file-saver-es';
@@ -380,7 +380,7 @@ The example below shows how to export DataGrid to CSV format.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DataGrid, { Export } from 'devextreme-react/data-grid';
     import { Workbook } from 'devextreme-exceljs-fork';
     import { saveAs } from 'file-saver-es';

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/masterDetail/template.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/masterDetail/template.md
@@ -118,7 +118,7 @@ You should call the [updateDimensions()](/api-reference/10%20UI%20Components/Gri
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxMasterDetail
@@ -155,7 +155,7 @@ You should call the [updateDimensions()](/api-reference/10%20UI%20Components/Gri
 
     <!-- tab: App.js -->
     import React, { useRef, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         MasterDetail

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onAdaptiveDetailRowPreparing.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onAdaptiveDetailRowPreparing.md
@@ -85,7 +85,7 @@ The following Form properties cannot be specified using **formOptions**:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-vue/{widget-name}';
   
@@ -113,7 +113,7 @@ The following Form properties cannot be specified using **formOptions**:
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-vue/{widget-name}';
     
@@ -131,7 +131,7 @@ The following Form properties cannot be specified using **formOptions**:
     <!-- tab: App.js -->
     import { useCallback } from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onCellPrepared.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onCellPrepared.md
@@ -141,7 +141,7 @@ In the following code, the **onCellPrepared** function is used to change a `Prod
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-vue/{widget-name}';
   
@@ -170,7 +170,7 @@ In the following code, the **onCellPrepared** function is used to change a `Prod
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onContextMenuPreparing.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onContextMenuPreparing.md
@@ -126,7 +126,7 @@ In the following code, the **onContextMenuPreparing** function adds a custom ite
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -163,7 +163,7 @@ In the following code, the **onContextMenuPreparing** function adds a custom ite
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onEditorPreparing.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onEditorPreparing.md
@@ -152,7 +152,7 @@ Use this function to:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -185,7 +185,7 @@ Use this function to:
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onExporting.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onExporting.md
@@ -142,7 +142,7 @@ You can use this function to adjust column properties before export. In the foll
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid, DxExport, DxColumn } from 'devextreme-vue/data-grid';
     import { exportDataGrid } from 'devextreme/excel_exporter';
@@ -182,7 +182,7 @@ You can use this function to adjust column properties before export. In the foll
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Workbook } from 'devextreme-exceljs-fork';
     import saveAs from 'file-saver';

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onFocusedCellChanging.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onFocusedCellChanging.md
@@ -104,7 +104,7 @@ In the following code, the **onFocusedCellChanging** function is used to customi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName} } from 'devextreme-vue/{widget-name}';
 
@@ -127,7 +127,7 @@ In the following code, the **onFocusedCellChanging** function is used to customi
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onInitNewRow.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onInitNewRow.md
@@ -146,7 +146,7 @@ In the following code, the **onInitNewRow** function is used to provide default 
         </Dx{WidgetName}>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName}, DxColumn } from 'devextreme-vue/{widget-name}';
     import 'whatwg-fetch';
@@ -192,7 +192,7 @@ In the following code, the **onInitNewRow** function is used to provide default 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName}, Column } from 'devextreme-react/{widget-name}';
     import 'whatwg-fetch';

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onKeyDown.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onKeyDown.md
@@ -93,7 +93,7 @@ The following code shows how to handle a key combination:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -116,7 +116,7 @@ The following code shows how to handle a key combination:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onRowClick.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onRowClick.md
@@ -131,7 +131,7 @@ In the following code, the **onRowClick** function calls the [editRow](/api-refe
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxEditing 
@@ -156,7 +156,7 @@ In the following code, the **onRowClick** function calls the [editRow](/api-refe
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Editing 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onRowRemoving.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onRowRemoving.md
@@ -143,7 +143,7 @@ This function allows you to intercept row removal and perform additional actions
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import {WidgetName}, { ... } from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/onRowValidating.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/onRowValidating.md
@@ -140,7 +140,7 @@ The following code illustrates how to validate an email address on the server an
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
     import 'whatwg-fetch';
@@ -174,7 +174,7 @@ The following code illustrates how to validate an email address on the server an
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
     import 'whatwg-fetch';

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/sortByGroupSummaryInfo/sortByGroupSummaryInfo.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/sortByGroupSummaryInfo/sortByGroupSummaryInfo.md
@@ -93,7 +93,7 @@ Normally, when records are grouped by a column, the groups are sorted according 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid, DxSummary, DxGroupItem } from 'devextreme-vue/data-grid';
 
@@ -111,7 +111,7 @@ Normally, when records are grouped by a column, the groups are sorted according 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, Summary, GroupItem } from 'devextreme-react/data-grid';
 
@@ -199,7 +199,7 @@ To use these summary items for sorting groups, assign an array of objects to the
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxDataGrid,
@@ -219,7 +219,7 @@ To use these summary items for sorting groups, assign an array of objects to the
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, SortByGroupSummaryInfo } from 'devextreme-react/data-grid';
 
@@ -308,7 +308,7 @@ After that, set the [groupColumn](/api-reference/10%20UI%20Components/dxDataGrid
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {
         DxDataGrid,
@@ -328,7 +328,7 @@ After that, set the [groupColumn](/api-reference/10%20UI%20Components/dxDataGrid
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DataGrid, SortByGroupSummaryInfo } from 'devextreme-react/data-grid';
 

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/sortByGroupSummaryInfo/summaryItem.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/sortByGroupSummaryInfo/summaryItem.md
@@ -77,7 +77,7 @@ The **summaryItem** property accepts one of the following values.
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDataGrid, {
             DxSummary,
@@ -100,7 +100,7 @@ The **summaryItem** property accepts one of the following values.
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DataGrid, {
             Summary,
@@ -191,7 +191,7 @@ The **summaryItem** property accepts one of the following values.
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDataGrid, {
             DxSummary,
@@ -214,7 +214,7 @@ The **summaryItem** property accepts one of the following values.
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DataGrid, {
             Summary,
@@ -330,7 +330,7 @@ The **summaryItem** property accepts one of the following values.
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDataGrid, {
             DxSummary,
@@ -353,7 +353,7 @@ The **summaryItem** property accepts one of the following values.
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DataGrid, {
             Summary,
@@ -470,7 +470,7 @@ The **summaryItem** property accepts one of the following values.
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDataGrid, {
             DxSummary,
@@ -493,7 +493,7 @@ The **summaryItem** property accepts one of the following values.
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DataGrid, {
             Summary,

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/groupItems/displayFormat.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/groupItems/displayFormat.md
@@ -83,7 +83,7 @@ You can use the following position markers in this text:
         </DxDataGrid>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, { DxSummary, DxGroupItem } from 'devextreme-vue/data-grid';
 
@@ -100,7 +100,7 @@ You can use the following position markers in this text:
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DataGrid, Summary, GroupItem } from 'devextreme-react/data-grid';
 
     class App extends React.Component {

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/groupItems/groupItems.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/groupItems/groupItems.md
@@ -81,7 +81,7 @@ To specify the items of the group summary, declare an array of objects, each of 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSummary,
@@ -102,7 +102,7 @@ To specify the items of the group summary, declare an array of objects, each of 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Summary,

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/groupItems/skipEmptyValues.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/groupItems/skipEmptyValues.md
@@ -57,7 +57,7 @@ Specified in a summary configuration object, this property affects an individual
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSummary
@@ -76,7 +76,7 @@ Specified in a summary configuration object, this property affects an individual
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Summary

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/skipEmptyValues.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/skipEmptyValues.md
@@ -94,7 +94,7 @@ Summaries of the *count* type do not skip empty values regardless of the **skipE
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSummary,
@@ -129,7 +129,7 @@ Summaries of the *count* type do not skip empty values regardless of the **skipE
 
     <!-- tab: App.js -->
     import React, { useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Summary,

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/totalItems/displayFormat.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/totalItems/displayFormat.md
@@ -83,7 +83,7 @@ You can use the following position markers in this text:
         </DxDataGrid>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid, DxSummary, DxTotalItem } from 'devextreme-vue/data-grid';
 
@@ -100,7 +100,7 @@ You can use the following position markers in this text:
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DataGrid, Summary, TotalItem } from 'devextreme-react/data-grid';
 
     class App extends React.Component {

--- a/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/totalItems/totalItems.md
+++ b/api-reference/10 UI Components/dxDataGrid/1 Configuration/summary/totalItems/totalItems.md
@@ -81,7 +81,7 @@ To specify the items of the total summary, declare an array of objects, each of 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSummary,
@@ -102,7 +102,7 @@ To specify the items of the total summary, declare an array of objects, each of 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Summary,

--- a/api-reference/10 UI Components/dxDataGrid/3 Methods/addRow().md
+++ b/api-reference/10 UI Components/dxDataGrid/3 Methods/addRow().md
@@ -84,7 +84,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDataGrid from 'devextreme-vue/data-grid';
         import DataSource from 'devextreme/data/data_source';
@@ -115,7 +115,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DataGrid from 'devextreme-react/data-grid';
         import DataSource from 'devextreme/data/data_source';
@@ -209,7 +209,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDataGrid from 'devextreme-vue/data-grid';
         import DataSource from 'devextreme/data/data_source';
@@ -242,7 +242,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DataGrid from 'devextreme-react/data-grid';
         import DataSource from 'devextreme/data/data_source';

--- a/api-reference/10 UI Components/dxDataGrid/3 Methods/getSelectedRowsData().md
+++ b/api-reference/10 UI Components/dxDataGrid/3 Methods/getSelectedRowsData().md
@@ -87,7 +87,7 @@ When selection is [deferred](/api-reference/10%20UI%20Components/dxDataGrid/1%20
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -126,7 +126,7 @@ When selection is [deferred](/api-reference/10%20UI%20Components/dxDataGrid/1%20
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
 

--- a/api-reference/10 UI Components/dxDataGrid/3 Methods/totalCount().md
+++ b/api-reference/10 UI Components/dxDataGrid/3 Methods/totalCount().md
@@ -212,7 +212,7 @@ The total row count.
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDataGrid from 'devextreme-vue/data-grid';
 
@@ -245,7 +245,7 @@ The total row count.
     
         <!-- tab: App.js -->
         import React, { useRef, useCallback } from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
         import DataGrid from 'devextreme-react/data-grid';
     

--- a/api-reference/10 UI Components/dxDataGrid/9 Types/Editing/allowDeleting.md
+++ b/api-reference/10 UI Components/dxDataGrid/9 Types/Editing/allowDeleting.md
@@ -75,7 +75,7 @@ The following code allows a user to delete only odd data rows:
     &lt;/template&gt;
 
     &lt;script&gt;
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxEditing
@@ -99,7 +99,7 @@ The following code allows a user to delete only odd data rows:
 
     &lt;!-- tab: App.js --&gt;
     import React, { useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Editing

--- a/api-reference/10 UI Components/dxDataGrid/9 Types/Summary/skipEmptyValues.md
+++ b/api-reference/10 UI Components/dxDataGrid/9 Types/Summary/skipEmptyValues.md
@@ -97,7 +97,7 @@ Summaries of the *count* type do not skip empty values regardless of the **skipE
     &lt;/template&gt;
 
     &lt;script&gt;
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSummary,
@@ -132,7 +132,7 @@ Summaries of the *count* type do not skip empty values regardless of the **skipE
 
     &lt;!-- tab: App.js --&gt;
     import React, { useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Summary,

--- a/api-reference/10 UI Components/dxDataGrid/9 Types/SummaryGroupItem/skipEmptyValues.md
+++ b/api-reference/10 UI Components/dxDataGrid/9 Types/SummaryGroupItem/skipEmptyValues.md
@@ -59,7 +59,7 @@ Specified in a summary configuration object, this property affects an individual
     &lt;/template&gt;
 
     &lt;script&gt;
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxSummary
@@ -78,7 +78,7 @@ Specified in a summary configuration object, this property affects an individual
 
     &lt;!-- tab: App.js --&gt;
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Summary

--- a/api-reference/10 UI Components/dxDateBox/1 Configuration/disabledDates.md
+++ b/api-reference/10 UI Components/dxDateBox/1 Configuration/disabledDates.md
@@ -93,7 +93,7 @@ This property accepts an array of dates:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -118,7 +118,7 @@ This property accepts an array of dates:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 
@@ -222,7 +222,7 @@ Alternatively, pass a function to **disabledDates**. This function should define
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -248,7 +248,7 @@ Alternatively, pass a function to **disabledDates**. This function should define
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxDateBox/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxDateBox/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxDateRangeBox/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxDateRangeBox/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxDateRangeBox/1 Configuration/value.md
+++ b/api-reference/10 UI Components/dxDateRangeBox/1 Configuration/value.md
@@ -60,7 +60,7 @@ If you change a date value, the new value is saved in the same format as the ini
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
 
@@ -79,7 +79,7 @@ If you change a date value, the new value is saved in the same format as the ini
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
     </script>
@@ -89,7 +89,7 @@ If you change a date value, the new value is saved in the same format as the ini
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateRangeBox } from 'devextreme-react/date-range-box';
  

--- a/api-reference/10 UI Components/dxDraggable/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxDraggable/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxDrawer/1 Configuration/closeOnOutsideClick.md
+++ b/api-reference/10 UI Components/dxDrawer/1 Configuration/closeOnOutsideClick.md
@@ -63,7 +63,7 @@ The function passed to this property enables you to specify a custom condition f
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDrawer from 'devextreme-vue/drawer';
 
@@ -83,7 +83,7 @@ The function passed to this property enables you to specify a custom condition f
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Drawer from 'devextreme-react/drawer';
 

--- a/api-reference/10 UI Components/dxDrawer/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxDrawer/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxDrawer/1 Configuration/template.md
+++ b/api-reference/10 UI Components/dxDrawer/1 Configuration/template.md
@@ -68,7 +68,7 @@ This property specifies the drawer's content. To specify the view's content, nes
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDrawer from 'devextreme-vue/drawer';
 
@@ -84,7 +84,7 @@ This property specifies the drawer's content. To specify the view's content, nes
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Drawer from 'devextreme-react/drawer';
 

--- a/api-reference/10 UI Components/dxDropDownBox/1 Configuration/displayValueFormatter.md
+++ b/api-reference/10 UI Components/dxDropDownBox/1 Configuration/displayValueFormatter.md
@@ -87,7 +87,7 @@ The following code demonstrates how to change separators from commas to semicolo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDropDownBox } from 'devextreme-vue/drop-down-box';
 
@@ -109,7 +109,7 @@ The following code demonstrates how to change separators from commas to semicolo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DropDownBox } from 'devextreme-react/drop-down-box';
 

--- a/api-reference/10 UI Components/dxDropDownBox/1 Configuration/fieldTemplate.md
+++ b/api-reference/10 UI Components/dxDropDownBox/1 Configuration/fieldTemplate.md
@@ -84,7 +84,7 @@ In the following code, the **fieldTemplate** is used to stylize the text field w
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDropDownBox from 'devextreme-vue/drop-down-box';
     import DxTextBox from 'devextreme-vue/text-box';
@@ -112,7 +112,7 @@ In the following code, the **fieldTemplate** is used to stylize the text field w
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DropDownBox } from 'devextreme-react/drop-down-box';
     import { TextBox } from 'devextreme-react/text-box';

--- a/api-reference/10 UI Components/dxDropDownBox/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxDropDownBox/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxDropDownButton/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxDropDownButton/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/abortUpload.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/abortUpload.md
@@ -85,7 +85,7 @@ A Promise that is resolved after the upload is aborted.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileUploader from 'devextreme-vue/file-uploader';
 
@@ -106,7 +106,7 @@ A Promise that is resolved after the upload is aborted.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileUploader from 'devextreme-react/file-uploader';
 

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/onBeforeSend.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/onBeforeSend.md
@@ -89,7 +89,7 @@ An object that provides information about the file upload session.
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileUploader

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/onFilesUploaded.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/onFilesUploaded.md
@@ -80,7 +80,7 @@ The UI component's instance.
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileUploader

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/onUploadError.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/onUploadError.md
@@ -102,7 +102,7 @@ The following code shows how you can handle a network error.
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileUploader

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadChunk.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadChunk.md
@@ -85,7 +85,7 @@ A Promise that is resolved after the chunk is uploaded.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileUploader from 'devextreme-vue/file-uploader';
 
@@ -106,7 +106,7 @@ A Promise that is resolved after the chunk is uploaded.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileUploader from 'devextreme-react/file-uploader';
 

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadCustomData.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadCustomData.md
@@ -60,7 +60,7 @@ Specifies custom data for the upload request.
         </DxFileUploader>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';    
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';    
         
         import {
             DxFileUploader
@@ -85,7 +85,7 @@ Specifies custom data for the upload request.
     <!-- tab: App.js -->
     import React from 'react';
     
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileUploader from 'devextreme-react/file-uploader';
     

--- a/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadFile.md
+++ b/api-reference/10 UI Components/dxFileUploader/1 Configuration/uploadFile.md
@@ -94,7 +94,7 @@ A Promise that is resolved after the file is uploaded.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileUploader from 'devextreme-vue/file-uploader';
 
@@ -119,7 +119,7 @@ A Promise that is resolved after the file is uploaded.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileUploader from 'devextreme-react/file-uploader';
 

--- a/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/filterOperationDescriptions/filterOperationDescriptions.md
+++ b/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/filterOperationDescriptions/filterOperationDescriptions.md
@@ -63,7 +63,7 @@ The following code sample illustrates how to set this property:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxFilterOperationDescriptions
@@ -81,7 +81,7 @@ The following code sample illustrates how to set this property:
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         FilterOperationDescriptions

--- a/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/groupOperationDescriptions/groupOperationDescriptions.md
+++ b/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/groupOperationDescriptions/groupOperationDescriptions.md
@@ -64,7 +64,7 @@ The following code sample illustrates how to set this property:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxGroupOperationDescriptions
@@ -82,7 +82,7 @@ The following code sample illustrates how to set this property:
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         GroupOperationDescriptions

--- a/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/onEditorPreparing.md
+++ b/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/onEditorPreparing.md
@@ -122,7 +122,7 @@ In the following code, the DevExtreme [TextArea](/concepts/05%20UI%20Components/
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFilterBuilder from 'devextreme-vue/filter-builder';
 
@@ -151,7 +151,7 @@ In the following code, the DevExtreme [TextArea](/concepts/05%20UI%20Components/
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FilterBuilder from 'devextreme-react/filter-builder';
 

--- a/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxFilterBuilder/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxForm/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxForm/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxForm/1 Configuration/screenByWidth.md
+++ b/api-reference/10 UI Components/dxForm/1 Configuration/screenByWidth.md
@@ -89,7 +89,7 @@ Implement the **screenByWidth** function to change the relation between a size q
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxForm, {
         // ...
@@ -115,7 +115,7 @@ Implement the **screenByWidth** function to change the relation between a size q
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Form, {
         // ...

--- a/api-reference/10 UI Components/dxForm/5 Item Types/SimpleItem/editorOptions.md
+++ b/api-reference/10 UI Components/dxForm/5 Item Types/SimpleItem/editorOptions.md
@@ -92,7 +92,7 @@ If you want to define multiple editors and avoid inline declarations, combine al
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxForm, {
         DxSimpleItem
@@ -125,7 +125,7 @@ If you use TypeScript, want to define multiple editors, and avoid inline declara
     import DxForm, { DxSimpleItem } from "devextreme-vue/form";
     import type { DxDateBoxTypes } from "devextreme-vue/date-box";
     import type { DxTextBoxTypes } from "devextreme-vue/text-box";
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     type EditorProps = DxDateBoxTypes.Properties | DxTextBoxTypes.Properties;
 
@@ -140,7 +140,7 @@ If you use TypeScript, want to define multiple editors, and avoid inline declara
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Form, {
         SimpleItem
@@ -165,7 +165,7 @@ If you use TypeScript, want to define multiple editors, and avoid inline declara
 If you use TypeScript, want to define multiple editors, and avoid inline declarations, combine all editor types into a [union](/concepts/Common/TypeScript%20Guides/10%20Best%20Practices/05%20Using%20Unions%20Instead%20of%20Base%20Classes.md '/Documentation/Guide/Common/TypeScript_Guides/Best_Practices/#Using_Unions_Instead_of_Base_Classes'). Next, assign each of your **editorOptions** an object with this union type.
 
     <!-- tab: App.tsx -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Form, { SimpleItem } from 'devextreme-react/form';
     import type { JSX } from 'react';
     import type { DateBoxTypes } from 'devextreme-react/date-box';

--- a/api-reference/10 UI Components/dxForm/5 Item Types/SimpleItem/template.md
+++ b/api-reference/10 UI Components/dxForm/5 Item Types/SimpleItem/template.md
@@ -179,7 +179,7 @@ The code below configures the [DateBox](/api-reference/10%20UI%20Components/dxDa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxForm, {
         DxSimpleItem,
@@ -221,7 +221,7 @@ The code below configures the [DateBox](/api-reference/10%20UI%20Components/dxDa
     <!-- tab: App.js -->
     import React, { useState } from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Form, {
         SimpleItem,

--- a/api-reference/10 UI Components/dxFunnel/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxFunnel/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxGallery/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxGallery/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxHtmlEditor/1 Configuration/customizeModules.md
+++ b/api-reference/10 UI Components/dxHtmlEditor/1 Configuration/customizeModules.md
@@ -81,7 +81,7 @@ The DevExtreme Quill modules and the API you can use to customize them are descr
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor from 'devextreme-vue/html-editor';
 
@@ -105,7 +105,7 @@ The DevExtreme Quill modules and the API you can use to customize them are descr
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor from 'devextreme-react/html-editor';
 

--- a/api-reference/10 UI Components/dxHtmlEditor/1 Configuration/imageUpload/imageUpload.md
+++ b/api-reference/10 UI Components/dxHtmlEditor/1 Configuration/imageUpload/imageUpload.md
@@ -95,7 +95,7 @@ Use the [fileUploadMode](/api-reference/_hidden/dxHtmlEditorImageUpload/fileUplo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor from 'devextreme-vue/html-editor';
 
@@ -119,7 +119,7 @@ Use the [fileUploadMode](/api-reference/_hidden/dxHtmlEditorImageUpload/fileUplo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor from 'devextreme-react/html-editor';
 

--- a/api-reference/10 UI Components/dxHtmlEditor/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxHtmlEditor/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxHtmlEditor/1 Configuration/variables/variables.md
+++ b/api-reference/10 UI Components/dxHtmlEditor/1 Configuration/variables/variables.md
@@ -73,7 +73,7 @@ A user can insert variables in the text and remove them, but never modify them.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor, {
         DxToolbar,
@@ -98,7 +98,7 @@ A user can insert variables in the text and remove them, but never modify them.
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor, {
         Variables

--- a/api-reference/10 UI Components/dxHtmlEditor/3 Methods/format(formatName_formatValue).md
+++ b/api-reference/10 UI Components/dxHtmlEditor/3 Methods/format(formatName_formatValue).md
@@ -67,7 +67,7 @@ If no content is selected, the format applies to the character typed next.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxHtmlEditor from 'devextreme-vue/html-editor';
 
     const htmlEditorRefKey = "my-html-editor";
@@ -105,7 +105,7 @@ If no content is selected, the format applies to the character typed next.
 
     <!-- tab: App.js -->
     import { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor from 'devextreme-react/html-editor';
 

--- a/api-reference/10 UI Components/dxHtmlEditor/3 Methods/formatLine(index_length_formatName_formatValue).md
+++ b/api-reference/10 UI Components/dxHtmlEditor/3 Methods/formatLine(index_length_formatName_formatValue).md
@@ -61,7 +61,7 @@ Pass **null** to remove a format.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxHtmlEditor from 'devextreme-vue/html-editor';
 
     const htmlEditorRefKey = "my-html-editor";
@@ -92,7 +92,7 @@ Pass **null** to remove a format.
 
     <!-- tab: App.js -->
     import { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor from 'devextreme-react/html-editor';
 

--- a/api-reference/10 UI Components/dxHtmlEditor/3 Methods/formatLine(index_length_formats).md
+++ b/api-reference/10 UI Components/dxHtmlEditor/3 Methods/formatLine(index_length_formats).md
@@ -60,7 +60,7 @@ Pass **null** to remove all formats.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxHtmlEditor from 'devextreme-vue/html-editor';
 
     const htmlEditorRefKey = "my-html-editor";
@@ -91,7 +91,7 @@ Pass **null** to remove all formats.
 
     <!-- tab: App.js -->
     import { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor from 'devextreme-react/html-editor';
 

--- a/api-reference/10 UI Components/dxHtmlEditor/3 Methods/formatText(index_length_formatName_formatValue).md
+++ b/api-reference/10 UI Components/dxHtmlEditor/3 Methods/formatText(index_length_formatName_formatValue).md
@@ -58,7 +58,7 @@ Applies a single [text format](/concepts/05%20UI%20Components/HtmlEditor/10%20Fo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxHtmlEditor from 'devextreme-vue/html-editor';
 
     const htmlEditorRefKey = "my-html-editor";
@@ -90,7 +90,7 @@ Applies a single [text format](/concepts/05%20UI%20Components/HtmlEditor/10%20Fo
 
     <!-- tab: App.js -->
     import { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor from 'devextreme-react/html-editor';
 

--- a/api-reference/10 UI Components/dxHtmlEditor/3 Methods/formatText(index_length_formats).md
+++ b/api-reference/10 UI Components/dxHtmlEditor/3 Methods/formatText(index_length_formats).md
@@ -56,7 +56,7 @@ Applies several [text formats](/concepts/05%20UI%20Components/HtmlEditor/10%20Fo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxHtmlEditor from 'devextreme-vue/html-editor';
 
     const htmlEditorRefKey = "my-html-editor";
@@ -88,7 +88,7 @@ Applies several [text formats](/concepts/05%20UI%20Components/HtmlEditor/10%20Fo
 
     <!-- tab: App.js -->
     import { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor from 'devextreme-react/html-editor';
 

--- a/api-reference/10 UI Components/dxHtmlEditor/3 Methods/get(componentPath).md
+++ b/api-reference/10 UI Components/dxHtmlEditor/3 Methods/get(componentPath).md
@@ -101,7 +101,7 @@ In the following code, the `bold` format is associated with the `<b>` tag instea
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor from 'devextreme-vue/html-editor';
 
@@ -137,7 +137,7 @@ In the following code, the `bold` format is associated with the `<b>` tag instea
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor from 'devextreme-react/html-editor';
 

--- a/api-reference/10 UI Components/dxHtmlEditor/3 Methods/insertEmbed(index_type_config).md
+++ b/api-reference/10 UI Components/dxHtmlEditor/3 Methods/insertEmbed(index_type_config).md
@@ -62,7 +62,7 @@ An embedded format's [value](/concepts/05%20UI%20Components/HtmlEditor/10%20Form
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxHtmlEditor from 'devextreme-vue/html-editor';
 
     const htmlEditorRefKey = "my-html-editor";
@@ -98,7 +98,7 @@ An embedded format's [value](/concepts/05%20UI%20Components/HtmlEditor/10%20Form
 
     <!-- tab: App.js -->
     import { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor from 'devextreme-react/html-editor';
 

--- a/api-reference/10 UI Components/dxHtmlEditor/3 Methods/insertText(index_text_formats).md
+++ b/api-reference/10 UI Components/dxHtmlEditor/3 Methods/insertText(index_text_formats).md
@@ -63,7 +63,7 @@ This object should have the following structure:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxHtmlEditor from 'devextreme-vue/html-editor';
 
     const htmlEditorRefKey = "my-html-editor";
@@ -98,7 +98,7 @@ This object should have the following structure:
 
     <!-- tab: App.js -->
     import { useRef } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor from 'devextreme-react/html-editor';
 

--- a/api-reference/10 UI Components/dxHtmlEditor/3 Methods/register(components).md
+++ b/api-reference/10 UI Components/dxHtmlEditor/3 Methods/register(components).md
@@ -49,7 +49,7 @@ where `path1` is *formats/[formatName]* for formats or *modules/[moduleName]* fo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor from 'devextreme-vue/html-editor';
 
@@ -82,7 +82,7 @@ where `path1` is *formats/[formatName]* for formats or *modules/[moduleName]* fo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor from 'devextreme-react/html-editor';
 

--- a/api-reference/10 UI Components/dxLinearGauge/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxLinearGauge/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxList/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxList/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxLoadIndicator/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxLoadIndicator/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxLoadPanel/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxLoadPanel/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxLookup/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxLookup/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxLookup/1 Configuration/searchStartEvent.md
+++ b/api-reference/10 UI Components/dxLookup/1 Configuration/searchStartEvent.md
@@ -61,7 +61,7 @@ The recommended events are "keyup", "blur", "change", "input", and "focusout", b
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import DxLookup from 'devextreme-vue/lookup'; 
 
     export default { 
@@ -77,7 +77,7 @@ The recommended events are "keyup", "blur", "change", "input", and "focusout", b
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import Lookup from 'devextreme-react/lookup'; 
 

--- a/api-reference/10 UI Components/dxMap/1 Configuration/apiKey/apiKey.md
+++ b/api-reference/10 UI Components/dxMap/1 Configuration/apiKey/apiKey.md
@@ -81,7 +81,7 @@ If you have more than one map provider in your application, specify the keys in 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMap, {
         DxApiKey
@@ -100,7 +100,7 @@ If you have more than one map provider in your application, specify the keys in 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Map, {
         ApiKey

--- a/api-reference/10 UI Components/dxMap/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxMap/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxMap/1 Configuration/providerConfig/providerConfig.md
+++ b/api-reference/10 UI Components/dxMap/1 Configuration/providerConfig/providerConfig.md
@@ -70,7 +70,7 @@ A [provider](/api-reference/10%20UI%20Components/dxMap/1%20Configuration/provide
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxMap, {
         DxProviderConfig
@@ -88,7 +88,7 @@ A [provider](/api-reference/10%20UI%20Components/dxMap/1%20Configuration/provide
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Map, {
         ProviderConfig

--- a/api-reference/10 UI Components/dxMenu/1 Configuration/adaptivityEnabled.md
+++ b/api-reference/10 UI Components/dxMenu/1 Configuration/adaptivityEnabled.md
@@ -64,7 +64,7 @@ The following code example sets the container's width to 400 pixels, sets the Me
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxMenu from 'devextreme-vue/menu';
 
@@ -90,7 +90,7 @@ The following code example sets the container's width to 400 pixels, sets the Me
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Menu } from 'devextreme-react/menu';
 

--- a/api-reference/10 UI Components/dxMenu/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxMenu/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxMultiView/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxMultiView/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxNumberBox/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxNumberBox/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxPieChart/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxPieChart/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxPivotGridFieldChooser/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxPivotGridFieldChooser/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxPolarChart/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxPolarChart/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxPopover/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxPopover/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxPopup/1 Configuration/toolbarItems/toolbarItems.md
+++ b/api-reference/10 UI Components/dxPopup/1 Configuration/toolbarItems/toolbarItems.md
@@ -131,7 +131,7 @@ In the following code, two items are defined on the toolbar: one is plain text, 
         </Dx{WidgetName}>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, { DxToolbarItem } from 'devextreme-vue/{widget-name}';
 
@@ -154,7 +154,7 @@ In the following code, two items are defined on the toolbar: one is plain text, 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName}, ToolbarItem } from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxProgressBar/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxProgressBar/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxRadioGroup/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxRadioGroup/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxRangeSelector/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxRangeSelector/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxRangeSlider/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxRangeSlider/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxResizable/1 Configuration/keepAspectRatio.md
+++ b/api-reference/10 UI Components/dxResizable/1 Configuration/keepAspectRatio.md
@@ -48,7 +48,7 @@ Set this property to **false** to enable free-form resize:
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Resizable from 'devextreme-react/resizable';
 

--- a/api-reference/10 UI Components/dxResizable/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxResizable/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxResponsiveBox/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxResponsiveBox/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxSankey/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxSankey/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxScrollView/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxScrollView/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxSelectBox/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxSelectBox/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxSlider/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxSlider/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxSliderBase/1 Configuration/valueChangeMode.md
+++ b/api-reference/10 UI Components/dxSliderBase/1 Configuration/valueChangeMode.md
@@ -86,7 +86,7 @@ If you want to change the component's [value](/api-reference/10%20UI%20Component
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName} } from 'devextreme-vue/slider';
 
@@ -113,7 +113,7 @@ If you want to change the component's [value](/api-reference/10%20UI%20Component
 
     <!-- tab: App.js -->
     import React, { useState, useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName} } from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxSortable/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxSortable/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxSparkline/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxSparkline/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxSpeedDialAction/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxSpeedDialAction/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxSplitter/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxSplitter/1 Configuration/onOptionChanged.md
@@ -101,7 +101,7 @@ The following code snippet shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -125,7 +125,7 @@ The following code snippet shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxStepper/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxStepper/1 Configuration/onOptionChanged.md
@@ -101,7 +101,7 @@ The following code snippet shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -125,7 +125,7 @@ The following code snippet shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxSwitch/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxSwitch/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxTabPanel/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxTabPanel/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxTabs/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxTabs/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxTagBox/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxTagBox/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxTagBox/1 Configuration/tagTemplate.md
+++ b/api-reference/10 UI Components/dxTagBox/1 Configuration/tagTemplate.md
@@ -82,7 +82,7 @@ This template replaces the default tag template. If you need to recreate the def
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTagBox from 'devextreme-vue/tag-box';
 
@@ -99,7 +99,7 @@ This template replaces the default tag template. If you need to recreate the def
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TagBox from 'devextreme-react/tag-box';
 

--- a/api-reference/10 UI Components/dxTextArea/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxTextArea/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxTextBox/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxTextBox/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxTextEditor/1 Configuration/inputAttr.md
+++ b/api-reference/10 UI Components/dxTextEditor/1 Configuration/inputAttr.md
@@ -51,7 +51,7 @@ Specifies the attributes to be passed on to the underlying HTML element.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -70,7 +70,7 @@ Specifies the attributes to be passed on to the underlying HTML element.
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxTextEditor/1 Configuration/maskRules.md
+++ b/api-reference/10 UI Components/dxTextEditor/1 Configuration/maskRules.md
@@ -120,7 +120,7 @@ The following code snippet demonstrates the use of the function to set a dynamic
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -151,7 +151,7 @@ The following code snippet demonstrates the use of the function to set a dynamic
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxTextEditor/1 Configuration/readOnly.md
+++ b/api-reference/10 UI Components/dxTextEditor/1 Configuration/readOnly.md
@@ -86,7 +86,7 @@ When this property is set to **true**, the following applies:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import Dx{WidgetName}, {
             DxButton as Dx{WidgetName}Button
@@ -115,7 +115,7 @@ When this property is set to **true**, the following applies:
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import {WidgetName}, {
             Button as {WidgetName}Button
@@ -228,7 +228,7 @@ When this property is set to **true**, the following applies:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import Dx{WidgetName}, {
             DxButton as Dx{WidgetName}Button
@@ -260,7 +260,7 @@ When this property is set to **true**, the following applies:
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import {WidgetName}, {
             Button as {WidgetName}Button

--- a/api-reference/10 UI Components/dxTextEditor/3 Methods/getButton(name).md
+++ b/api-reference/10 UI Components/dxTextEditor/3 Methods/getButton(name).md
@@ -56,7 +56,7 @@ Use the returned button instance to call the [Button UI component's methods](/ap
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -90,7 +90,7 @@ Use the returned button instance to call the [Button UI component's methods](/ap
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxTileView/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxTileView/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxToast/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxToast/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxToolbar/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxToolbar/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxTooltip/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxTooltip/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxTreeList/1 Configuration/cacheEnabled.md
+++ b/api-reference/10 UI Components/dxTreeList/1 Configuration/cacheEnabled.md
@@ -46,7 +46,7 @@ To update data in cache, call the [refresh()](/api-reference/10%20UI%20Component
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -82,7 +82,7 @@ To update data in cache, call the [refresh()](/api-reference/10%20UI%20Component
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxTreeList/1 Configuration/columns/columns.md
+++ b/api-reference/10 UI Components/dxTreeList/1 Configuration/columns/columns.md
@@ -78,7 +78,7 @@ This property accepts an array of objects, where each object configures a single
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxColumn
@@ -96,7 +96,7 @@ This property accepts an array of objects, where each object configures a single
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Column

--- a/api-reference/10 UI Components/dxTreeList/1 Configuration/editing/allowAdding.md
+++ b/api-reference/10 UI Components/dxTreeList/1 Configuration/editing/allowAdding.md
@@ -72,7 +72,7 @@ In the following code, the **Add** button is added to rows whose status is _not_
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxEditing
@@ -96,7 +96,7 @@ In the following code, the **Add** button is added to rows whose status is _not_
 
     <!-- tab: App.js -->
     import React, { useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Editing

--- a/api-reference/10 UI Components/dxTreeList/1 Configuration/onAdaptiveDetailRowPreparing.md
+++ b/api-reference/10 UI Components/dxTreeList/1 Configuration/onAdaptiveDetailRowPreparing.md
@@ -85,7 +85,7 @@ The following Form properties cannot be specified using **formOptions**:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-vue/{widget-name}';
   
@@ -113,7 +113,7 @@ The following Form properties cannot be specified using **formOptions**:
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-vue/{widget-name}';
     
@@ -131,7 +131,7 @@ The following Form properties cannot be specified using **formOptions**:
     <!-- tab: App.js -->
     import { useCallback } from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxTreeList/1 Configuration/onContextMenuPreparing.md
+++ b/api-reference/10 UI Components/dxTreeList/1 Configuration/onContextMenuPreparing.md
@@ -126,7 +126,7 @@ In the following code, the **onContextMenuPreparing** function adds a custom ite
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -163,7 +163,7 @@ In the following code, the **onContextMenuPreparing** function adds a custom ite
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxTreeList/1 Configuration/onInitNewRow.md
+++ b/api-reference/10 UI Components/dxTreeList/1 Configuration/onInitNewRow.md
@@ -147,7 +147,7 @@ In the following code, the **onInitNewRow** function is used to provide default 
         </Dx{WidgetName}>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName}, DxColumn } from 'devextreme-vue/{widget-name}';
     import 'whatwg-fetch';
@@ -193,7 +193,7 @@ In the following code, the **onInitNewRow** function is used to provide default 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName}, Column } from 'devextreme-react/{widget-name}';
     import 'whatwg-fetch';

--- a/api-reference/10 UI Components/dxTreeList/1 Configuration/onKeyDown.md
+++ b/api-reference/10 UI Components/dxTreeList/1 Configuration/onKeyDown.md
@@ -93,7 +93,7 @@ The following code shows how to handle a key combination:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -116,7 +116,7 @@ The following code shows how to handle a key combination:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxTreeList/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxTreeList/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxTreeList/1 Configuration/onRowRemoving.md
+++ b/api-reference/10 UI Components/dxTreeList/1 Configuration/onRowRemoving.md
@@ -143,7 +143,7 @@ This function allows you to intercept row removal and perform additional actions
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import {WidgetName}, { ... } from 'devextreme-react/{widget-name}';
 

--- a/api-reference/10 UI Components/dxTreeList/1 Configuration/onRowValidating.md
+++ b/api-reference/10 UI Components/dxTreeList/1 Configuration/onRowValidating.md
@@ -140,7 +140,7 @@ The following code illustrates how to validate an email address on the server an
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
     import 'whatwg-fetch';
@@ -174,7 +174,7 @@ The following code illustrates how to validate an email address on the server an
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
     import 'whatwg-fetch';

--- a/api-reference/10 UI Components/dxTreeList/3 Methods/addRow().md
+++ b/api-reference/10 UI Components/dxTreeList/3 Methods/addRow().md
@@ -80,7 +80,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxTreeList from 'devextreme-vue/tree-list';
         import DataSource from 'devextreme/data/data_source';
@@ -111,7 +111,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import TreeList from 'devextreme-react/tree-list';
         import DataSource from 'devextreme/data/data_source';
@@ -207,7 +207,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxTreeList from 'devextreme-vue/tree-list';
         import DataSource from 'devextreme/data/data_source';
@@ -240,7 +240,7 @@ Use this method if you want to add an empty row. If you need to add a row with d
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import TreeList from 'devextreme-react/tree-list';
         import DataSource from 'devextreme/data/data_source';

--- a/api-reference/10 UI Components/dxTreeList/3 Methods/getSelectedRowsData().md
+++ b/api-reference/10 UI Components/dxTreeList/3 Methods/getSelectedRowsData().md
@@ -76,7 +76,7 @@ The objects are not processed by the [DataSource](/api-reference/30%20Data%20Lay
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -110,7 +110,7 @@ The objects are not processed by the [DataSource](/api-reference/30%20Data%20Lay
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/api-reference/10 UI Components/dxTreeList/3 Methods/getSelectedRowsData(mode).md
+++ b/api-reference/10 UI Components/dxTreeList/3 Methods/getSelectedRowsData(mode).md
@@ -100,7 +100,7 @@ Returns data objects of the end nodes ("leaves") only.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList from 'devextreme-vue/tree-list';
 
@@ -134,7 +134,7 @@ Returns data objects of the end nodes ("leaves") only.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList from 'devextreme-react/tree-list';
 

--- a/api-reference/10 UI Components/dxTreeList/9 Types/Editing/allowAdding.md
+++ b/api-reference/10 UI Components/dxTreeList/9 Types/Editing/allowAdding.md
@@ -75,7 +75,7 @@ In the following code, the **Add** button is added to rows whose status is _not_
     &lt;/template&gt;
 
     &lt;script&gt;
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeList, {
         DxEditing
@@ -99,7 +99,7 @@ In the following code, the **Add** button is added to rows whose status is _not_
 
     &lt;!-- tab: App.js --&gt;
     import React, { useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeList, {
         Editing

--- a/api-reference/10 UI Components/dxTreeMap/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxTreeMap/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxTreeView/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxTreeView/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxTreeView/3 Methods/getSelectedNodes().md
+++ b/api-reference/10 UI Components/dxTreeView/3 Methods/getSelectedNodes().md
@@ -73,7 +73,7 @@ Selected nodes.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxTreeView from 'devextreme-vue/tree-view';
 
@@ -105,7 +105,7 @@ Selected nodes.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import TreeView from 'devextreme-react/tree-view';
 

--- a/api-reference/10 UI Components/dxValidationGroup/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxValidationGroup/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxValidationGroup/9 Validation Result/complete.md
+++ b/api-reference/10 UI Components/dxValidationGroup/9 Validation Result/complete.md
@@ -158,7 +158,7 @@ In the following example, a button validates a group of editors with async rules
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTextBox } from 'devextreme-vue/text-box';
     import { DxDateBox } from 'devextreme-vue/date-box';
@@ -201,7 +201,7 @@ In the following example, a button validates a group of editors with async rules
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TextBox } from 'devextreme-react/text-box';
     import { DateBox } from 'devextreme-react/date-box';

--- a/api-reference/10 UI Components/dxValidationSummary/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxValidationSummary/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 

--- a/api-reference/10 UI Components/dxValidator/8 Validation Rules/AsyncRule/validationCallback.md
+++ b/api-reference/10 UI Components/dxValidator/8 Validation Rules/AsyncRule/validationCallback.md
@@ -142,7 +142,7 @@ The following code shows a generic **validationCallback** implementation for a s
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTextBox } from 'devextreme-vue/text-box';
     import {
@@ -193,7 +193,7 @@ The following code shows a generic **validationCallback** implementation for a s
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TextBox } from 'devextreme-react/text-box';
     import {

--- a/api-reference/10 UI Components/dxValidator/8 Validation Rules/CustomRule/validationCallback.md
+++ b/api-reference/10 UI Components/dxValidator/8 Validation Rules/CustomRule/validationCallback.md
@@ -98,7 +98,7 @@ The following code sample shows a **validationCallback** example. The **validate
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxNumberBox from 'devextreme-vue/number-box';
     import DxValidator, {
@@ -124,7 +124,7 @@ The following code sample shows a **validationCallback** example. The **validate
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import NumberBox from 'devextreme-react/number-box';
     import Validator, {
@@ -241,7 +241,7 @@ The code snippet below demonstrates how to implement multiple validation message
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxNumberBox from 'devextreme-vue/number-box';
     import DxValidator, {
@@ -279,7 +279,7 @@ The code snippet below demonstrates how to implement multiple validation message
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import NumberBox from 'devextreme-react/number-box';
     import Validator, {

--- a/api-reference/10 UI Components/dxValidator/9 Validation Result/complete.md
+++ b/api-reference/10 UI Components/dxValidator/9 Validation Result/complete.md
@@ -124,7 +124,7 @@ In the following example, a button validates an editor with an async rule. The *
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxTextBox } from 'devextreme-vue/text-box';
     import { DxButton } from 'devextreme-vue/button';
@@ -165,7 +165,7 @@ In the following example, a button validates an editor with an async rule. The *
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { TextBox } from 'devextreme-react/text-box';
     import { Button } from 'devextreme-react/button';

--- a/api-reference/10 UI Components/dxVectorMap/1 Configuration/onOptionChanged.md
+++ b/api-reference/10 UI Components/dxVectorMap/1 Configuration/onOptionChanged.md
@@ -102,7 +102,7 @@ The following example shows how to subscribe to component property changes:
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}'; 
 
     export default { 
@@ -126,7 +126,7 @@ The following example shows how to subscribe to component property changes:
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName} from 'devextreme-react/{widget-name}'; 
 


### PR DESCRIPTION
Replaced mentions of Generic themes with Fluent:
import 'devextreme/dist/css/dx.light.css'; > import 'devextreme/dist/css/dx.fluent.blue.light.css';

Included files:

```
api-reference\10 UI Components\**\*.md
```

Excluded files:

```
api-reference\10 UI Components\dxGantt\**\*.md,
api-reference\10 UI Components\dxDiagram\**\*.md,
api-reference\10 UI Components\dxFileManager\**\*.md,
api-reference\10 UI Components\dxScheduler\**\*.md,
api-reference\10 UI Components\dxPivotGrid\**\*.md,
```