### PR TITLE
Icons Library: Update to CDN (v26.2)

### DIFF
--- a/applications/Icons/styles.css
+++ b/applications/Icons/styles.css
@@ -46,18 +46,18 @@
 
 @font-face {
     font-family: DXIconsMaterial;
-    src: url("/SharedStatic/DevExtreme/26_2/css/icons/dxiconsmaterial.woff2") format("woff2"),
-        url("/SharedStatic/DevExtreme/26_2/css/icons/dxiconsmaterial.woff") format("woff"),
-        url("/SharedStatic/DevExtreme/26_2/css/icons/dxiconsmaterial.ttf") format("truetype");
+    src: url("https://cdn3.devexpress.com/jslib/26.1.4/css/icons/dxiconsmaterial.woff2") format("woff2"),
+        url("https://cdn3.devexpress.com/jslib/26.1.4/css/icons/dxiconsmaterial.woff") format("woff"),
+        url("https://cdn3.devexpress.com/jslib/26.1.4/css/icons/dxiconsmaterial.ttf") format("truetype");
     font-weight: 400;
     font-style: normal
 }
 
 @font-face {
     font-family: DXIconsGeneric;
-    src: url("/SharedStatic/DevExtreme/26_2/css/icons/dxicons.woff2") format("woff2"),
-        url("/SharedStatic/DevExtreme/26_2/css/icons/dxicons.woff") format("woff"),
-        url("/SharedStatic/DevExtreme/26_2/css/icons/dxicons.ttf") format("truetype");
+    src: url("https://cdn3.devexpress.com/jslib/26.1.4/css/icons/dxicons.woff2") format("woff2"),
+        url("https://cdn3.devexpress.com/jslib/26.1.4/css/icons/dxicons.woff") format("woff"),
+        url("https://cdn3.devexpress.com/jslib/26.1.4/css/icons/dxicons.ttf") format("truetype");
     font-weight: 400;
     font-style: normal
 }


### PR DESCRIPTION
Uses 26.1.4 sources since v26.2 is not available on the CDN at the time of writing.