### PR TITLE
Update Theme Mentions to Fluent - All Remaining Files

### DIFF
--- a/api-reference/10 UI Components/dxGantt/1 Configuration/dependencies/dependencies.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/dependencies/dependencies.md
@@ -173,7 +173,7 @@ Use the [dataSource](/api-reference/10%20UI%20Components/dxGantt/1%20Configurati
             "build": {
               "options": {
                 "styles": [
-                  "node_modules/devextreme/dist/css/dx.light.css",
+                  "node_modules/devextreme/dist/css/dx.fluent.blue.light.css",
                   "node_modules/devexpress-gantt/dist/dx-gantt.css",
                   "src/styles.css"
                 ],

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/resourceAssignments/resourceAssignments.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/resourceAssignments/resourceAssignments.md
@@ -125,7 +125,7 @@ Use the [dataSource](/api-reference/10%20UI%20Components/dxGantt/1%20Configurati
             "build": {
               "options": {
                 "styles": [
-                  "node_modules/devextreme/dist/css/dx.light.css",
+                  "node_modules/devextreme/dist/css/dx.fluent.blue.light.css",
                   "node_modules/devexpress-gantt/dist/dx-gantt.css",
                   "src/styles.css"
                 ],

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/resources/resources.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/resources/resources.md
@@ -134,7 +134,7 @@ The 'color' field accepts the following values:
             "build": {
               "options": {
                 "styles": [
-                  "node_modules/devextreme/dist/css/dx.light.css",
+                  "node_modules/devextreme/dist/css/dx.fluent.blue.light.css",
                   "node_modules/devexpress-gantt/dist/dx-gantt.css",
                   "src/styles.css"
                 ],

--- a/api-reference/10 UI Components/dxGantt/1 Configuration/tasks/tasks.md
+++ b/api-reference/10 UI Components/dxGantt/1 Configuration/tasks/tasks.md
@@ -153,7 +153,7 @@ The 'color' field accepts the following values:
             "build": {
               "options": {
                 "styles": [
-                  "node_modules/devextreme/dist/css/dx.light.css",
+                  "node_modules/devextreme/dist/css/dx.fluent.blue.light.css",
                   "node_modules/devexpress-gantt/dist/dx-gantt.css",
                   "src/styles.css"
                 ],

--- a/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/fields/format.md
+++ b/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/fields/format.md
@@ -322,7 +322,7 @@ The following code declares a custom group for the `ShippingDate` data field. Th
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import PivotGrid from 'devextreme-react/pivot-grid';
     import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
@@ -475,7 +475,7 @@ Cannot be converted, the cell value is exported without formatting. To export th
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxPivotGrid, {
             DxExport
@@ -514,7 +514,7 @@ Cannot be converted, the cell value is exported without formatting. To export th
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import PivotGrid, {
             Export

--- a/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/fields/headerFilter/headerFilter.md
+++ b/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/fields/headerFilter/headerFilter.md
@@ -159,7 +159,7 @@ Configures the field's header filter.
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
     import DxPivotGrid from 'devextreme-react/pivot-grid';

--- a/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/fields/headerFilter/search/editorOptions.md
+++ b/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/fields/headerFilter/search/editorOptions.md
@@ -178,7 +178,7 @@ See the [TextBox Configuration](/Documentation/ApiReference/UI_Components/dxText
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
     import DxPivotGrid from 'devextreme-react/pivot-grid';

--- a/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/fields/headerFilter/search/search.md
+++ b/api-reference/30 Data Layer/PivotGridDataSource/1 Configuration/fields/headerFilter/search/search.md
@@ -177,7 +177,7 @@ Configures the header filter's search functionality.
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import PivotGridDataSource from 'devextreme/ui/pivot_grid/data_source';
     import DxPivotGrid from 'devextreme-react/pivot-grid';

--- a/api-reference/40 Common Types/14 gauges/BaseGaugeAnimation/BaseGaugeAnimation.md
+++ b/api-reference/40 Common Types/14 gauges/BaseGaugeAnimation/BaseGaugeAnimation.md
@@ -83,7 +83,7 @@ To make your gauge "live", enable animation for it by setting the **enabled** pr
     &lt;/template&gt;
 
     &lt;script&gt;
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxAnimation
@@ -103,7 +103,7 @@ To make your gauge "live", enable animation for it by setting the **enabled** pr
     &lt;!-- tab: App.js --&gt;
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Animation 

--- a/api-reference/40 Common Types/15 grids/ColumnHeaderFilter/groupInterval.md
+++ b/api-reference/40 Common Types/15 grids/ColumnHeaderFilter/groupInterval.md
@@ -112,7 +112,7 @@ The default header filter for date columns is hierarchical. To implement a non-h
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName}, DxColumn, DxHeaderFilter } from 'devextreme-vue/{widget-name}';
 
@@ -130,7 +130,7 @@ The default header filter for date columns is hierarchical. To implement a non-h
 
     <!-- tab: App.tsx -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName}, Column, HeaderFilter } from 'devextreme-react/{widget-name}';
 

--- a/api-reference/40 Common Types/15 grids/EditingBase/texts.md
+++ b/api-reference/40 Common Types/15 grids/EditingBase/texts.md
@@ -83,7 +83,7 @@ The following code shows the **editing**.**texts** declaration syntax:
     &lt;/template&gt;
 
     &lt;script&gt;
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxEditing,
@@ -107,7 +107,7 @@ The following code shows the **editing**.**texts** declaration syntax:
     &lt;!-- tab: App.js --&gt;
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Editing,

--- a/api-reference/40 Common Types/15 grids/EditingTextsBase/EditingTextsBase.md
+++ b/api-reference/40 Common Types/15 grids/EditingTextsBase/EditingTextsBase.md
@@ -87,7 +87,7 @@ The following code shows the **editing**.**texts** declaration syntax:
     &lt;/template&gt;
 
     &lt;script&gt;
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxEditing,
@@ -111,7 +111,7 @@ The following code shows the **editing**.**texts** declaration syntax:
     &lt;!-- tab: App.js --&gt;
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Editing,

--- a/api-reference/40 Common Types/15 grids/FilterRow/operationDescriptions.md
+++ b/api-reference/40 Common Types/15 grids/FilterRow/operationDescriptions.md
@@ -70,7 +70,7 @@ The following code sample illustrates how to set this property:
     &lt;/template&gt;
 
     &lt;script&gt;
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxFilterRow,
@@ -90,7 +90,7 @@ The following code sample illustrates how to set this property:
 ##### React
 
     &lt;!-- tab: App.js --&gt;
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         FilterRow,

--- a/api-reference/40 Common Types/15 grids/FilterRowOperationDescriptions/FilterRowOperationDescriptions.md
+++ b/api-reference/40 Common Types/15 grids/FilterRowOperationDescriptions/FilterRowOperationDescriptions.md
@@ -73,7 +73,7 @@ The following code sample illustrates how to set this property:
     &lt;/template&gt;
 
     &lt;script&gt;
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxFilterRow,
@@ -93,7 +93,7 @@ The following code sample illustrates how to set this property:
 ##### React
 
     &lt;!-- tab: App.js --&gt;
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         FilterRow,

--- a/api-reference/40 Common Types/BaseWidgetMargin/BaseWidgetMargin.md
+++ b/api-reference/40 Common Types/BaseWidgetMargin/BaseWidgetMargin.md
@@ -89,7 +89,7 @@ Generates space around the UI component.
     &lt;/template&gt;
 
     &lt;script&gt;
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxMargin 
@@ -109,7 +109,7 @@ Generates space around the UI component.
     &lt;!-- tab: App.js --&gt;
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Margin 

--- a/api-reference/50 Common/Object Structures/ExcelExportDataGridProps/customizeCell.md
+++ b/api-reference/50 Common/Object Structures/ExcelExportDataGridProps/customizeCell.md
@@ -151,7 +151,7 @@ The following code snippet checks DataGrid cell [rowType](/api-reference/10%20UI
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid, DxExport } from 'devextreme-vue/data-grid';
     import { exportDataGrid } from 'devextreme/excel_exporter';
@@ -194,7 +194,7 @@ The following code snippet checks DataGrid cell [rowType](/api-reference/10%20UI
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, { Export } from 'devextreme-react/data-grid';
     import { Workbook } from 'devextreme-exceljs-fork';

--- a/api-reference/50 Common/Object Structures/PdfCell/PdfCell.md
+++ b/api-reference/50 Common/Object Structures/PdfCell/PdfCell.md
@@ -127,7 +127,7 @@ The [customDrawCell](/api-reference/50%20Common/Object%20Structures/PdfExportDat
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -177,7 +177,7 @@ The [customDrawCell](/api-reference/50%20Common/Object%20Structures/PdfExportDat
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfCell/drawBottomBorder.md
+++ b/api-reference/50 Common/Object Structures/PdfCell/drawBottomBorder.md
@@ -117,7 +117,7 @@ Specifies whether to show cell's bottom border.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -166,7 +166,7 @@ Specifies whether to show cell's bottom border.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfCell/drawLeftBorder.md
+++ b/api-reference/50 Common/Object Structures/PdfCell/drawLeftBorder.md
@@ -116,7 +116,7 @@ Specifies whether to show cell's left border.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -165,7 +165,7 @@ Specifies whether to show cell's left border.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfCell/drawRightBorder.md
+++ b/api-reference/50 Common/Object Structures/PdfCell/drawRightBorder.md
@@ -116,7 +116,7 @@ Specifies whether to show cell's right border.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -165,7 +165,7 @@ Specifies whether to show cell's right border.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfCell/drawTopBorder.md
+++ b/api-reference/50 Common/Object Structures/PdfCell/drawTopBorder.md
@@ -116,7 +116,7 @@ Specifies whether to show cell's top border.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -165,7 +165,7 @@ Specifies whether to show cell's top border.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfCell/font/font.md
+++ b/api-reference/50 Common/Object Structures/PdfCell/font/font.md
@@ -119,7 +119,7 @@ An object that contains information about the font's size, name, and style.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -168,7 +168,7 @@ An object that contains information about the font's size, name, and style.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfCell/padding/padding.md
+++ b/api-reference/50 Common/Object Structures/PdfCell/padding/padding.md
@@ -118,7 +118,7 @@ Uses the measure units which are specified in the constructor of the [jsPDFDocum
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -167,7 +167,7 @@ Uses the measure units which are specified in the constructor of the [jsPDFDocum
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfExportDataGridProps/PdfExportDataGridProps.md
+++ b/api-reference/50 Common/Object Structures/PdfExportDataGridProps/PdfExportDataGridProps.md
@@ -121,7 +121,7 @@ The [exportDataGrid(options)](/api-reference/50%20Common/utils/pdfExporter/expor
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -163,7 +163,7 @@ The [exportDataGrid(options)](/api-reference/50%20Common/utils/pdfExporter/expor
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfExportDataGridProps/columnWidths.md
+++ b/api-reference/50 Common/Object Structures/PdfExportDataGridProps/columnWidths.md
@@ -120,7 +120,7 @@ The example below calls the [exportDataGrid(options)](/api-reference/50%20Common
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -163,7 +163,7 @@ The example below calls the [exportDataGrid(options)](/api-reference/50%20Common
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfExportDataGridProps/customDrawCell.md
+++ b/api-reference/50 Common/Object Structures/PdfExportDataGridProps/customDrawCell.md
@@ -141,7 +141,7 @@ In the following example, this function adds an image to a cell:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -190,7 +190,7 @@ In the following example, this function adds an image to a cell:
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfExportDataGridProps/customizeCell.md
+++ b/api-reference/50 Common/Object Structures/PdfExportDataGridProps/customizeCell.md
@@ -134,7 +134,7 @@ In the following example, this function changes the font size of the *'data'* gr
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -184,7 +184,7 @@ In the following example, this function changes the font size of the *'data'* gr
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfExportDataGridProps/indent.md
+++ b/api-reference/50 Common/Object Structures/PdfExportDataGridProps/indent.md
@@ -120,7 +120,7 @@ This property uses the measure units that are specified in the constructor of th
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -163,7 +163,7 @@ This property uses the measure units that are specified in the constructor of th
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfExportDataGridProps/loadPanel.md
+++ b/api-reference/50 Common/Object Structures/PdfExportDataGridProps/loadPanel.md
@@ -126,7 +126,7 @@ The example below calls the [exportDataGrid(options)](/api-reference/50%20Common
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -173,7 +173,7 @@ The example below calls the [exportDataGrid(options)](/api-reference/50%20Common
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfExportDataGridProps/margin/margin.md
+++ b/api-reference/50 Common/Object Structures/PdfExportDataGridProps/margin/margin.md
@@ -109,7 +109,7 @@ Uses the measure units that are specified in the constructor of the [jsPDFDocume
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -153,7 +153,7 @@ Uses the measure units that are specified in the constructor of the [jsPDFDocume
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PdfExportDataGridProps/onRowExporting.md
+++ b/api-reference/50 Common/Object Structures/PdfExportDataGridProps/onRowExporting.md
@@ -121,7 +121,7 @@ Specifies the height of the exported row. If the specified value is less than th
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -167,7 +167,7 @@ Specifies the height of the exported row. If the specified value is less than th
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/Object Structures/PivotGridExportOptions/customizeCell.md
+++ b/api-reference/50 Common/Object Structures/PivotGridExportOptions/customizeCell.md
@@ -140,7 +140,7 @@ In the following code, the **customizeCell** function customizes <a href="https:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPivotGrid, DxExport } from 'devextreme-vue/pivot-grid';
     import { exportPivotGrid } from 'devextreme/excel_exporter';
@@ -183,7 +183,7 @@ In the following code, the **customizeCell** function customizes <a href="https:
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import PivotGrid, { Export } from 'devextreme-react/pivot-grid';
     import { Workbook } from 'devextreme-exceljs-fork';

--- a/api-reference/50 Common/Object Structures/positionConfig/at/at.md
+++ b/api-reference/50 Common/Object Structures/positionConfig/at/at.md
@@ -50,7 +50,7 @@ To set this property, use an object with the **x** and **y** fields. These field
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxPopup, {
         DxPosition,
@@ -71,7 +71,7 @@ To set this property, use an object with the **x** and **y** fields. These field
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Popup, {
         Position,

--- a/api-reference/50 Common/Object Structures/positionConfig/boundaryOffset/boundaryOffset.md
+++ b/api-reference/50 Common/Object Structures/positionConfig/boundaryOffset/boundaryOffset.md
@@ -52,7 +52,7 @@ In the following code, left and right boundaries are narrowed (**x** is 50), but
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxPopup, {
         DxPosition,
@@ -73,7 +73,7 @@ In the following code, left and right boundaries are narrowed (**x** is 50), but
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Popup, {
         Position,

--- a/api-reference/50 Common/Object Structures/positionConfig/collision/collision.md
+++ b/api-reference/50 Common/Object Structures/positionConfig/collision/collision.md
@@ -64,7 +64,7 @@ To set the **collision** property, use an object with the **x** and **y** fields
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxPopup, {
         DxPosition,
@@ -85,7 +85,7 @@ To set the **collision** property, use an object with the **x** and **y** fields
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Popup, {
         Position,

--- a/api-reference/50 Common/Object Structures/positionConfig/my/my.md
+++ b/api-reference/50 Common/Object Structures/positionConfig/my/my.md
@@ -50,7 +50,7 @@ To set this property, use an object with the **x** and **y** fields. These field
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxPopup, {
         DxPosition,
@@ -71,7 +71,7 @@ To set this property, use an object with the **x** and **y** fields. These field
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Popup, {
         Position,

--- a/api-reference/50 Common/Object Structures/positionConfig/of.md
+++ b/api-reference/50 Common/Object Structures/positionConfig/of.md
@@ -45,7 +45,7 @@ This property accepts the following value types:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxPopup, {
             DxPosition
@@ -64,7 +64,7 @@ This property accepts the following value types:
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import Popup, {
             Position
@@ -133,7 +133,7 @@ This property accepts the following value types:
         </template>
     
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
         import DxPopup, {
             DxPosition
@@ -157,7 +157,7 @@ This property accepts the following value types:
         <!-- tab: App.js -->
         import React from 'react';
     
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
         import Popup, {
             Position
@@ -233,7 +233,7 @@ This property accepts the following value types:
         </template>
     
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
         import DxPopover, {
             DxPosition
@@ -257,7 +257,7 @@ This property accepts the following value types:
         <!-- tab: App.js -->
         import React from 'react';
     
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
         import Popover, {
             Position

--- a/api-reference/50 Common/Object Structures/positionConfig/offset/offset.md
+++ b/api-reference/50 Common/Object Structures/positionConfig/offset/offset.md
@@ -52,7 +52,7 @@ In the following code, the overlay element is shifted 50 pixels to the right and
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxPopup, {
         DxPosition,
@@ -73,7 +73,7 @@ In the following code, the overlay element is shifted 50 pixels to the right and
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Popup, {
         Position,

--- a/api-reference/50 Common/Object Structures/positionConfig/positionConfig.md
+++ b/api-reference/50 Common/Object Structures/positionConfig/positionConfig.md
@@ -53,7 +53,7 @@ To position an element, specify the [my](/api-reference/50%20Common/Object%20Str
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxPopup, {
         DxPosition
@@ -72,7 +72,7 @@ To position an element, specify the [my](/api-reference/50%20Common/Object%20Str
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Popup, {
         Position

--- a/api-reference/50 Common/utils/excelExporter/exportDataGrid(options).md
+++ b/api-reference/50 Common/utils/excelExporter/exportDataGrid(options).md
@@ -121,7 +121,7 @@ You can call this method at any point in your application. In the example below,
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid, DxExport } from 'devextreme-vue/data-grid';
     import { exportDataGrid } from 'devextreme/excel_exporter';
@@ -156,7 +156,7 @@ You can call this method at any point in your application. In the example below,
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, { Export } from 'devextreme-react/data-grid';
     import { Workbook } from 'devextreme-exceljs-fork';

--- a/api-reference/50 Common/utils/excelExporter/exportPivotGrid(options).md
+++ b/api-reference/50 Common/utils/excelExporter/exportPivotGrid(options).md
@@ -120,7 +120,7 @@ You can call this method at any point in your application. In the example below,
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxPivotGrid, DxExport } from 'devextreme-vue/pivot-grid';
     import { exportPivotGrid } from 'devextreme/excel_exporter';
@@ -155,7 +155,7 @@ You can call this method at any point in your application. In the example below,
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import PivotGrid, { Export } from 'devextreme-react/pivot-grid';
     import { Workbook } from 'devextreme-exceljs-fork';

--- a/api-reference/50 Common/utils/pdfExporter/exportDataGrid(options).md
+++ b/api-reference/50 Common/utils/pdfExporter/exportDataGrid(options).md
@@ -133,7 +133,7 @@ In the following example, a DevExtreme [Button](/concepts/05%20UI%20Components/B
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxButton from 'devextreme-vue/button';
@@ -175,7 +175,7 @@ In the following example, a DevExtreme [Button](/concepts/05%20UI%20Components/B
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import Button from 'devextreme-react/button';

--- a/api-reference/50 Common/utils/pdfExporter/exportGantt(options).md
+++ b/api-reference/50 Common/utils/pdfExporter/exportGantt(options).md
@@ -150,7 +150,7 @@ In the following example, a toolbar button's [onClick](/api-reference/10%20UI%20
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -209,7 +209,7 @@ In the following example, a toolbar button's [onClick](/api-reference/10%20UI%20
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/50 Common/utils/zz Errors and Warnings/W0018.md
+++ b/api-reference/50 Common/utils/zz Errors and Warnings/W0018.md
@@ -104,7 +104,7 @@ If your function returned different **position** values based on a condition, sp
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxPopup from 'devextreme-vue/popup';
 
@@ -136,7 +136,7 @@ If your function returned different **position** values based on a condition, sp
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxPopup from 'devextreme-vue/popup';
 
@@ -165,7 +165,7 @@ If your function returned different **position** values based on a condition, sp
 
     <!-- tab: App.js -->
     import React, { useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Popup from 'devextreme-react/popup';
 
@@ -185,7 +185,7 @@ If your function returned different **position** values based on a condition, sp
 
     <!-- tab: App.js -->
     import React, { useCallback, useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Popup from 'devextreme-react/popup';
 
@@ -268,7 +268,7 @@ If your function always returned the same **position** value, simply assign this
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxPopup from 'devextreme-vue/popup';
 
@@ -297,7 +297,7 @@ If your function always returned the same **position** value, simply assign this
 
     <!-- tab: App.js -->
     import React, { useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Popup from 'devextreme-react/popup';
 

--- a/api-reference/_hidden/GridBaseColumn/calculateCellValue.md
+++ b/api-reference/_hidden/GridBaseColumn/calculateCellValue.md
@@ -141,7 +141,7 @@ In the following code, the **calculateCellValue** function is used to create an 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn
@@ -189,7 +189,7 @@ In the following code, the **calculateCellValue** function is used to create an 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column 

--- a/api-reference/_hidden/GridBaseColumn/calculateDisplayValue.md
+++ b/api-reference/_hidden/GridBaseColumn/calculateDisplayValue.md
@@ -66,7 +66,7 @@ This property accepts the name of the [data source field](/api-reference/10%20UI
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn 
@@ -86,7 +86,7 @@ This property accepts the name of the [data source field](/api-reference/10%20UI
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column
@@ -184,7 +184,7 @@ This property accepts the name of the [data source field](/api-reference/10%20UI
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn 
@@ -208,7 +208,7 @@ This property accepts the name of the [data source field](/api-reference/10%20UI
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column

--- a/api-reference/_hidden/GridBaseColumn/calculateFilterExpression.md
+++ b/api-reference/_hidden/GridBaseColumn/calculateFilterExpression.md
@@ -124,7 +124,7 @@ The default *"between"* implementation is inclusive (filter results include the 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn
@@ -161,7 +161,7 @@ The default *"between"* implementation is inclusive (filter results include the 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column
@@ -261,7 +261,7 @@ To specify a function as a `selector`, return a property from the `rowData` obje
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn
@@ -290,7 +290,7 @@ To specify a function as a `selector`, return a property from the `rowData` obje
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column
@@ -383,7 +383,7 @@ You can also implement a function with [custom filter conditions](/concepts/70%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn
@@ -412,7 +412,7 @@ You can also implement a function with [custom filter conditions](/concepts/70%2
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column
@@ -511,7 +511,7 @@ DataGrid uses *"anyof"* and *"noneof"* filter values for [headerFilter](/api-ref
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn
@@ -540,7 +540,7 @@ DataGrid uses *"anyof"* and *"noneof"* filter values for [headerFilter](/api-ref
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column

--- a/api-reference/_hidden/GridBaseColumn/columns/columns.md
+++ b/api-reference/_hidden/GridBaseColumn/columns/columns.md
@@ -63,7 +63,7 @@ Unlike normal columns, band columns do not hold data. Instead, they collect two 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn
@@ -82,7 +82,7 @@ Unlike normal columns, band columns do not hold data. Instead, they collect two 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column
@@ -177,7 +177,7 @@ For example, the following code specifies the **width** and **sortOrder** proper
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn
@@ -196,7 +196,7 @@ For example, the following code specifies the **width** and **sortOrder** proper
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column
@@ -305,7 +305,7 @@ Band columns support hierarchies of any nesting level. It means that the followi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn
@@ -324,7 +324,7 @@ Band columns support hierarchies of any nesting level. It means that the followi
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column

--- a/api-reference/_hidden/GridBaseColumn/cssClass.md
+++ b/api-reference/_hidden/GridBaseColumn/cssClass.md
@@ -104,7 +104,7 @@ In the following code, this property is assigned a `cell-highlighted` CSS class 
         </Dx{WidgetName}>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName}, DxColumn } from 'devextreme-vue/{widget-name}';
 
@@ -140,7 +140,7 @@ In the following code, this property is assigned a `cell-highlighted` CSS class 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName}, Column } from 'devextreme-react/{widget-name}';
 

--- a/api-reference/_hidden/GridBaseColumn/customizeText.md
+++ b/api-reference/_hidden/GridBaseColumn/customizeText.md
@@ -105,7 +105,7 @@ The `this` keyword refers to the column's configuration.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName}, DxColumn } from "devextreme-vue/{widget-name}";
 
@@ -127,7 +127,7 @@ The `this` keyword refers to the column's configuration.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, { Column } from "devextreme-react/{widget-name}";
     

--- a/api-reference/_hidden/GridBaseColumn/dataField.md
+++ b/api-reference/_hidden/GridBaseColumn/dataField.md
@@ -69,7 +69,7 @@ The **columns** array can contain column objects and data field names as strings
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn
@@ -88,7 +88,7 @@ The **columns** array can contain column objects and data field names as strings
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column

--- a/api-reference/_hidden/GridBaseColumn/editorOptions.md
+++ b/api-reference/_hidden/GridBaseColumn/editorOptions.md
@@ -85,7 +85,7 @@ Because of this dependency, **editorOptions** cannot be typed and are not implem
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn
@@ -111,7 +111,7 @@ Because of this dependency, **editorOptions** cannot be typed and are not implem
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column

--- a/api-reference/_hidden/GridBaseColumn/filterValues.md
+++ b/api-reference/_hidden/GridBaseColumn/filterValues.md
@@ -83,7 +83,7 @@ If you specify the **headerFilter**.[groupInterval](/api-reference/40%20Common%2
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn,
@@ -104,7 +104,7 @@ If you specify the **headerFilter**.[groupInterval](/api-reference/40%20Common%2
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column,

--- a/api-reference/_hidden/GridBaseColumn/formItem.md
+++ b/api-reference/_hidden/GridBaseColumn/formItem.md
@@ -81,7 +81,7 @@ In the following code, the `Full_Name` grid column in the editing state produces
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxEditing,
@@ -106,7 +106,7 @@ In the following code, the `Full_Name` grid column in the editing state produces
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Editing,

--- a/api-reference/_hidden/GridBaseColumn/format.md
+++ b/api-reference/_hidden/GridBaseColumn/format.md
@@ -76,7 +76,7 @@ In the following code, the *"fixedPoint"* [format type](/api-reference/50%20Comm
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn,
@@ -100,7 +100,7 @@ In the following code, the *"fixedPoint"* [format type](/api-reference/50%20Comm
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column,

--- a/api-reference/_hidden/GridBaseColumn/isBand.md
+++ b/api-reference/_hidden/GridBaseColumn/isBand.md
@@ -80,7 +80,7 @@ The following code uses the **isBand** and **ownerBand** properties to display t
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         // ...
@@ -113,7 +113,7 @@ The following code uses the **isBand** and **ownerBand** properties to display t
 
     <!-- tab: App.js -->
     import React, { useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         // ...

--- a/api-reference/_hidden/GridBaseColumn/lookup/allowClearing.md
+++ b/api-reference/_hidden/GridBaseColumn/lookup/allowClearing.md
@@ -81,7 +81,7 @@ To specify this property based on a condition, set the [showClearButton](/api-re
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -105,7 +105,7 @@ To specify this property based on a condition, set the [showClearButton](/api-re
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/_hidden/GridBaseColumn/lookup/displayExpr.md
+++ b/api-reference/_hidden/GridBaseColumn/lookup/displayExpr.md
@@ -102,7 +102,7 @@ This property accepts a string - the name of the data field that provides displa
         </template>
 
         <script setup>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import Dx{WidgetName}, { DxColumn, DxLookup } from 'devextreme-vue/{widget-name}';
 
         const calculateSortValue = (data) => {
@@ -116,7 +116,7 @@ This property accepts a string - the name of the data field that provides displa
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import {WidgetName}, {
             Column,

--- a/api-reference/_hidden/GridBaseColumn/lookup/lookup.md
+++ b/api-reference/_hidden/GridBaseColumn/lookup/lookup.md
@@ -96,7 +96,7 @@ All `drivers` have the `busID` field, which refers to a bus. If `drivers` is the
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn,
@@ -134,7 +134,7 @@ All `drivers` have the `busID` field, which refers to a bus. If `drivers` is the
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column,

--- a/api-reference/_hidden/GridBaseColumn/setCellValue.md
+++ b/api-reference/_hidden/GridBaseColumn/setCellValue.md
@@ -106,7 +106,7 @@ This function allows you to process user input before it is saved to the data so
         </Dx{WidgetName}>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName}, DxColumn } from 'devextreme-vue/{widget-name}';
 
@@ -130,7 +130,7 @@ This function allows you to process user input before it is saved to the data so
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName}, Column } from 'devextreme-react/{widget-name}';
 
@@ -290,7 +290,7 @@ To perform asynchronous operations in the **setCellValue** function, return a pr
         </Dx{WidgetName}>
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName}, DxColumn } from 'devextreme-vue/{widget-name}';
     import 'whatwg-fetch';
@@ -327,7 +327,7 @@ To perform asynchronous operations in the **setCellValue** function, return a pr
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName}, Column } from 'devextreme-react/{widget-name}';
     import 'whatwg-fetch';

--- a/api-reference/_hidden/GridBaseColumn/showEditorAlways.md
+++ b/api-reference/_hidden/GridBaseColumn/showEditorAlways.md
@@ -153,7 +153,7 @@ The following example illustrates how this property works for the Boolean and Da
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn
@@ -172,7 +172,7 @@ The following example illustrates how this property works for the Boolean and Da
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column

--- a/api-reference/_hidden/GridBaseColumn/sortIndex.md
+++ b/api-reference/_hidden/GridBaseColumn/sortIndex.md
@@ -75,7 +75,7 @@ To sort data first by the *"Last Name"* and then by the *"First Name"* column, u
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn
@@ -94,7 +94,7 @@ To sort data first by the *"Last Name"* and then by the *"First Name"* column, u
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column

--- a/api-reference/_hidden/GridBaseColumn/sortingMethod.md
+++ b/api-reference/_hidden/GridBaseColumn/sortingMethod.md
@@ -96,7 +96,7 @@ The string comparison is culture-insensitive by default. Use the following code 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn
@@ -125,7 +125,7 @@ The string comparison is culture-insensitive by default. Use the following code 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column

--- a/api-reference/_hidden/dxButtonGroupItem/elementAttr.md
+++ b/api-reference/_hidden/dxButtonGroupItem/elementAttr.md
@@ -103,7 +103,7 @@ Specifies the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import ButtonGroup from 'devextreme-react/button-group';
 

--- a/api-reference/_hidden/dxDataGridColumn/format.md
+++ b/api-reference/_hidden/dxDataGridColumn/format.md
@@ -100,7 +100,7 @@ Cannot be converted, the cell value is exported without formatting. To export th
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DxDataGrid, {
             DxExport,
@@ -126,7 +126,7 @@ Cannot be converted, the cell value is exported without formatting. To export th
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import DataGrid, {
             Export,

--- a/api-reference/_hidden/dxDataGridColumn/groupIndex.md
+++ b/api-reference/_hidden/dxDataGridColumn/groupIndex.md
@@ -72,7 +72,7 @@ To group these records first by the *"LastName"* field and then by the *"FirstNa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -91,7 +91,7 @@ To group these records first by the *"LastName"* field and then by the *"FirstNa
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column

--- a/api-reference/_hidden/dxDataGridColumnButton/name.md
+++ b/api-reference/_hidden/dxDataGridColumnButton/name.md
@@ -67,7 +67,7 @@ To configure a built-in button, assign its name to this property. The other prop
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn,
@@ -88,7 +88,7 @@ To configure a built-in button, assign its name to this property. The other prop
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column,

--- a/api-reference/_hidden/dxDataGridColumnButton/template.md
+++ b/api-reference/_hidden/dxDataGridColumnButton/template.md
@@ -108,7 +108,7 @@ A template name or container.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumn,
         DxButton
@@ -139,7 +139,7 @@ A template name or container.
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumn,
         DxButton
@@ -151,7 +151,7 @@ A template name or container.
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column,

--- a/api-reference/_hidden/dxDataGridColumnButton/visible.md
+++ b/api-reference/_hidden/dxDataGridColumnButton/visible.md
@@ -87,7 +87,7 @@ Use the function to show or hide the button for specific rows. For example, the 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxColumn,
@@ -113,7 +113,7 @@ Use the function to show or hide the button for specific rows. For example, the 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Column,

--- a/api-reference/_hidden/dxFileManagerContextMenu/items/items.md
+++ b/api-reference/_hidden/dxFileManagerContextMenu/items/items.md
@@ -108,7 +108,7 @@ To add a predefined item to the context menu, add its [name](/api-reference/_hid
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileManager, 
@@ -289,7 +289,7 @@ To add a custom context menu item, specify its [text](/api-reference/_hidden/dxM
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileManager, 

--- a/api-reference/_hidden/dxFileManagerContextMenuItem/items.md
+++ b/api-reference/_hidden/dxFileManagerContextMenuItem/items.md
@@ -95,7 +95,7 @@ The FileManager UI component allows you to add default and create custom context
     </template>
 
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { 
             DxFileManager, 

--- a/api-reference/_hidden/dxFileManagerToolbar/fileSelectionItems/options.md
+++ b/api-reference/_hidden/dxFileManagerToolbar/fileSelectionItems/options.md
@@ -50,7 +50,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxToolbar,
@@ -78,7 +78,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Toolbar,

--- a/api-reference/_hidden/dxFileManagerToolbar/items/options.md
+++ b/api-reference/_hidden/dxFileManagerToolbar/items/options.md
@@ -51,7 +51,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFileManager, {
         DxToolbar
@@ -77,7 +77,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FileManager, {
         Toolbar

--- a/api-reference/_hidden/dxFilterBuilderField/calculateFilterExpression.md
+++ b/api-reference/_hidden/dxFilterBuilderField/calculateFilterExpression.md
@@ -109,7 +109,7 @@ In the following code, the **calculateFilterExpression** function implements an 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFilterBuilder, {
         DxField
@@ -145,7 +145,7 @@ In the following code, the **calculateFilterExpression** function implements an 
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FilterBuilder, {
         Field

--- a/api-reference/_hidden/dxFilterBuilderField/editorOptions.md
+++ b/api-reference/_hidden/dxFilterBuilderField/editorOptions.md
@@ -55,7 +55,7 @@ Because **editorOptions** depend on the **dataType**, they cannot be typed and a
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFilterBuilder, {
         DxField
@@ -81,7 +81,7 @@ Because **editorOptions** depend on the **dataType**, they cannot be typed and a
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FilterBuilder, {
         Field
@@ -176,7 +176,7 @@ Do not specify the **onValueChanged** property in this object. If you need to ad
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFilterBuilder from 'devextreme-vue/filter-builder';
 
@@ -209,7 +209,7 @@ Do not specify the **onValueChanged** property in this object. If you need to ad
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FilterBuilder from 'devextreme-react/filter-builder';
 

--- a/api-reference/_hidden/dxFilterBuilderField/format.md
+++ b/api-reference/_hidden/dxFilterBuilderField/format.md
@@ -71,7 +71,7 @@ This property also controls the user input in cells that use the [DateBox](/api-
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxFilterBuilder, {
         DxField
@@ -95,7 +95,7 @@ This property also controls the user input in cells that use the [DateBox](/api-
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import FilterBuilder, {
         Field

--- a/api-reference/_hidden/dxFilterBuilderField/lookup/allowClearing.md
+++ b/api-reference/_hidden/dxFilterBuilderField/lookup/allowClearing.md
@@ -81,7 +81,7 @@ If you need to specify this property based on a condition, set the [showClearBut
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -105,7 +105,7 @@ If you need to specify this property based on a condition, set the [showClearBut
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName} from 'devextreme-react/{widget-name}';
 

--- a/api-reference/_hidden/dxGanttContextMenu/enabled.md
+++ b/api-reference/_hidden/dxGanttContextMenu/enabled.md
@@ -54,7 +54,7 @@ Specifies whether the context menu is enabled in the UI component.
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DxGantt, DxContextMenu } from 'devextreme-vue/gantt';
     

--- a/api-reference/_hidden/dxGanttContextMenu/items.md
+++ b/api-reference/_hidden/dxGanttContextMenu/items.md
@@ -85,7 +85,7 @@ To add a predefined item to the context menu, add its [name](/api-reference/_hid
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DxGantt, DxContextMenu } from 'devextreme-vue/gantt';
     
@@ -255,7 +255,7 @@ To add a custom context menu item, specify its [text](/api-reference/_hidden/dxM
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DxGantt, DxContextMenu } from 'devextreme-vue/gantt';
     

--- a/api-reference/_hidden/dxGanttContextMenuItem/name.md
+++ b/api-reference/_hidden/dxGanttContextMenuItem/name.md
@@ -96,7 +96,7 @@ Specifies the context menu item name.
     </template>
     
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { DxGantt, DxContextMenu } from 'devextreme-vue/gantt';
     

--- a/api-reference/_hidden/dxGanttContextMenuItem/template.md
+++ b/api-reference/_hidden/dxGanttContextMenuItem/template.md
@@ -104,7 +104,7 @@ The following example adds a custom item to the component. Note that Angular and
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         ContextMenu, Item

--- a/api-reference/_hidden/dxGanttToolbar/items.md
+++ b/api-reference/_hidden/dxGanttToolbar/items.md
@@ -116,7 +116,7 @@ The Gantt UI component allows you to add default and create custom toolbar items
         </DxGantt>
     </template>
     <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import 'devexpress-gantt/dist/dx-gantt.css'; 
 
         import { 
@@ -148,7 +148,7 @@ The Gantt UI component allows you to add default and create custom toolbar items
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import 'devexpress-gantt/dist/dx-gantt.css'; 
 
     import Gantt, { 

--- a/api-reference/_hidden/dxHtmlEditorImageUpload/fileUploaderOptions.md
+++ b/api-reference/_hidden/dxHtmlEditorImageUpload/fileUploaderOptions.md
@@ -75,7 +75,7 @@ See [FileUploader Configuration](/api-reference/10%20UI%20Components/dxFileUploa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor from 'devextreme-vue/html-editor';
 
@@ -99,7 +99,7 @@ See [FileUploader Configuration](/api-reference/10%20UI%20Components/dxFileUploa
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor from 'devextreme-react/html-editor';
 

--- a/api-reference/_hidden/dxHtmlEditorMention/dataSource.md
+++ b/api-reference/_hidden/dxHtmlEditorMention/dataSource.md
@@ -104,7 +104,7 @@ Use one of the following extensions to enable the server to process data accordi
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';
@@ -132,7 +132,7 @@ Use one of the following extensions to enable the server to process data accordi
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';

--- a/api-reference/_hidden/dxHtmlEditorTableContextMenu/enabled.md
+++ b/api-reference/_hidden/dxHtmlEditorTableContextMenu/enabled.md
@@ -42,7 +42,7 @@ Specifies whether to enable the table context menu.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor, {
         DxTableContextMenu
@@ -60,7 +60,7 @@ Specifies whether to enable the table context menu.
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor, {
         TableContextMenu

--- a/api-reference/_hidden/dxHtmlEditorTableContextMenu/items.md
+++ b/api-reference/_hidden/dxHtmlEditorTableContextMenu/items.md
@@ -76,7 +76,7 @@ Use this property to customize the context menu. For example, the following code
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor, {
         DxTableContextMenu,
@@ -96,7 +96,7 @@ Use this property to customize the context menu. For example, the following code
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor, {
         TableContextMenu,

--- a/api-reference/_hidden/dxHtmlEditorTableContextMenuItem/items.md
+++ b/api-reference/_hidden/dxHtmlEditorTableContextMenuItem/items.md
@@ -65,7 +65,7 @@ Use this property to create a hierarchical context menu. The following code demo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor, {
         DxTableContextMenu,
@@ -85,7 +85,7 @@ Use this property to create a hierarchical context menu. The following code demo
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor, {
         TableContextMenu,

--- a/api-reference/_hidden/dxHtmlEditorTableContextMenuItem/template.md
+++ b/api-reference/_hidden/dxHtmlEditorTableContextMenuItem/template.md
@@ -104,7 +104,7 @@ The following example adds a custom item to the component. Note that Angular and
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         ContextMenu, Item

--- a/api-reference/_hidden/dxHtmlEditorToolbar/items/items.md
+++ b/api-reference/_hidden/dxHtmlEditorToolbar/items/items.md
@@ -65,7 +65,7 @@ The toolbar provides [predefined items](/concepts/05%20UI%20Components/HtmlEdito
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor, {
         DxToolbar,
@@ -85,7 +85,7 @@ The toolbar provides [predefined items](/concepts/05%20UI%20Components/HtmlEdito
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor, {
         Toolbar,
@@ -188,7 +188,7 @@ Most of the predefined items are buttons. To customize a button, assign its name
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor, {
         DxToolbar,
@@ -215,7 +215,7 @@ Most of the predefined items are buttons. To customize a button, assign its name
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor, {
         Toolbar,

--- a/api-reference/_hidden/dxHtmlEditorToolbarItem/name.md
+++ b/api-reference/_hidden/dxHtmlEditorToolbarItem/name.md
@@ -91,7 +91,7 @@ In the following code, the `header` and `size` formats are configured as describ
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor, {
         DxToolbar,
@@ -117,7 +117,7 @@ In the following code, the `header` and `size` formats are configured as describ
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor, {
         Toolbar,

--- a/api-reference/_hidden/dxHtmlEditorToolbarItem/options.md
+++ b/api-reference/_hidden/dxHtmlEditorToolbarItem/options.md
@@ -50,7 +50,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxToolbar,
@@ -78,7 +78,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Toolbar,

--- a/api-reference/_hidden/dxHtmlEditorToolbarItem/widget.md
+++ b/api-reference/_hidden/dxHtmlEditorToolbarItem/widget.md
@@ -122,7 +122,7 @@ In the following example, the [CheckBox](/api-reference/10%20UI%20Widgets/dxChec
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor, {
         DxToolbar,
@@ -153,7 +153,7 @@ In the following example, the [CheckBox](/api-reference/10%20UI%20Widgets/dxChec
 
     <!-- tab: App.js -->
     import { useMemo } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor, {
         Toolbar,

--- a/api-reference/_hidden/dxHtmlEditorVariables/dataSource.md
+++ b/api-reference/_hidden/dxHtmlEditorVariables/dataSource.md
@@ -104,7 +104,7 @@ Use one of the following extensions to enable the server to process data accordi
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';
@@ -132,7 +132,7 @@ Use one of the following extensions to enable the server to process data accordi
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';

--- a/api-reference/_hidden/dxHtmlEditorVariables/escapeChar.md
+++ b/api-reference/_hidden/dxHtmlEditorVariables/escapeChar.md
@@ -64,7 +64,7 @@ Specifies the special character(s) that should surround the variables.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxHtmlEditor, {
         DxVariables
@@ -87,7 +87,7 @@ Specifies the special character(s) that should surround the variables.
 ##### React
 
     <!-- tab: App.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import HtmlEditor, {
         Variables

--- a/api-reference/_hidden/dxPopupToolbarItem/options.md
+++ b/api-reference/_hidden/dxPopupToolbarItem/options.md
@@ -67,7 +67,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName}, {
         DxToolbarItem
@@ -93,7 +93,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         ToolbarItem

--- a/api-reference/_hidden/dxPopupToolbarItem/template.md
+++ b/api-reference/_hidden/dxPopupToolbarItem/template.md
@@ -98,7 +98,7 @@ The following example adds a custom item to the Popup toolbar. Note that Angular
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         ToolbarItem

--- a/api-reference/_hidden/dxToolbarItem/options.md
+++ b/api-reference/_hidden/dxToolbarItem/options.md
@@ -69,7 +69,7 @@ Configures the DevExtreme UI component used as a toolbar item.
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxToolbar, {
         DxItem
@@ -95,7 +95,7 @@ Configures the DevExtreme UI component used as a toolbar item.
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Toolbar, {
         Item

--- a/concepts/40 Angular Components/10 Getting Started/03 Add DevExtreme to an Angular CLI Application/03 Configure Stylesheets.md
+++ b/concepts/40 Angular Components/10 Getting Started/03 Add DevExtreme to an Angular CLI Application/03 Configure Stylesheets.md
@@ -1,4 +1,4 @@
-Open the `angular.json` file and reference a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.light.css` in the code below).
+Open the `angular.json` file and reference a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.fluent.blue.light.css` in the code below).
 
     <!-- tab: angular.json -->
     {
@@ -8,7 +8,7 @@ Open the `angular.json` file and reference a [predefined theme stylesheet](/conc
             "build": {
               "options": {
                 "styles": [
-                  "node_modules/devextreme/dist/css/dx.light.css",
+                  "node_modules/devextreme/dist/css/dx.fluent.blue.light.css",
                   "src/styles.css"
                 ],
                 ...

--- a/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/04 Using Webpack/04 Import Stylesheets.md
+++ b/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/04 Using Webpack/04 Import Stylesheets.md
@@ -1,4 +1,4 @@
-Open the main `.ts` file and import a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.light.css` in the code below).
+Open the main `.ts` file and import a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.fluent.blue.light.css` in the code below).
 
     <!--TypeScript-->
     // ...

--- a/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/04 Using Webpack/04 Import Stylesheets.md
+++ b/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/04 Using Webpack/04 Import Stylesheets.md
@@ -2,6 +2,6 @@ Open the main `.ts` file and import a [predefined theme stylesheet](/concepts/60
 
     <!--TypeScript-->
     // ...
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
 [note] [SVG-based UI components](/concepts/60%20Themes%20and%20Styles/00%20Styling%20Methods.md '/Documentation/Guide/Themes_and_Styles/Styling_Methods/') do not require theme stylesheets. If you choose to import the stylesheets, the UI components apply an appearance that matches them.

--- a/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/05 Using Ionic/05 Import Stylesheets.md
+++ b/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/05 Using Ionic/05 Import Stylesheets.md
@@ -1,4 +1,4 @@
-Open the `global.scss` file in the `src` folder and import a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.light.css` in the code below).
+Open the `global.scss` file in the `src` folder and import a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.fluent.blue.light.css` in the code below).
 
     <!-- tab: global.scss -->
     @import '~devextreme/dist/css/dx.light.css';

--- a/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/05 Using Ionic/05 Import Stylesheets.md
+++ b/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/05 Using Ionic/05 Import Stylesheets.md
@@ -1,6 +1,6 @@
 Open the `global.scss` file in the `src` folder and import a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.fluent.blue.light.css` in the code below).
 
     <!-- tab: global.scss -->
-    @import '~devextreme/dist/css/dx.light.css';
+    @import '~devextreme/dist/css/dx.fluent.blue.light.css';
 
 [note] [SVG-based UI components](/concepts/60%20Themes%20and%20Styles/00%20Styling%20Methods.md '/Documentation/Guide/Themes_and_Styles/Styling_Methods/') do not require theme stylesheets. If you choose to import the stylesheets, the UI components apply an appearance that matches them.

--- a/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/06 Using Rollup/04 Import Stylesheets.md
+++ b/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/06 Using Rollup/04 Import Stylesheets.md
@@ -1,4 +1,4 @@
-Go to the `NgModule` in which you are going to use DevExtreme UI components and import a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.light.css` in the code below).
+Go to the `NgModule` in which you are going to use DevExtreme UI components and import a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.fluent.blue.light.css` in the code below).
 
     <!-- tab: app.module.ts -->
     import 'devextreme/dist/css/dx.fluent.blue.light.css';

--- a/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/06 Using Rollup/04 Import Stylesheets.md
+++ b/concepts/40 Angular Components/10 Getting Started/30 Other Approaches/06 Using Rollup/04 Import Stylesheets.md
@@ -1,7 +1,7 @@
 Go to the `NgModule` in which you are going to use DevExtreme UI components and import a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.light.css` in the code below).
 
     <!-- tab: app.module.ts -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     // ...
     // DevExtreme modules will be imported here later
     // ...

--- a/concepts/40 Angular Components/50 Components Testing/10 Unit Testing.md
+++ b/concepts/40 Angular Components/50 Components Testing/10 Unit Testing.md
@@ -37,7 +37,7 @@ Reference a DevExtreme style file in `angular.json`:
     "test": {
         "options": {
             "styles": [
-                "node_modules/devextreme/dist/css/dx.light.css"
+                "node_modules/devextreme/dist/css/dx.fluent.blue.light.css"
             ]
         }
     }

--- a/concepts/50 React Components/05 Add DevExtreme to a React Application/40 Import Stylesheets.md
+++ b/concepts/50 React Components/05 Add DevExtreme to a React Application/40 Import Stylesheets.md
@@ -2,7 +2,7 @@ Open the main application file (`App.js`) and import a [predefined theme stylesh
 
     <!-- tab: App.js -->
     // ...
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
 [note]
 

--- a/concepts/50 React Components/05 Add DevExtreme to a React Application/40 Import Stylesheets.md
+++ b/concepts/50 React Components/05 Add DevExtreme to a React Application/40 Import Stylesheets.md
@@ -1,4 +1,4 @@
-Open the main application file (`App.js`) and import a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.light.css` in the code below). Alternatively, you can import the stylesheets where DevExtreme UI components are used. The syntax is the same.
+Open the main application file (`App.js`) and import a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.fluent.blue.light.css` in the code below). Alternatively, you can import the stylesheets where DevExtreme UI components are used. The syntax is the same.
 
     <!-- tab: App.js -->
     // ...

--- a/concepts/50 React Components/05 Add DevExtreme to a React Application/60 Import DevExtreme Components.md
+++ b/concepts/50 React Components/05 Add DevExtreme to a React Application/60 Import DevExtreme Components.md
@@ -3,7 +3,7 @@ Import the DevExtreme components you are going to use from specific modules. In 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Button from 'devextreme-react/button';
 

--- a/concepts/50 React Components/20 State Management/3 Controlled Mode.md
+++ b/concepts/50 React Components/20 State Management/3 Controlled Mode.md
@@ -6,7 +6,7 @@ Handle component events to update the parent component's state. Note: components
 
     <!-- tab: App.js -->
     import React, { useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import TextBox from 'devextreme-react/text-box';
 
 

--- a/concepts/50 React Components/40 Component Configuration Syntax/55 Markup Customization/5 Using a Custom Component.md
+++ b/concepts/50 React Components/40 Component Configuration Syntax/55 Markup Customization/5 Using a Custom Component.md
@@ -53,7 +53,7 @@ In the following code snippet, a standalone ListItem component is created to ren
     import * as React from 'react';
     import List from 'devextreme-react/list';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     const dataSource = ['Apples', 'Bananas', 'Cranberries'];
     const defaultWeight = 1;

--- a/concepts/55 Vue Components/05 Add DevExtreme to a Vue Application/40 Import Stylesheets.md
+++ b/concepts/55 Vue Components/05 Add DevExtreme to a Vue Application/40 Import Stylesheets.md
@@ -1,7 +1,7 @@
 Open the main application file (`main.js`) and import a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.light.css` in the code below). Alternatively, you can import the stylesheets where DevExtreme UI components are used. The syntax is the same.
 
     <!-- tab: main.js -->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     // ...
 
 [note]

--- a/concepts/55 Vue Components/05 Add DevExtreme to a Vue Application/40 Import Stylesheets.md
+++ b/concepts/55 Vue Components/05 Add DevExtreme to a Vue Application/40 Import Stylesheets.md
@@ -1,4 +1,4 @@
-Open the main application file (`main.js`) and import a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.light.css` in the code below). Alternatively, you can import the stylesheets where DevExtreme UI components are used. The syntax is the same.
+Open the main application file (`main.js`) and import a [predefined theme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') (`dx.fluent.blue.light.css` in the code below). Alternatively, you can import the stylesheets where DevExtreme UI components are used. The syntax is the same.
 
     <!-- tab: main.js -->
     import 'devextreme/dist/css/dx.fluent.blue.light.css';

--- a/concepts/70 Data Binding/00 Specify a Data Source/10 Local Array.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/10 Local Array.md
@@ -119,7 +119,7 @@ To bind a UI component to a local array, pass this array to the UI component's [
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxSelectBox from 'devextreme-vue/select-box';
@@ -163,7 +163,7 @@ To bind a UI component to a local array, pass this array to the UI component's [
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import SelectBox from 'devextreme-react/select-box';
@@ -306,7 +306,7 @@ The following example declares an **ArrayStore**, wraps it in a **DataSource**, 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import DxSelectBox from 'devextreme-vue/select-box';
@@ -350,7 +350,7 @@ The following example declares an **ArrayStore**, wraps it in a **DataSource**, 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import SelectBox from 'devextreme-react/select-box';

--- a/concepts/70 Data Binding/00 Specify a Data Source/20 Read-Only Data in JSON Format.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/20 Read-Only Data in JSON Format.md
@@ -59,7 +59,7 @@ To bind a UI component to JSON data, pass the data URL to the UI component's [da
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDataGrid } from 'devextreme-vue/data-grid';
 
@@ -71,7 +71,7 @@ To bind a UI component to JSON data, pass the data URL to the UI component's [da
     <!-- tab: App.tsx -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DataGrid } from 'devextreme-react/data-grid';
 
     const jsonUrl: string = 'https://jsonplaceholder.typicode.com/posts';
@@ -195,7 +195,7 @@ The following code configures **CustomStore**.**load** to include custom paramet
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxList } from 'devextreme-vue/list';
     import { CustomStore } from 'devextreme/data/custom_store';
@@ -230,7 +230,7 @@ The following code configures **CustomStore**.**load** to include custom paramet
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { List } from 'devextreme-react/list';
     import { CustomStore } from 'devextreme/data/custom_store';

--- a/concepts/70 Data Binding/00 Specify a Data Source/30 Web API, PHP, MongoDB.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/30 Web API, PHP, MongoDB.md
@@ -94,7 +94,7 @@ To access the server from the client, configure the [CustomStore](/api-reference
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxRemoteOperations
@@ -130,7 +130,7 @@ To access the server from the client, configure the [CustomStore](/api-reference
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         RemoteOperations

--- a/concepts/70 Data Binding/00 Specify a Data Source/40 OData.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/40 OData.md
@@ -80,7 +80,7 @@ To access an OData service, implement the [ODataStore](/api-reference/30%20Data%
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import ODataStore from 'devextreme/data/odata/store';
@@ -111,7 +111,7 @@ To access an OData service, implement the [ODataStore](/api-reference/30%20Data%
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import ODataStore from 'devextreme/data/odata/store';
@@ -223,7 +223,7 @@ The following example declares an **ODataStore**, wraps it in a **DataSource**, 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid from 'devextreme-vue/data-grid';
     import ODataStore from 'devextreme/data/odata/store';
@@ -255,7 +255,7 @@ The following example declares an **ODataStore**, wraps it in a **DataSource**, 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid from 'devextreme-react/data-grid';
     import ODataStore from 'devextreme/data/odata/store';

--- a/concepts/70 Data Binding/00 Specify a Data Source/50 OLAP Cube.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/50 OLAP Cube.md
@@ -87,7 +87,7 @@ Wrap the **XmlaStore** into a **PivotGridDataSource**. This component enables yo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxPivotGrid from 'devextreme-vue/pivot-grid';
     import XmlaStore from 'devextreme/ui/pivot_grid/xmla_store';
@@ -120,7 +120,7 @@ Wrap the **XmlaStore** into a **PivotGridDataSource**. This component enables yo
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import PivotGrid from 'devextreme-react/pivot-grid';
     import XmlaStore from 'devextreme/ui/pivot_grid/xmla_store';

--- a/concepts/70 Data Binding/00 Specify a Data Source/60 Custom Data Sources/2 Load Data/2 Client-Side Data Processing.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/60 Custom Data Sources/2 Load Data/2 Client-Side Data Processing.md
@@ -83,7 +83,7 @@ To process data on the client, load all data from the server in the [load](/api-
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxList from 'devextreme-vue/list';
     import 'whatwg-fetch';
@@ -123,7 +123,7 @@ To process data on the client, load all data from the server in the [load](/api-
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
     import 'whatwg-fetch';

--- a/concepts/70 Data Binding/00 Specify a Data Source/60 Custom Data Sources/2 Load Data/5 Server-Side Data Processing.md
+++ b/concepts/70 Data Binding/00 Specify a Data Source/60 Custom Data Sources/2 Load Data/5 Server-Side Data Processing.md
@@ -192,7 +192,7 @@ The following example shows a **CustomStore** that sends data processing setting
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxRemoteOperations
@@ -276,7 +276,7 @@ The following example shows a **CustomStore** that sends data processing setting
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         RemoteOperations 

--- a/concepts/70 Data Binding/03 Update Data/05 DevExtreme DataSource/02 Data Shaping.md
+++ b/concepts/70 Data Binding/03 Update Data/05 DevExtreme DataSource/02 Data Shaping.md
@@ -114,7 +114,7 @@ The following code demonstrates the [filter(filterExpr)](/api-reference/30%20Dat
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import DxDataGrid from 'devextreme-vue/data-grid';
 
         export default {
@@ -167,7 +167,7 @@ The following code demonstrates the [filter(filterExpr)](/api-reference/30%20Dat
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
         import DataGrid from 'devextreme-react/data-grid';
 
         class App extends React.Component {

--- a/concepts/Common/DevExtreme CLI/10 Add DevExtreme to an Existing Application.md
+++ b/concepts/Common/DevExtreme CLI/10 Add DevExtreme to an Existing Application.md
@@ -9,7 +9,7 @@
 This command does the following:
 
 - Adds the <a href="https://www.npmjs.com/package/devextreme" target="_blank">`devextreme`</a> and <a href="https://www.npmjs.com/package/devextreme-angular" target="_blank">`devextreme-angular`</a> npm packages to the `dependencies` in `package.json` and installs their latest versions.
-- References the `dx.light.css` [DevExtreme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') in `angular.json`.
+- References the `dx.fluent.blue.light.css` [DevExtreme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') in `angular.json`.
 
 These steps are explained in the [Add DevExtreme to an Angular CLI Application](/concepts/40%20Angular%20Components/10%20Getting%20Started/03%20Add%20DevExtreme%20to%20an%20Angular%20CLI%20Application '/Documentation/Guide/Angular_Components/Getting_Started/Add_DevExtreme_to_an_Angular_CLI_Application/') article.
 
@@ -24,7 +24,7 @@ Once the command is executed, [import DevExtreme components](/concepts/40%20Angu
 This command does the following:
 
 - Adds the <a href="https://www.npmjs.com/package/devextreme" target="_blank">`devextreme`</a> and <a href="https://www.npmjs.com/package/devextreme-vue" target="_blank">`devextreme-vue`</a> npm packages to the `dependencies` in `package.json` and installs their latest versions.
-- Imports the `dx.light.css` [DevExtreme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') in `src/main.js`.
+- Imports the `dx.fluent.blue.light.css` [DevExtreme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') in `src/main.js`.
 
 These steps are explained in the [Add DevExtreme to a Vue Application](/concepts/55%20Vue%20Components/05%20Add%20DevExtreme%20to%20a%20Vue%20Application/00%20Add%20DevExtreme%20to%20a%20Vue%20Application.md '/Documentation/Guide/Vue_Components/Add_DevExtreme_to_a_Vue_Application/') article.
 
@@ -39,7 +39,7 @@ Once the command is executed, [import DevExtreme components](/concepts/55%20Vue%
 This command does the following:
 
 - Adds the <a href="https://www.npmjs.com/package/devextreme" target="_blank">`devextreme`</a> and <a href="https://www.npmjs.com/package/devextreme-react" target="_blank">`devextreme-react`</a> npm packages to the `dependencies` in `package.json` and installs their latest versions.
-- Imports the `dx.light.css` [DevExtreme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') in `src/App.js`.
+- Imports the `dx.fluent.blue.light.css` [DevExtreme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') in `src/App.js`.
 
 These steps are explained in the [Add DevExtreme to a React Application](/concepts/50%20React%20Components/05%20Add%20DevExtreme%20to%20a%20React%20Application/00%20Add%20DevExtreme%20to%20a%20React%20Application.md '/Documentation/Guide/React_Components/Add_DevExtreme_to_a_React_Application/') article.
 

--- a/concepts/Common/DevExtreme CLI/10 Add DevExtreme to an Existing Application.md
+++ b/concepts/Common/DevExtreme CLI/10 Add DevExtreme to an Existing Application.md
@@ -9,7 +9,7 @@
 This command does the following:
 
 - Adds the <a href="https://www.npmjs.com/package/devextreme" target="_blank">`devextreme`</a> and <a href="https://www.npmjs.com/package/devextreme-angular" target="_blank">`devextreme-angular`</a> npm packages to the `dependencies` in `package.json` and installs their latest versions.
-- References the `dx.fluent.blue.light.css` [DevExtreme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') in `angular.json`.
+- References the `dx.light.css` [DevExtreme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') in `angular.json`.
 
 These steps are explained in the [Add DevExtreme to an Angular CLI Application](/concepts/40%20Angular%20Components/10%20Getting%20Started/03%20Add%20DevExtreme%20to%20an%20Angular%20CLI%20Application '/Documentation/Guide/Angular_Components/Getting_Started/Add_DevExtreme_to_an_Angular_CLI_Application/') article.
 
@@ -24,7 +24,7 @@ Once the command is executed, [import DevExtreme components](/concepts/40%20Angu
 This command does the following:
 
 - Adds the <a href="https://www.npmjs.com/package/devextreme" target="_blank">`devextreme`</a> and <a href="https://www.npmjs.com/package/devextreme-vue" target="_blank">`devextreme-vue`</a> npm packages to the `dependencies` in `package.json` and installs their latest versions.
-- Imports the `dx.fluent.blue.light.css` [DevExtreme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') in `src/main.js`.
+- Imports the `dx.light.css` [DevExtreme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') in `src/main.js`.
 
 These steps are explained in the [Add DevExtreme to a Vue Application](/concepts/55%20Vue%20Components/05%20Add%20DevExtreme%20to%20a%20Vue%20Application/00%20Add%20DevExtreme%20to%20a%20Vue%20Application.md '/Documentation/Guide/Vue_Components/Add_DevExtreme_to_a_Vue_Application/') article.
 
@@ -39,7 +39,7 @@ Once the command is executed, [import DevExtreme components](/concepts/55%20Vue%
 This command does the following:
 
 - Adds the <a href="https://www.npmjs.com/package/devextreme" target="_blank">`devextreme`</a> and <a href="https://www.npmjs.com/package/devextreme-react" target="_blank">`devextreme-react`</a> npm packages to the `dependencies` in `package.json` and installs their latest versions.
-- Imports the `dx.fluent.blue.light.css` [DevExtreme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') in `src/App.js`.
+- Imports the `dx.light.css` [DevExtreme stylesheet](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') in `src/App.js`.
 
 These steps are explained in the [Add DevExtreme to a React Application](/concepts/50%20React%20Components/05%20Add%20DevExtreme%20to%20a%20React%20Application/00%20Add%20DevExtreme%20to%20a%20React%20Application.md '/Documentation/Guide/React_Components/Add_DevExtreme_to_a_React_Application/') article.
 

--- a/concepts/Common/First Steps/07 Style the App.md
+++ b/concepts/Common/First Steps/07 Style the App.md
@@ -1,6 +1,6 @@
 DevExtreme offers over 40 [predefined themes](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') for component styling. You can also create a custom theme with our [ThemeBuilder](https://devexpress.github.io/ThemeBuilder/).
 
-In the next step of the tutorial, apply the `dx.light` theme and add CSS styles to the components.
+In the next step of the tutorial, apply the `dx.fluent.blue.light` theme and add CSS styles to the components.
 
 ---
 ##### jQuery
@@ -10,7 +10,7 @@ To apply a theme, link its file in the `<head>` between jQuery and DevExtreme so
     <!-- tab: index.html -->
     <head>
         <script type="text/javascript" src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-        <link rel="stylesheet" href="https://cdn3.devexpress.com/jslib/minor_25_2/css/dx.light.css" />
+        <link rel="stylesheet" href="https://cdn3.devexpress.com/jslib/minor_25_2/css/dx.fluent.blue.light.css" />
         <link rel="stylesheet" type="text/css" href="index.css" />
         <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/minor_25_2/js/dx.all.js"></script>
     </head>

--- a/concepts/Common/First Steps/07 Style the App.md
+++ b/concepts/Common/First Steps/07 Style the App.md
@@ -27,7 +27,7 @@ To apply a theme, open the `angular.json` file and reference a stylesheet:
             "build": {
               "options": {
                 "styles": [
-                  "node_modules/devextreme/dist/css/dx.light.css",
+                  "node_modules/devextreme/dist/css/dx.fluent.blue.light.css",
                   "src/styles.css"
                 ],
                 ...

--- a/concepts/Common/First Steps/07 Style the App.md
+++ b/concepts/Common/First Steps/07 Style the App.md
@@ -46,13 +46,13 @@ To apply a theme, open the `angular.json` file and reference a stylesheet:
 
 To apply a theme, import a stylesheet where DevExtreme components are used or in the main application file:
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
 ##### React
 
 To apply a theme, import a stylesheet where DevExtreme components are used or in the main application file:
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
 ---
 

--- a/concepts/Common/Integration Guides/10 Create a DevExtreme application with Gatsby/10 Create a DevExtreme application with Gatsby.md
+++ b/concepts/Common/Integration Guides/10 Create a DevExtreme application with Gatsby/10 Create a DevExtreme application with Gatsby.md
@@ -213,7 +213,7 @@ To apply a single DevExtreme theme to your website, add a file named `gatsby-bro
 Add the following `import` statement to the file:
 
     <!--tab: gatsby-browser.js-->
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
 This statement applies the `light` theme to the DevExtreme DataGrid.
 

--- a/concepts/Common/Localization/05 Localize Dates, Numbers, and Currencies/05 Using Intl.md
+++ b/concepts/Common/Localization/05 Localize Dates, Numbers, and Currencies/05 Using Intl.md
@@ -188,7 +188,7 @@ If you want to format and localize strings, numbers, dates, and currencies autom
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import config from 'devextreme/core/config';
 
@@ -215,7 +215,7 @@ If you want to format and localize strings, numbers, dates, and currencies autom
     <!-- tab: App.js -->
     import React from 'react';
     import config from 'devextreme/core/config';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column, Format

--- a/concepts/Common/Localization/05 Localize Dates, Numbers, and Currencies/10 Using Globalize.md
+++ b/concepts/Common/Localization/05 Localize Dates, Numbers, and Currencies/10 Using Globalize.md
@@ -250,7 +250,7 @@ In addition, you can now format values using structures accepted by <a href="htt
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     // ...
     // import dictionaries and localization modules here
 
@@ -272,7 +272,7 @@ In addition, you can now format values using structures accepted by <a href="htt
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column

--- a/concepts/Common/Localization/20 Right-to-Left Support.md
+++ b/concepts/Common/Localization/20 Right-to-Left Support.md
@@ -62,7 +62,7 @@ RTL layout can be specified for an individual UI component using its **rtlEnable
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxSlider from 'devextreme-vue/slider';
 
@@ -78,7 +78,7 @@ RTL layout can be specified for an individual UI component using its **rtlEnable
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Slider from 'devextreme-react/slider';
 

--- a/concepts/Common/Modularity/01 Link Modules/10 Use Webpack.md
+++ b/concepts/Common/Modularity/01 Link Modules/10 Use Webpack.md
@@ -26,7 +26,7 @@
 1. Add [DevExtreme themes](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/').  
 
         <!--HTML-->
-        <link rel="stylesheet" href="node_modules/devextreme/dist/css/dx.light.css">
+        <link rel="stylesheet" href="node_modules/devextreme/dist/css/dx.fluent.blue.light.css">
 
 1. Create your application's entry script and specify modules in it.
 

--- a/concepts/Common/Modularity/01 Link Modules/30 Use RequireJS.md
+++ b/concepts/Common/Modularity/01 Link Modules/30 Use RequireJS.md
@@ -9,7 +9,7 @@
 1. Add [DevExtreme themes](/concepts/60%20Themes%20and%20Styles/05%20Predefined%20Themes/00%20Predefined%20Themes.md '/Documentation/Guide/Themes_and_Styles/Predefined_Themes/') to your application. 
 
         <!--HTML-->
-        <link rel="stylesheet" href="node_modules/devextreme/dist/css/dx.light.css">
+        <link rel="stylesheet" href="node_modules/devextreme/dist/css/dx.fluent.blue.light.css">
 
 
 1. Link RequireJS and define its <a href="http://requirejs.org/docs/api.html#config" target="_blank">configuration object</a>. 

--- a/concepts/Common/Security Considerations/20 HTML Encoding/10 Encode User Input.md
+++ b/concepts/Common/Security Considerations/20 HTML Encoding/10 Encode User Input.md
@@ -108,7 +108,7 @@ DevExtreme text editors, such as [TextBox](/api-reference/10%20UI%20Components/d
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxHtmlEditor } from 'devextreme-vue/html-editor';
     import { DxButton } from 'devextreme-vue/button';
@@ -137,7 +137,7 @@ DevExtreme text editors, such as [TextBox](/api-reference/10%20UI%20Components/d
 
     <!-- tab: App.js -->
     import React, { useCallback, useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { HtmlEditor } from 'devextreme-react/html-editor';
     import { Button } from 'devextreme-react/button';

--- a/concepts/Common/Security Considerations/20 HTML Encoding/30 Potentially Vulnerable API/noDataText.md
+++ b/concepts/Common/Security Considerations/20 HTML Encoding/30 Potentially Vulnerable API/noDataText.md
@@ -87,7 +87,7 @@ You should encode the value as follows:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DxList from 'devextreme-vue/list';
 
     const noDataTextUnsafe = "No data to display<img src=1 onerror=alert('XSS') \/>";
@@ -116,7 +116,7 @@ You should encode the value as follows:
 
     <!-- tab: App.js -->
     import React, { useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
 

--- a/concepts/Common/Security Considerations/30 Export Vulnerabilities/20 ExcelJS CSP Threats.md
+++ b/concepts/Common/Security Considerations/30 Export Vulnerabilities/20 ExcelJS CSP Threats.md
@@ -106,7 +106,7 @@ If you apply [CSP rules](/concepts/Common/Security%20Considerations/40%20Content
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxDataGrid, DxExport } from 'devextreme-vue/data-grid';
     import { Workbook } from 'devextreme-exceljs-fork';
 
@@ -145,7 +145,7 @@ If you apply [CSP rules](/concepts/Common/Security%20Considerations/40%20Content
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { DxDataGrid, DxExport } from 'devextreme-vue/data-grid';
     import { Workbook } from 'devextreme-exceljs-fork';
 
@@ -171,7 +171,7 @@ If you apply [CSP rules](/concepts/Common/Security%20Considerations/40%20Content
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import DataGrid, { Export } from 'devextreme-react/data-grid';
     import { Workbook } from 'devextreme-exceljs-fork';
 

--- a/concepts/Common/Value Formatting/10 Format UI Component Values/10 Predefined Formats.md
+++ b/concepts/Common/Value Formatting/10 Format UI Component Values/10 Predefined Formats.md
@@ -67,7 +67,7 @@ Set the **format** UI component property to apply a predefined format. In the fo
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxSlider, {
         DxTooltip,
@@ -92,7 +92,7 @@ Set the **format** UI component property to apply a predefined format. In the fo
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Slider, {
         Tooltip,

--- a/concepts/Common/Value Formatting/10 Format UI Component Values/15 Intl Formats.md
+++ b/concepts/Common/Value Formatting/10 Format UI Component Values/15 Intl Formats.md
@@ -70,7 +70,7 @@ A UI component's **format** property is compatible with the `options` parameter 
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxDataGrid, {
         DxColumn
@@ -95,7 +95,7 @@ A UI component's **format** property is compatible with the `options` parameter 
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DataGrid, {
         Column 

--- a/concepts/Common/Value Formatting/10 Format UI Component Values/30 Custom Function.md
+++ b/concepts/Common/Value Formatting/10 Format UI Component Values/30 Custom Function.md
@@ -64,7 +64,7 @@ A custom function is useful when advanced formatting is required. The value to b
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxSlider, {
         DxTooltip
@@ -93,7 +93,7 @@ A custom function is useful when advanced formatting is required. The value to b
 
     <!-- tab: App.js -->
     import React, { useCallback } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Slider, {
         Tooltip

--- a/includes/column-header-filter-code.md
+++ b/includes/column-header-filter-code.md
@@ -107,7 +107,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumn,
         DxHeaderFilter, 
@@ -153,7 +153,7 @@
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumn,
         DxHeaderFilter, 
@@ -174,7 +174,7 @@
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName}, {
         Column,

--- a/includes/column-header-filter-editor-options-code.md
+++ b/includes/column-header-filter-editor-options-code.md
@@ -102,7 +102,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumn,
         DxHeaderFilter, 
@@ -150,7 +150,7 @@
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumn,
         DxHeaderFilter, 
@@ -173,7 +173,7 @@
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName}, {
         Column,

--- a/includes/column-header-filter-searchexpr-code.md
+++ b/includes/column-header-filter-searchexpr-code.md
@@ -88,7 +88,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumn,
         DxHeaderFilter, 
@@ -126,7 +126,7 @@
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxColumn,
         DxHeaderFilter, 
@@ -142,7 +142,7 @@
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName}, {
         Column,

--- a/includes/common-code-register-key-handler.md
+++ b/includes/common-code-register-key-handler.md
@@ -49,7 +49,7 @@ Use the [registerKeyHandler(key, handler)](/api-reference/10%20UI%20Widgets/Widg
         <Dx{WidgetName} :ref="my{WidgetName}Ref" />
     </template>
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import Dx{WidgetName} from 'devextreme-vue/{widget-name}';
 
@@ -84,7 +84,7 @@ Use the [registerKeyHandler(key, handler)](/api-reference/10%20UI%20Widgets/Widg
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { {WidgetName} } from 'devextreme-react/{widget-name}';
 

--- a/includes/common-dataSource-description.md
+++ b/includes/common-dataSource-description.md
@@ -98,7 +98,7 @@ Use one of the following extensions to enable the server to process data accordi
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';
@@ -128,7 +128,7 @@ Use one of the following extensions to enable the server to process data accordi
 
         <!-- tab: App.js -->
         import React from 'react';
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import CustomStore from 'devextreme/data/custom_store';
         import { createStore } from 'devextreme-aspnet-data-nojquery';

--- a/includes/custom-templates.md
+++ b/includes/custom-templates.md
@@ -114,7 +114,7 @@ The following code shows how to declare a template and use these parameters. Thi
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxList from 'devextreme-vue/list';
 
@@ -147,7 +147,7 @@ The following code shows how to declare a template and use these parameters. Thi
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List from 'devextreme-react/list';
 
@@ -297,7 +297,7 @@ Declare **named** templates within the component's markup but outside the templa
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import DxList, {
         DxItem
@@ -349,7 +349,7 @@ Declare **named** templates within the component's markup but outside the templa
 
     <!-- tab: App.js -->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import List, { Item } from 'devextreme-react/list';
     import Button from 'devextreme-react/button';

--- a/includes/datagrid-ref-confirm-action-and-validate-data.md
+++ b/includes/datagrid-ref-confirm-action-and-validate-data.md
@@ -149,7 +149,7 @@
 
     <!--tab: App.js-->
     import React from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     
     import { confirm } from 'devextreme/ui/dialog';
     import {WidgetName}, { ... } from 'devextreme-react/{widget-name}';

--- a/includes/drb-min-max-code.md
+++ b/includes/drb-min-max-code.md
@@ -38,7 +38,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName} } from 'devextreme-vue/{widget-name}';
 
@@ -58,7 +58,7 @@
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { Dx{WidgetName} } from 'devextreme-vue/{widget-name}';
     </script>
@@ -68,7 +68,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName} } from 'devextreme-react/{widget-name}';
  

--- a/includes/drb-startdate-enddate-code.md
+++ b/includes/drb-startdate-enddate-code.md
@@ -39,7 +39,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
 
@@ -59,7 +59,7 @@
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
     </script>
@@ -69,7 +69,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateRangeBox } from 'devextreme-react/date-range-box';
  

--- a/includes/drb-startdate-enddate-placeholder-code.md
+++ b/includes/drb-startdate-enddate-placeholder-code.md
@@ -38,7 +38,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
 
@@ -58,7 +58,7 @@
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
     </script>
@@ -68,7 +68,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateRangeBox } from 'devextreme-react/date-range-box';
  

--- a/includes/drb-startdatelabel-enddatelabel-code.md
+++ b/includes/drb-startdatelabel-enddatelabel-code.md
@@ -38,7 +38,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
 
@@ -58,7 +58,7 @@
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DxDateRangeBox } from 'devextreme-vue/date-range-box';
     </script>
@@ -68,7 +68,7 @@
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { DateRangeBox } from 'devextreme-react/date-range-box';
  

--- a/includes/grids-customize-columns-react-note.md
+++ b/includes/grids-customize-columns-react-note.md
@@ -7,7 +7,7 @@ Note that the [element_Name]**Render** and [element_Name]**Component** (for exam
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         // ...

--- a/includes/header-filter-code.md
+++ b/includes/header-filter-code.md
@@ -92,7 +92,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxHeaderFilter, 
         DxSearch,
@@ -132,7 +132,7 @@
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxHeaderFilter, 
         DxSearch,
@@ -151,7 +151,7 @@
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName}, {
         HeaderFilter, 

--- a/includes/header-filter-editor-options-code.md
+++ b/includes/header-filter-editor-options-code.md
@@ -92,7 +92,7 @@
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxHeaderFilter, 
         DxSearch,
@@ -136,7 +136,7 @@
     </template>
 
     <script setup>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import Dx{WidgetName}, {
         DxHeaderFilter, 
         DxSearch,
@@ -158,7 +158,7 @@
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import {WidgetName}, {
         HeaderFilter, 

--- a/includes/treeview-custom-icons.md
+++ b/includes/treeview-custom-icons.md
@@ -63,7 +63,7 @@
     </template> 
   
     <script>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import DxTreeView from 'devextreme-vue/tree-view'; 
 
     export default { 
@@ -83,7 +83,7 @@
     </template> 
   
     <script setup>  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
     import DxTreeView from 'devextreme-vue/tree-view'; 
 
     // ...
@@ -93,7 +93,7 @@
 
     <!-- tab: App.js -->
     import React from 'react';  
-    import 'devextreme/dist/css/dx.light.css'; 
+    import 'devextreme/dist/css/dx.fluent.blue.light.css'; 
 
     import TreeView from 'devextreme-react/tree-view'; 
 

--- a/includes/tutorials-editors-create-an-editor.md
+++ b/includes/tutorials-editors-create-an-editor.md
@@ -14,7 +14,7 @@ Use the code below to create an empty {WidgetName}:
         <head>
             <!-- ... -->
             <script type="text/javascript" src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-            <link rel="stylesheet" href="https://cdn3.devexpress.com/jslib/minor_25_2/css/dx.light.css">
+            <link rel="stylesheet" href="https://cdn3.devexpress.com/jslib/minor_25_2/css/dx.fluent.blue.light.css">
             <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/minor_25_2/js/dx.all.js"></script>
             <script type="text/javascript" src="index.js"></script>
         </head>

--- a/includes/tutorials-editors-create-an-editor.md
+++ b/includes/tutorials-editors-create-an-editor.md
@@ -73,7 +73,7 @@ Use the code below to create an empty {WidgetName}:
     </template>
 
     <script>
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import { Dx{WidgetName} } from 'devextreme-vue/{widget-name}';
 
     export default {
@@ -90,7 +90,7 @@ Use the code below to create an empty {WidgetName}:
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import { {WidgetName} } from 'devextreme-react/{widget-name}';
 

--- a/includes/tutorials-export-data-to-excel.md
+++ b/includes/tutorials-export-data-to-excel.md
@@ -140,7 +140,7 @@ You can call this method at any point in your application. The following code ca
 
     <!-- tab: App.js -->
     import React, { useState } from 'react';
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
     import './App.css';
 
     import {

--- a/includes/uiwidgets-ref-validation-message.md
+++ b/includes/uiwidgets-ref-validation-message.md
@@ -62,7 +62,7 @@ An error message can be specified as follows:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { DxTextBox } from 'devextreme-vue/text-box';
         import {
@@ -84,7 +84,7 @@ An error message can be specified as follows:
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { TextBox } from 'devextreme-react/text-box';
         import {
@@ -170,7 +170,7 @@ An error message can be specified as follows:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { DxTextBox } from 'devextreme-vue/text-box';
         import {
@@ -192,7 +192,7 @@ An error message can be specified as follows:
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { TextBox } from 'devextreme-react/text-box';
         import {
@@ -279,7 +279,7 @@ An error message can be specified as follows:
         </template>
 
         <script>
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { DxTextBox } from 'devextreme-vue/text-box';
         import {
@@ -300,7 +300,7 @@ An error message can be specified as follows:
         <!-- tab: App.js -->
         import React from 'react';
 
-        import 'devextreme/dist/css/dx.light.css';
+        import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
         import { TextBox } from 'devextreme-react/text-box';
         import {

--- a/includes/uiwidgets-toolbar-items-template.md
+++ b/includes/uiwidgets-toolbar-items-template.md
@@ -104,7 +104,7 @@ The following example adds a custom item to the component. Note that Angular and
     <!-- tab: App.js -->
     import React from 'react';
 
-    import 'devextreme/dist/css/dx.light.css';
+    import 'devextreme/dist/css/dx.fluent.blue.light.css';
 
     import {WidgetName}, {
         Toolbar, Item


### PR DESCRIPTION
Replaced mentions of Generic themes with Fluent:
import 'devextreme/dist/css/dx.light.css'; > import 'devextreme/dist/css/dx.fluent.blue.light.css';

Includes all remaining files after #8657 and all previous PRs.